### PR TITLE
feat: enhance SEO with OpenGraph, Twitter meta tags, robots.txt and static favicon

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -16,6 +16,20 @@ const AppFont = DM_Sans({
 export const metadata: Metadata = {
   title: "DoubtDesk - AI Doubt Solver",
   description: "DoubtDesk is an AI-powered collaborative classroom platform where students get instant doubt resolution, teachers manage virtual classrooms, and analytics drive better learning outcomes.",
+  keywords: ["doubt solver", "AI education", "classroom platform", "student help", "instant doubt resolution"],
+  robots: { index: true, follow: true },
+  openGraph: {
+    title: "DoubtDesk - AI Doubt Solver",
+    description: "AI-powered collaborative classroom platform for instant doubt resolution and better learning outcomes.",
+    siteName: "DoubtDesk",
+    type: "website",
+    locale: "en_US",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "DoubtDesk - AI Doubt Solver",
+    description: "AI-powered collaborative classroom platform for instant doubt resolution and better learning outcomes.",
+  },
 };
 
 export default function RootLayout({

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <defs>
+    <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#2563eb" />
+      <stop offset="100%" style="stop-color:#9333ea" />
+    </linearGradient>
+  </defs>
+  <rect width="100" height="100" rx="24" fill="url(#grad)" />
+  <text x="50" y="68" font-family="sans-serif" font-size="56" font-weight="bold" fill="white" text-anchor="middle">D</text>
+</svg>

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Allow: /


### PR DESCRIPTION
## Summary

Closes #35

### Changes
- Added Open Graph meta tags for social media sharing previews
- Added Twitter Card meta tags with summary_large_image
- Added keywords and robots meta tags
- Added `robots.txt` to allow search engine crawling
- Added static SVG favicon for broader browser support (complements existing `icon.tsx`)

### Files Changed
- `app/layout.tsx` — enhanced metadata export
- `public/robots.txt` — new file
- `public/favicon.svg` — new file

### Testing
- [x] `npm run build` passes
- [x] Metadata object conforms to Next.js Metadata type