### PR TITLE
feat: add custom 404 not found page

### DIFF
--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,51 @@
+import Link from 'next/link';
+import { Home, AlertCircle } from 'lucide-react';
+
+export default function NotFound() {
+    return (
+        <div className="min-h-screen bg-[#020617] flex flex-col items-center justify-center p-6 text-center relative overflow-hidden">
+            {/* Ambient Background Glows */}
+            <div className="absolute top-1/4 -left-20 w-[500px] h-[500px] bg-blue-600/10 rounded-full blur-[120px] pointer-events-none" />
+            <div className="absolute bottom-1/4 -right-20 w-[500px] h-[500px] bg-purple-600/10 rounded-full blur-[120px] pointer-events-none" />
+
+            <div className="relative z-10 space-y-8 max-w-xl">
+                {/* Error Badge */}
+                <div className="flex flex-col items-center space-y-4">
+                    <div className="inline-flex items-center gap-2 px-4 py-1.5 rounded-full bg-red-500/10 border border-red-500/20 text-red-400 text-[10px] font-black uppercase tracking-widest animate-pulse">
+                        <AlertCircle className="w-3.5 h-3.5" /> Navigation Error
+                    </div>
+                    
+                    {/* Hero 404 Text */}
+                    <h1 className="text-[120px] sm:text-[180px] font-black text-transparent bg-clip-text bg-gradient-to-b from-white via-white to-slate-800 leading-none tracking-tighter select-none drop-shadow-2xl">
+                        404
+                    </h1>
+                </div>
+
+                {/* Message Content */}
+                <div className="space-y-4">
+                    <h2 className="text-3xl sm:text-5xl font-black text-white tracking-tight leading-tight">
+                        LOST IN THE <br />
+                        <span className="text-transparent bg-clip-text bg-gradient-to-r from-blue-400 to-cyan-400 uppercase italic pr-2">Knowledge Base?</span>
+                    </h2>
+                    <p className="text-slate-400 text-lg font-medium max-w-md mx-auto leading-relaxed">
+                        The resource you're searching for has moved to another dimension. Let's get your learning back on track.
+                    </p>
+                </div>
+
+                {/* Action Button */}
+                <div className="pt-6">
+                    <Link 
+                        href="/" 
+                        className="inline-flex items-center gap-3 px-10 py-5 bg-gradient-to-r from-blue-600 to-cyan-600 hover:from-blue-500 hover:to-cyan-500 text-white rounded-3xl font-black uppercase tracking-widest text-xs transition-all shadow-2xl shadow-blue-500/20 active:scale-95 group border border-white/10"
+                    >
+                        <Home className="w-4 h-4 transition-transform group-hover:-translate-y-1" />
+                        Return to Dashboard
+                    </Link>
+                </div>
+            </div>
+
+            {/* Decorative Grid/Lines */}
+            <div className="absolute inset-0 bg-[linear-gradient(to_right,#80808012_1px,transparent_1px),linear-gradient(to_bottom,#80808012_1px,transparent_1px)] bg-[size:40px_40px] [mask-image:radial-gradient(ellipse_60%_50%_at_50%_0%,#000_70%,transparent_100%)] pointer-events-none" />
+        </div>
+    );
+}


### PR DESCRIPTION
## Description
Added a custom 404 Not Found page for DoubtDesk to replace the default Next.js 404 screen.

The new page follows the existing DoubtDesk design system and includes:
- Custom styled 404 UI
- Friendly error message
- Responsive centered layout
- “Return to dashboard” navigation button
- Consistent dark neon-themed styling

## Related Issue
Closes #31

## Type of Change
- [x] New feature (non-breaking change that adds functionality)
- [x] Style / UI change (no logic change)

## Screenshots (if UI change)

| Before | 
<img width="1912" height="942" alt="Screenshot 2026-05-15 005035" src="https://github.com/user-attachments/assets/8e15dd3e-348e-4fa9-ae39-b2268dbebe15" />

| After |
<img width="1912" height="939" alt="Screenshot 2026-05-15 004757" src="https://github.com/user-attachments/assets/d8f42e67-c528-46fb-b08f-5396ecb2b34c" />
 

## How Has This Been Tested?
- [x] Tested locally with `npm run dev`
- [x] Verified on mobile viewport (375px)
- [x] Verified on desktop viewport (1440px)

## Checklist
- [x] I have tested my changes locally (`npm run dev`)
- [x] My code follows the existing code style (TypeScript, Tailwind, no `any` types)
- [x] I have not introduced unrelated changes (each PR should address one issue)
- [x] I have added comments where necessary
- [x] My branch is up to date with `main`
- [x] I have linked the related issue above
- [x] Screenshots are included (if this is a UI change)