### PR TITLE
feat: implement "Helpful" upvotes for community replies #23

### DIFF
--- a/app/api/replies/route.ts
+++ b/app/api/replies/route.ts
@@ -1,5 +1,5 @@
 import { db } from "@/configs/db";
-import { repliesTable, doubtsTable, classroomsTable } from "@/configs/schema";
+import { repliesTable, doubtsTable, classroomsTable, replyLikesTable } from "@/configs/schema";
 import { eq, asc, sql } from "drizzle-orm";
 import { NextResponse } from "next/server";
 import { auth, currentUser } from "@clerk/nextjs/server";
@@ -24,6 +24,7 @@ export async function GET(req: Request) {
 
         const { searchParams } = new URL(req.url);
         const doubtIdStr = searchParams.get("doubtId");
+        const userName = searchParams.get("userName");
 
         if (!doubtIdStr) {
             return NextResponse.json({ error: "Doubt ID required" }, { status: 400 });
@@ -49,7 +50,22 @@ export async function GET(req: Request) {
             .where(eq(repliesTable.doubtId, doubtId))
             .orderBy(asc(repliesTable.createdAt));
 
-        return NextResponse.json(data);
+        // If userName is provided, check which replies are upvoted by this user
+        let repliesWithVotes = data;
+        if (userName) {
+            const userUpvotes = await db.select()
+                .from(replyLikesTable)
+                .where(eq(replyLikesTable.userName, userName));
+            
+            const upvotedReplyIds = new Set(userUpvotes.map(v => v.replyId));
+            
+            repliesWithVotes = data.map(reply => ({
+                ...reply,
+                hasUpvoted: upvotedReplyIds.has(reply.id)
+            }));
+        }
+
+        return NextResponse.json(repliesWithVotes);
     } catch (error) {
         console.error("Error fetching replies:", error);
         return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });

--- a/app/api/replies/vote/route.ts
+++ b/app/api/replies/vote/route.ts
@@ -1,0 +1,61 @@
+import { db } from "@/configs/db";
+import { repliesTable, replyLikesTable } from "@/configs/schema";
+import { and, eq, sql } from "drizzle-orm";
+import { NextResponse } from "next/server";
+import { currentUser } from "@clerk/nextjs/server";
+
+export async function POST(req: Request) {
+    try {
+        const user = await currentUser();
+        if (!user) {
+            return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+        }
+
+        const { replyId, userName } = await req.json();
+
+        if (!replyId || !userName) {
+            return NextResponse.json({ error: "Reply ID and User Name are required" }, { status: 400 });
+        }
+
+        // Check if reply exists
+        const [reply] = await db.select().from(repliesTable).where(eq(repliesTable.id, replyId)).limit(1);
+        if (!reply) {
+            return NextResponse.json({ error: "Reply not found" }, { status: 404 });
+        }
+
+        // Check if already upvoted
+        const existingLike = await db.select()
+            .from(replyLikesTable)
+            .where(and(eq(replyLikesTable.userName, userName), eq(replyLikesTable.replyId, replyId)))
+            .limit(1);
+
+        if (existingLike.length > 0) {
+            // Unvote
+            await db.delete(replyLikesTable)
+                .where(and(eq(replyLikesTable.userName, userName), eq(replyLikesTable.replyId, replyId)));
+            
+            const updated = await db.update(repliesTable)
+                .set({ upvotes: sql`${repliesTable.upvotes} - 1` })
+                .where(eq(repliesTable.id, replyId))
+                .returning();
+            
+            return NextResponse.json({ ...updated[0], hasUpvoted: false });
+        } else {
+            // Vote
+            await db.insert(replyLikesTable).values({
+                userName,
+                replyId
+            });
+
+            const updated = await db.update(repliesTable)
+                .set({ upvotes: sql`${repliesTable.upvotes} + 1` })
+                .where(eq(repliesTable.id, replyId))
+                .returning();
+            
+            return NextResponse.json({ ...updated[0], hasUpvoted: true });
+        }
+    } catch (error) {
+        console.error("Error voting on reply:", error);
+        return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+    }
+}

--- a/components/DoubtRepliesModal.tsx
+++ b/components/DoubtRepliesModal.tsx
@@ -11,6 +11,8 @@ interface Reply {
     type: 'comment' | 'solution';
     content: string | null;
     imageUrl: string | null;
+    upvotes: number;
+    hasUpvoted?: boolean;
     createdAt: string;
 }
 
@@ -62,8 +64,9 @@ export default function DoubtRepliesModal({ doubt, isOpen, onClose, onReplyChang
     }, [replies]);
 
     const fetchReplies = async () => {
+        const storedUserName = localStorage.getItem("anonymous_user") || "";
         try {
-            const res = await fetch(`/api/replies?doubtId=${doubt.id}`);
+            const res = await fetch(`/api/replies?doubtId=${doubt.id}&userName=${storedUserName}`);
             if (res.ok) {
                 const data = await res.json();
                 setReplies(data);
@@ -202,6 +205,30 @@ export default function DoubtRepliesModal({ doubt, isOpen, onClose, onReplyChang
             toast.error("Failed to delete");
         } finally {
             setMenuOpenId(null);
+        }
+    };
+
+    const handleVote = async (replyId: number) => {
+        const storedUserName = localStorage.getItem("anonymous_user");
+        if (!storedUserName) return;
+
+        try {
+            const res = await fetch("/api/replies/vote", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ replyId, userName: storedUserName })
+            });
+
+            if (res.ok) {
+                const updatedReply = await res.json();
+                setReplies(prev => prev.map(r => r.id === replyId ? {
+                    ...r,
+                    upvotes: updatedReply.upvotes,
+                    hasUpvoted: updatedReply.hasUpvoted
+                } : r));
+            }
+        } catch (error) {
+            console.error("Failed to vote:", error);
         }
     };
 
@@ -352,6 +379,23 @@ export default function DoubtRepliesModal({ doubt, isOpen, onClose, onReplyChang
                                 )}
                             </>
                         )}
+                    </div>
+
+                    {/* Vote Action */}
+                    <div className="mt-4 flex items-center justify-end">
+                        <button 
+                            onClick={() => handleVote(reply.id)}
+                            className={`flex items-center gap-2 px-3 py-1.5 rounded-xl border transition-all active:scale-95 group/vote ${
+                                reply.hasUpvoted 
+                                ? "bg-blue-600/20 text-blue-400 border-blue-500/30 shadow-lg shadow-blue-500/10" 
+                                : "bg-white/5 text-slate-500 border-white/5 hover:text-white hover:bg-white/10"
+                            }`}
+                        >
+                            <ThumbsUp className={`w-3.5 h-3.5 ${reply.hasUpvoted ? 'fill-blue-400' : 'group-hover/vote:scale-110 transition-transform'}`} />
+                            <span className="text-[10px] font-black uppercase tracking-widest">
+                                {reply.upvotes || 0} <span className="hidden sm:inline ml-1 opacity-60">Helpful</span>
+                            </span>
+                        </button>
                     </div>
                 </div>
 

--- a/configs/schema.ts
+++ b/configs/schema.ts
@@ -150,10 +150,18 @@ export const repliesTable = pgTable("replies", {
     type: varchar({ length: 20 }).notNull(), // 'comment' or 'solution'
     content: text(),
     imageUrl: text(),
+    upvotes: integer().default(0).notNull(),
     createdAt: timestamp().defaultNow().notNull(),
 }, (table) => ({
     doubtIdIndex: index("doubtId_idx").on(table.doubtId),
 }));
+
+export const replyLikesTable = pgTable("reply_likes", {
+    id: integer().primaryKey().generatedAlwaysAsIdentity(),
+    userName: varchar({ length: 255 }).notNull(),
+    replyId: integer().notNull(),
+    createdAt: timestamp().defaultNow().notNull(),
+});
 
 /**
  * Audit log for AI moderation actions.


### PR DESCRIPTION
 Problem
There is currently no way to distinguish a good community answer from a bad one. Adding a voting system helps surface the most helpful solutions to the top.

 Solution
Implemented a "Helpful" upvote system for community replies with a premium UI and robust backend tracking.

- **Database**: Added `upvotes` column to `repliesTable` and created `replyLikesTable` to track individual votes and prevent double-voting.
- **API**: 
  - Created `app/api/replies/vote/route.ts` to handle vote/unvote toggling.
  - Updated `app/api/replies/route.ts` to return `hasUpvoted` status for the current user.
- **UI**: Added a sleek upvote button with real-time count updates and active state persistence in `DoubtRepliesModal.tsx`.

 Tasks
- [x] Add a likes or upvotes column to the repliesTable in configs/schema.ts.
- [x] Update the DoubtCard or Reply component to show the vote count and a clickable icon.
- [x] Create an API route to handle upvoting and prevent double-voting.

🛠️ Files Involved
- `configs/schema.ts`
- `components/DoubtRepliesModal.tsx`
- `app/api/replies/vote/route.ts`
- `app/api/replies/route.ts`


fixes #23 
