### PR TITLE
fix: add aria-labels to icon-only buttons

### DIFF
--- a/app/ask-ai/page.tsx
+++ b/app/ask-ai/page.tsx
@@ -233,7 +233,7 @@ export default function AskAIPage() {
             <main className="flex-1 flex flex-col overflow-y-auto">
                 {/* Mobile Header */}
                 <header className="flex lg:hidden items-center gap-3 px-4 py-3 border-b border-white/5 bg-slate-950/80 backdrop-blur-xl sticky top-0 z-20">
-                    <button onClick={() => setIsSidebarOpen(true)} className="p-2 hover:bg-white/5 rounded-lg">
+                    <button onClick={() => setIsSidebarOpen(true)} className="p-2 hover:bg-white/5 rounded-lg" aria-label="Open sidebar">
                         <div className="w-5 h-0.5 bg-white mb-1 rounded" /><div className="w-5 h-0.5 bg-white mb-1 rounded" /><div className="w-5 h-0.5 bg-white rounded" />
                     </button>
                     <div className="w-8 h-8 bg-gradient-to-br from-cyan-500 to-blue-600 rounded-lg flex items-center justify-center">
@@ -324,6 +324,7 @@ export default function AskAIPage() {
                                             <button
                                                 onClick={() => { setImageBase64(null); if (fileInputRef.current) fileInputRef.current.value = ''; }}
                                                 className="absolute top-3 right-3 w-8 h-8 bg-red-500/90 hover:bg-red-500 rounded-full flex items-center justify-center shadow-lg hover:scale-110 transition-transform"
+                                                aria-label="Remove image"
                                             >
                                                 <X className="w-4 h-4 text-white" />
                                             </button>
@@ -497,6 +498,7 @@ export default function AskAIPage() {
                                             <button 
                                                 onClick={() => { setActiveStepContext(null); setFollowUpPrompt(''); }}
                                                 className="ml-2 hover:bg-white/5 p-1 rounded-md transition-colors"
+                                                aria-label="Clear context"
                                             >
                                                 <X className="w-3 h-3 text-slate-500" />
                                             </button>
@@ -518,6 +520,7 @@ export default function AskAIPage() {
                                             onClick={() => handleAskAI('standard', true)}
                                             disabled={!followUpPrompt.trim()}
                                             className="p-3 bg-cyan-600 hover:bg-cyan-500 text-white rounded-xl shadow-lg shadow-cyan-500/20 transition-all disabled:opacity-40"
+                                            aria-label="Send follow-up"
                                         >
                                             <Send className="w-5 h-5" />
                                         </button>

--- a/app/rooms/[id]/page.tsx
+++ b/app/rooms/[id]/page.tsx
@@ -498,6 +498,7 @@ export default function ClassroomPage() {
                             <button 
                                 onClick={() => setIsCodeModalOpen(false)}
                                 className="p-2 text-slate-500 hover:text-white transition-colors"
+                                aria-label="Close modal"
                             >
                                 <Plus className="w-5 h-5 rotate-45" />
                             </button>

--- a/components/AskAIView.tsx
+++ b/components/AskAIView.tsx
@@ -212,6 +212,7 @@ export default function AskAIView({ classroomId = null, onSuccess, initialDoubt 
                                     <button
                                         onClick={() => setImageBase64(null)}
                                         className="absolute top-3 right-3 w-8 h-8 bg-red-500 rounded-full flex items-center justify-center shadow-lg"
+                                        aria-label="Remove image"
                                     >
                                         <X className="w-4 h-4 text-white" />
                                     </button>

--- a/components/AskDoubt.tsx
+++ b/components/AskDoubt.tsx
@@ -121,6 +121,7 @@ export default function AskDoubt({ defaultSubject = "", isOpen, onClose, onSucce
                     <button 
                         onClick={onClose}
                         className="p-2 hover:bg-white/5 rounded-full text-slate-400 transition-colors"
+                        aria-label="Close modal"
                     >
                         <X className="w-6 h-6" />
                     </button>

--- a/components/DashboardLayout.tsx
+++ b/components/DashboardLayout.tsx
@@ -43,6 +43,7 @@ export default function DashboardLayout({
                             <button
                                 onClick={() => setIsSidebarOpen(true)}
                                 className="lg:hidden p-2 text-slate-400 hover:bg-white/5 rounded-lg mr-2"
+                                aria-label="Open sidebar"
                             >
                                 <Menu className="w-6 h-6" />
                             </button>

--- a/components/DoubtCard.tsx
+++ b/components/DoubtCard.tsx
@@ -203,6 +203,7 @@ export default function DoubtCard({ doubt, onUpdate, onViewAISolution, role }: D
                                     <button 
                                         onClick={() => setIsEditModalOpen(true)}
                                         className="flex-1 sm:flex-none p-3 rounded-xl hover:bg-blue-600/20 text-slate-500 hover:text-blue-400 transition-all group/edit"
+                                        aria-label="Edit doubt"
                                     >
                                         <Edit2 className="w-4 h-4 group-hover/edit:scale-110 transition-transform" />
                                     </button>
@@ -210,6 +211,7 @@ export default function DoubtCard({ doubt, onUpdate, onViewAISolution, role }: D
                                 <button 
                                     onClick={() => setIsDeleteDialogOpen(true)}
                                     className="flex-1 sm:flex-none p-3 rounded-xl hover:bg-red-500/20 text-slate-500 hover:text-red-400 transition-all group/trash"
+                                    aria-label="Delete doubt"
                                 >
                                     <Trash2 className="w-4 h-4 group-hover/trash:scale-110 transition-transform" />
                                 </button>
@@ -256,6 +258,7 @@ export default function DoubtCard({ doubt, onUpdate, onViewAISolution, role }: D
                     <button 
                         className="absolute top-8 right-8 p-3 rounded-full bg-white/10 hover:bg-white/20 text-white transition-all z-[110]"
                         onClick={(e) => { e.stopPropagation(); setIsFullscreenImageOpen(false); }}
+                        aria-label="Close fullscreen view"
                     >
                         <X className="w-6 h-6" />
                     </button>

--- a/components/DoubtRepliesModal.tsx
+++ b/components/DoubtRepliesModal.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect, useRef } from "react";
-import { X, Send, CheckCircle, MessageSquare, Loader2, Upload, File, ZoomIn, MoreVertical, Pencil, Trash2, PlusCircle } from "lucide-react";
+import { X, Send, CheckCircle, MessageSquare, Loader2, Upload, File, ZoomIn, MoreVertical, Pencil, Trash2, PlusCircle, ThumbsUp } from "lucide-react";
 import { toast } from "sonner";
 
 interface Reply {
@@ -308,6 +308,7 @@ export default function DoubtRepliesModal({ doubt, isOpen, onClose, onReplyChang
                                     <button 
                                         onClick={() => setMenuOpenId(menuOpenId === reply.id ? null : reply.id)}
                                         className="p-1.5 hover:bg-white/10 rounded-xl text-slate-500 hover:text-white transition-all"
+                                        aria-label="More options"
                                     >
                                         <MoreVertical className="w-3.5 h-3.5" />
                                     </button>
@@ -370,6 +371,7 @@ export default function DoubtRepliesModal({ doubt, isOpen, onClose, onReplyChang
                                     <button 
                                         onClick={() => { setFullscreenImageUrl(reply.imageUrl!); setIsFullscreenImageOpen(true); }}
                                         className="mt-2 rounded-2xl overflow-hidden border border-white/5 group/img relative cursor-zoom-in active:scale-[0.98] transition-all w-full"
+                                        aria-label="View image fullscreen"
                                     >
                                         <img src={reply.imageUrl} alt="Solution" className="w-full h-auto object-cover max-h-[32rem]" />
                                         <div className="absolute inset-0 bg-white/0 group-hover/img:bg-white/5 flex items-center justify-center transition-all">
@@ -428,7 +430,7 @@ export default function DoubtRepliesModal({ doubt, isOpen, onClose, onReplyChang
                             </p>
                         </div>
                     </div>
-                    <button onClick={onClose} className="p-3 hover:bg-white/5 rounded-2xl text-slate-400 transition-colors">
+                    <button onClick={onClose} className="p-3 hover:bg-white/5 rounded-2xl text-slate-400 transition-colors" aria-label="Close modal">
                         <X className="w-6 h-6" />
                     </button>
                 </div>
@@ -585,6 +587,7 @@ export default function DoubtRepliesModal({ doubt, isOpen, onClose, onReplyChang
                                         setFileName("");
                                     }} 
                                     className="p-3 hover:bg-white/5 rounded-2xl text-slate-500 hover:text-white transition-all hover:rotate-90"
+                                    aria-label="Close form"
                                 >
                                     <X className="w-6 h-6" />
                                 </button>
@@ -615,6 +618,7 @@ export default function DoubtRepliesModal({ doubt, isOpen, onClose, onReplyChang
                                                 type="button"
                                                 onClick={() => { setFullscreenImageUrl(solutionImage); setIsFullscreenImageOpen(true); }}
                                                 className="w-10 h-10 bg-white/10 hover:bg-white/20 backdrop-blur-md rounded-xl flex items-center justify-center text-white transition-all scale-75 group-hover/img:scale-100"
+                                                aria-label="Zoom image"
                                             >
                                                 <ZoomIn className="w-5 h-5" />
                                             </button>
@@ -622,6 +626,7 @@ export default function DoubtRepliesModal({ doubt, isOpen, onClose, onReplyChang
                                                 type="button"
                                                 onClick={() => { setSolutionImage(""); setFileName(""); }}
                                                 className="w-10 h-10 bg-red-500/20 hover:bg-red-500 backdrop-blur-md rounded-xl flex items-center justify-center text-white transition-all scale-75 group-hover/img:scale-100 border border-red-500/20 hover:border-transparent"
+                                                aria-label="Delete image"
                                             >
                                                 <Trash2 className="w-5 h-5" />
                                             </button>
@@ -680,6 +685,7 @@ export default function DoubtRepliesModal({ doubt, isOpen, onClose, onReplyChang
                                     onClick={() => handlePost('comment')}
                                     disabled={isPosting || !chatText.trim()}
                                     className="absolute right-2 top-2 p-2 bg-blue-600 hover:bg-blue-700 text-white rounded-xl transition-all disabled:opacity-50"
+                                    aria-label="Send message"
                                 >
                                     {isPosting ? <Loader2 className="w-4 h-4 animate-spin" /> : <Send className="w-4 h-4" />}
                                 </button>
@@ -699,6 +705,7 @@ export default function DoubtRepliesModal({ doubt, isOpen, onClose, onReplyChang
                     <button 
                         onClick={() => setIsFullscreenImageOpen(false)}
                         className="absolute top-8 right-8 p-4 bg-white/5 hover:bg-white/10 rounded-full text-white transition-all hover:rotate-90 z-[210]"
+                        aria-label="Close fullscreen view"
                     >
                         <X className="w-8 h-8" />
                     </button>

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -67,6 +67,7 @@ export default function Sidebar({ isOpen, onClose }: SidebarProps) {
                         <button
                             onClick={onClose}
                             className="lg:hidden p-2 text-slate-400 hover:bg-white/5 rounded-lg"
+                            aria-label="Close sidebar"
                         >
                             <X className="w-6 h-6" />
                         </button>


### PR DESCRIPTION
## Description
Added descriptive `aria-label` attributes to icon-only buttons across the application to improve accessibility and screen-reader support.

Updated interactive elements such as:
- Sidebar toggle buttons
- Modal close buttons
- Image action buttons
- Reply/send action buttons
- Fullscreen view controls
- Context and attachment action buttons

Also fixed a missing `ThumbsUp` import in `DoubtRepliesModal.tsx` to resolve a TypeScript error.

## Related Issue
Closes #4

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Style / UI change (no logic change)

## Screenshots (if UI change)
N/A

## How Has This Been Tested?
- [x] Tested locally with `npm run dev`
- [x] Verified on mobile viewport (375px)
- [x] Verified on desktop viewport (1440px)

## Checklist
- [x] I have tested my changes locally (`npm run dev`)
- [x] My code follows the existing code style (TypeScript, Tailwind, no `any` types)
- [x] I have not introduced unrelated changes (each PR should address one issue)
- [x] I have added comments where necessary
- [x] My branch is up to date with `main`
- [x] I have linked the related issue above
- [ ] Screenshots are included (if this is a UI change)