### PR TITLE
fix: add aria-label attributes to icon-only buttons for accessibility

### DIFF
--- a/components/AskAIView.tsx
+++ b/components/AskAIView.tsx
@@ -212,6 +212,7 @@ export default function AskAIView({ classroomId = null, onSuccess, initialDoubt 
                                     <button
                                         onClick={() => setImageBase64(null)}
                                         className="absolute top-3 right-3 w-8 h-8 bg-red-500 rounded-full flex items-center justify-center shadow-lg"
+                                        aria-label="Remove uploaded image"
                                     >
                                         <X className="w-4 h-4 text-white" />
                                     </button>

--- a/components/DashboardLayout.tsx
+++ b/components/DashboardLayout.tsx
@@ -43,6 +43,7 @@ export default function DashboardLayout({
                             <button
                                 onClick={() => setIsSidebarOpen(true)}
                                 className="lg:hidden p-2 text-slate-400 hover:bg-white/5 rounded-lg mr-2"
+                                aria-label="Open sidebar"
                             >
                                 <Menu className="w-6 h-6" />
                             </button>

--- a/components/DoubtRepliesModal.tsx
+++ b/components/DoubtRepliesModal.tsx
@@ -428,7 +428,7 @@ export default function DoubtRepliesModal({ doubt, isOpen, onClose, onReplyChang
                             </p>
                         </div>
                     </div>
-                    <button onClick={onClose} className="p-3 hover:bg-white/5 rounded-2xl text-slate-400 transition-colors">
+                    <button onClick={onClose} className="p-3 hover:bg-white/5 rounded-2xl text-slate-400 transition-colors" aria-label="Close">
                         <X className="w-6 h-6" />
                     </button>
                 </div>
@@ -576,15 +576,16 @@ export default function DoubtRepliesModal({ doubt, isOpen, onClose, onReplyChang
                                         </p>
                                     </div>
                                 </div>
-                                <button 
+                                <button
                                     onClick={() => {
                                         setShowSolutionForm(false);
                                         setEditingId(null);
                                         setSolutionContent("");
                                         setSolutionImage("");
                                         setFileName("");
-                                    }} 
+                                    }}
                                     className="p-3 hover:bg-white/5 rounded-2xl text-slate-500 hover:text-white transition-all hover:rotate-90"
+                                    aria-label="Close solution form"
                                 >
                                     <X className="w-6 h-6" />
                                 </button>
@@ -696,9 +697,10 @@ export default function DoubtRepliesModal({ doubt, isOpen, onClose, onReplyChang
                     className="fixed inset-0 z-[200] flex items-center justify-center bg-slate-950/95 backdrop-blur-xl animate-in fade-in duration-300"
                     onClick={() => setIsFullscreenImageOpen(false)}
                 >
-                    <button 
+                    <button
                         onClick={() => setIsFullscreenImageOpen(false)}
                         className="absolute top-8 right-8 p-4 bg-white/5 hover:bg-white/10 rounded-full text-white transition-all hover:rotate-90 z-[210]"
+                        aria-label="Close fullscreen image"
                     >
                         <X className="w-8 h-8" />
                     </button>

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -67,6 +67,7 @@ export default function Sidebar({ isOpen, onClose }: SidebarProps) {
                         <button
                             onClick={onClose}
                             className="lg:hidden p-2 text-slate-400 hover:bg-white/5 rounded-lg"
+                            aria-label="Close sidebar"
                         >
                             <X className="w-6 h-6" />
                         </button>


### PR DESCRIPTION
## Summary

Closes #4

### Changes
Added `aria-label` attributes to all icon-only buttons across the application:

| File | Button | aria-label |
|------|--------|------------|
| `components/DashboardLayout.tsx` | Hamburger menu toggle | `Open sidebar` |
| `components/Sidebar.tsx` | Close sidebar (X) | `Close sidebar` |
| `components/DoubtRepliesModal.tsx` | Close modal (X) | `Close` |
| `components/DoubtRepliesModal.tsx` | Close solution form (X) | `Close solution form` |
| `components/DoubtRepliesModal.tsx` | Close fullscreen image (X) | `Close fullscreen image` |
| `components/AskAIView.tsx` | Remove uploaded image (X) | `Remove uploaded image` |

### Why
Icon-only buttons are invisible to screen readers without aria-labels. These additions improve WCAG compliance and make the app more accessible.