### PR TITLE
feat: add dark mode toggle

### DIFF
--- a/__tests__/lib/moderation.test.ts
+++ b/__tests__/lib/moderation.test.ts
@@ -1,5 +1,13 @@
 import { moderateContent } from '@/lib/moderation';
 
+jest.mock('@/configs/db', () => ({
+    db: {
+        select: jest.fn(),
+        update: jest.fn(),
+        insert: jest.fn(),
+    },
+}));
+
 // Mock groq-sdk
 jest.mock('groq-sdk', () => {
     return {

--- a/app/globals.css
+++ b/app/globals.css
@@ -29,6 +29,7 @@
     --chart-4: 43 74% 66%;
     --chart-5: 27 87% 67%;
     --radius: 0.5rem;
+    color-scheme: light;
   }
 
   .dark {
@@ -56,6 +57,7 @@
     --chart-3: 30 80% 55%;
     --chart-4: 280 65% 60%;
     --chart-5: 340 75% 55%;
+    color-scheme: dark;
   }
 }
 
@@ -64,15 +66,69 @@
     @apply border-border;
   }
   body {
-    @apply bg-background text-foreground;
+    @apply bg-background text-foreground transition-colors duration-300;
   }
 }
 
 html,
 body {
-  background-color: #020617;
+  background-color: hsl(var(--background));
   font-family: Arial, Helvetica, sans-serif;
   min-height: 100%;
+}
+
+:where(html, body, main, header, aside, section, div, button, a, input, textarea) {
+  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, box-shadow;
+  transition-duration: 200ms;
+  transition-timing-function: ease;
+}
+
+html.light [class~="bg-[#020617]"],
+html.light [class~="bg-slate-950"],
+html.light [class~="bg-slate-950/80"],
+html.light [class~="bg-[#040B1A]/88"],
+html.light [class~="supports-[backdrop-filter]:bg-[#040B1A]/72"] {
+  background-color: hsl(var(--background));
+}
+
+html.light [class~="bg-slate-900"],
+html.light [class~="bg-slate-900/40"],
+html.light [class~="bg-slate-900/50"],
+html.light [class~="bg-slate-900/60"],
+html.light [class~="bg-slate-800/80"],
+html.light [class~="bg-white/5"],
+html.light [class~="bg-white/[0.08]"],
+html.light [class~="bg-white/10"] {
+  background-color: hsl(var(--card));
+}
+
+html.light [class~="border-white/5"],
+html.light [class~="border-white/8"],
+html.light [class~="border-white/10"],
+html.light [class~="border-white/20"] {
+  border-color: hsl(var(--border));
+}
+
+html.light [class~="text-white"],
+html.light [class~="text-slate-100"],
+html.light [class~="text-slate-200"],
+html.light [class~="text-slate-300"] {
+  color: hsl(var(--foreground));
+}
+
+html.light [class~="text-slate-400"],
+html.light [class~="text-slate-500"],
+html.light [class~="text-slate-600"] {
+  color: hsl(var(--muted-foreground));
+}
+
+html.light [class~="bg-blue-600"][class~="text-white"],
+html.light [class~="bg-cyan-600"][class~="text-white"],
+html.light [class~="bg-red-600"][class~="text-white"],
+html.light [class~="bg-[#5E8CFF]"][class~="text-white"],
+html.light [class~="from-blue-600"][class~="text-white"],
+html.light [class~="from-cyan-600"][class~="text-white"] {
+  color: #fff;
 }
 
 /* Custom Scrollbar Styling */
@@ -81,26 +137,23 @@ body {
 }
 
 ::-webkit-scrollbar-track {
-  background: #020617;
-  /* slate-950 */
+  background: hsl(var(--background));
 }
 
 ::-webkit-scrollbar-thumb {
-  background: #1e293b;
-  /* slate-800 */
+  background: hsl(var(--muted-foreground) / 0.35);
   border-radius: 5px;
-  border: 2px solid #020617;
+  border: 2px solid hsl(var(--background));
 }
 
 ::-webkit-scrollbar-thumb:hover {
-  background: #334155;
-  /* slate-700 */
+  background: hsl(var(--muted-foreground) / 0.55);
 }
 
 /* For Firefox */
 * {
   scrollbar-width: thin;
-  scrollbar-color: #1e293b #020617;
+  scrollbar-color: hsl(var(--muted-foreground) / 0.45) hsl(var(--background));
 }
 /* Markdown Renderer Styles */
 .markdown-renderer p:last-child {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -68,7 +68,7 @@ export default function RootLayout({
 }>) {
   return (
     <ClerkProvider>
-      <html lang="en">
+      <html lang="en" suppressHydrationWarning>
         <body
           className={AppFont.className}
         >

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -16,6 +16,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
+import { ThemeToggle } from "@/components/ThemeToggle";
 
 const inter = Inter({ subsets: ["latin"] });
 const staatliches = Staatliches({ subsets: ["latin"], weight: "400" });
@@ -30,21 +31,22 @@ export default function Home() {
   };
 
   return (
-    <div className={`${inter.className} min-h-screen bg-[#020617] text-slate-200 flex flex-col selection:bg-[#5E8CFF]/30`}>
+    <div className={`${inter.className} min-h-screen bg-background text-foreground flex flex-col selection:bg-[#5E8CFF]/30 transition-colors duration-300`}>
       {/* Navbar */}
-      <header className="fixed inset-x-0 top-0 z-50 bg-[#040B1A]/88 supports-[backdrop-filter]:bg-[#040B1A]/72 backdrop-blur-xl relative overflow-visible">
-        <div className="absolute inset-x-0 bottom-0 h-px bg-[#8BB8FF]/40 shadow-[0_0_10px_rgba(139,184,255,0.18)]" />
+      <header className="fixed inset-x-0 top-0 z-50 bg-background/88 supports-[backdrop-filter]:bg-background/72 backdrop-blur-xl relative overflow-visible transition-colors duration-300">
+        <div className="absolute inset-x-0 bottom-0 h-px bg-border shadow-[0_0_10px_rgba(139,184,255,0.18)]" />
         <div className="max-w-7xl mx-auto h-20 flex items-center justify-between px-[clamp(24px,5vw,64px)]">
           <Link href="/" className="flex items-center gap-2 hover:opacity-90 transition-opacity">
             <div className="w-10 h-10 bg-[#5E8CFF] rounded-xl flex items-center justify-center text-white font-bold text-xl shadow-[0_0_20px_rgba(94,140,255,0.25)] ring-1 ring-[#AABFFF]/35">
               D
             </div>
-            <h1 className="text-2xl font-bold text-white transition-colors drop-shadow-[0_0_10px_rgba(170,191,255,0.15)]">
+            <h1 className="text-2xl font-bold text-foreground transition-colors drop-shadow-[0_0_10px_rgba(170,191,255,0.15)]">
               DoubtDesk
             </h1>
           </Link>
 
           <div className="flex items-center gap-4">
+            <ThemeToggle />
             <SignedOut>
               <SignInButton mode="modal" forceRedirectUrl="/rooms">
                 <button className="px-5 py-2.5 bg-white/5 hover:bg-white/10 text-white rounded-xl text-sm font-semibold border border-white/10 transition-all hover:shadow-[0_0_16px_rgba(255,255,255,0.08)]">

--- a/app/provider.tsx
+++ b/app/provider.tsx
@@ -30,6 +30,13 @@ import { Toaster } from "sonner";
 import { useRouter, usePathname } from "next/navigation";
 import { KeyboardShortcutsProvider } from "@/components/KeyboardShortcutsProvider";
 import { CommandMenu } from "@/components/CommandMenu";
+import { ThemeProvider, useTheme } from "next-themes";
+
+function ThemedToaster() {
+    const { resolvedTheme } = useTheme();
+
+    return <Toaster theme={resolvedTheme === "dark" ? "dark" : "light"} closeButton />;
+}
 
 export function Provider({ children }: { children: React.ReactNode }) {
     const [appUser, setAppUser] = useState<AppUser | null>(null);
@@ -76,12 +83,14 @@ export function Provider({ children }: { children: React.ReactNode }) {
 
     return (
         <UserContext.Provider value={{ appUser, setAppUser, loading, refresh }}>
-            <KeyboardShortcutsProvider>
-                <SessionTracker />
-                {children}
-                <CommandMenu />
-                <Toaster theme="dark" closeButton />
-            </KeyboardShortcutsProvider>
+            <ThemeProvider attribute="class" defaultTheme="system" enableSystem storageKey="doubtdesk-theme">
+                <KeyboardShortcutsProvider>
+                    <SessionTracker />
+                    {children}
+                    <CommandMenu />
+                    <ThemedToaster />
+                </KeyboardShortcutsProvider>
+            </ThemeProvider>
         </UserContext.Provider>
     );
 }

--- a/components/DashboardLayout.tsx
+++ b/components/DashboardLayout.tsx
@@ -15,6 +15,7 @@ import {
     AlertDialogHeader,
     AlertDialogTitle,
 } from "@/components/ui/alert-dialog"
+import { ThemeToggle } from "@/components/ThemeToggle"
 
 export default function DashboardLayout({
     children,
@@ -30,14 +31,14 @@ export default function DashboardLayout({
     }
 
     return (
-        <div className="flex h-screen bg-slate-950 overflow-hidden text-slate-200">
+        <div className="flex h-screen bg-background overflow-hidden text-foreground transition-colors duration-300">
             {/* Sidebar */}
             <Sidebar isOpen={isSidebarOpen} onClose={() => setIsSidebarOpen(false)} />
 
             {/* Main Content Wrapper */}
             <div className="flex-1 flex flex-col min-w-0">
                 {/* Header */}
-                <header className="bg-slate-950/80 backdrop-blur-xl border-b border-white/5 z-20 shrink-0 h-20 flex items-center">
+                <header className="bg-background/80 backdrop-blur-xl border-b border-border z-20 shrink-0 h-20 flex items-center transition-colors duration-300">
                     <div className="flex-1 flex items-center justify-between px-6">
                         <div className="flex items-center gap-4">
                             <button
@@ -50,9 +51,10 @@ export default function DashboardLayout({
                         </div>
 
                         <div className="flex items-center gap-4">
+                            <ThemeToggle />
                             <SignedIn>
                                 <div className="flex items-center gap-4">
-                                    <Link href="/profile" className="text-sm font-medium text-slate-300 hover:text-white transition-colors">
+                                    <Link href="/profile" className="text-sm font-medium text-muted-foreground hover:text-foreground transition-colors">
                                         Profile
                                     </Link>
                                     <UserButton
@@ -64,7 +66,7 @@ export default function DashboardLayout({
                                                 userButtonPopoverFooter: {
                                                     display: "none"
                                                 },
-                                                userButtonAvatarBox: "w-10 h-10 border border-white/10"
+                                                userButtonAvatarBox: "w-10 h-10 border border-border"
                                             }
                                         }}
                                     >
@@ -89,15 +91,15 @@ export default function DashboardLayout({
 
                 {/* Confirm Sign Out Dialog */}
                 <AlertDialog open={showSignOutDialog} onOpenChange={setShowSignOutDialog}>
-                    <AlertDialogContent className="bg-slate-900 border-white/10 text-white">
+                    <AlertDialogContent className="bg-popover border-border text-popover-foreground">
                         <AlertDialogHeader>
                             <AlertDialogTitle>Are you sure you want to sign out?</AlertDialogTitle>
-                            <AlertDialogDescription className="text-slate-400">
+                            <AlertDialogDescription className="text-muted-foreground">
                                 You will need to log in again to access your dashboard and AI tools.
                             </AlertDialogDescription>
                         </AlertDialogHeader>
                         <AlertDialogFooter>
-                            <AlertDialogCancel className="bg-white/5 border-white/10 text-white hover:bg-white/10">Cancel</AlertDialogCancel>
+                            <AlertDialogCancel className="bg-background border-border text-foreground hover:bg-accent">Cancel</AlertDialogCancel>
                             <AlertDialogAction
                                 onClick={handleSignOut}
                                 className="bg-red-600 hover:bg-red-700 text-white border-none"
@@ -109,7 +111,7 @@ export default function DashboardLayout({
                 </AlertDialog>
 
                 {/* Scrollable Content */}
-                <main className="flex-1 overflow-auto bg-slate-950">
+                <main className="flex-1 overflow-auto bg-background transition-colors duration-300">
                     {children}
                 </main>
             </div>

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -21,6 +21,7 @@ import {
     School,
     Bookmark
 } from 'lucide-react'
+import { ThemeToggle } from '@/components/ThemeToggle'
 
 const menuItems = [
     { name: 'Dashboard', icon: LayoutDashboard, href: '/dashboard' },
@@ -50,25 +51,25 @@ export default function Sidebar({ isOpen, onClose }: SidebarProps) {
             <aside
                 className={`
           fixed lg:static inset-y-0 left-0 z-40
-          w-64 bg-slate-950 border-r border-white/5
+          w-64 bg-background border-r border-border
           transform transition-transform duration-300 ease-in-out
           ${isOpen ? 'translate-x-0' : '-translate-x-full lg:translate-x-0'}
         `}
             >
                 <div className="flex flex-col h-full">
                     {/* Logo Section */}
-                    <div className="flex items-center justify-between px-6 border-b border-white/5 h-20">
+                    <div className="flex items-center justify-between px-6 border-b border-border h-20">
                         <Link href="/" className="flex items-center gap-3 hover:opacity-80 transition-opacity">
                             <div className="w-10 h-10 bg-gradient-to-br from-blue-600 to-purple-600 rounded-xl flex items-center justify-center text-white font-bold text-xl shadow-[0_0_15px_rgba(37,99,235,0.2)]">
                                 D
                             </div>
-                            <h1 className="text-xl font-bold text-blue-400 hover:text-blue-300 tracking-tight transition-colors">
+                            <h1 className="text-xl font-bold text-blue-500 hover:text-blue-600 dark:text-blue-400 dark:hover:text-blue-300 tracking-tight transition-colors">
                                 DoubtDesk
                             </h1>
                         </Link>
                         <button
                             onClick={onClose}
-                            className="lg:hidden p-2 text-slate-400 hover:bg-white/5 rounded-lg"
+                            className="lg:hidden p-2 text-muted-foreground hover:bg-accent rounded-lg"
                             aria-label="Close sidebar"
                         >
                             <X className="w-6 h-6" />
@@ -92,11 +93,11 @@ export default function Sidebar({ isOpen, onClose }: SidebarProps) {
                                             transition-all duration-200 group
                                             ${isActive
                                                 ? 'bg-blue-600/10 text-blue-400'
-                                                : 'text-slate-400 hover:bg-white/5 hover:text-white'
+                                                : 'text-muted-foreground hover:bg-accent hover:text-foreground'
                                             }
                                         `}
                                     >
-                                        <Icon className={`w-5 h-5 transition-colors ${isActive ? 'text-blue-400' : 'text-slate-500 group-hover:text-slate-300'}`} />
+                                        <Icon className={`w-5 h-5 transition-colors ${isActive ? 'text-blue-400' : 'text-muted-foreground group-hover:text-foreground'}`} />
                                         <span className="text-sm font-medium">{item.name}</span>
                                         {isActive && (
                                             <div className="ml-auto w-1.5 h-1.5 rounded-full bg-blue-400 shadow-[0_0_8px_rgba(96,165,250,0.6)]" />
@@ -109,10 +110,10 @@ export default function Sidebar({ isOpen, onClose }: SidebarProps) {
                         {/* Public Doubt Rooms Section */}
                         <div className="space-y-4">
                             <div className="px-4">
-                                <h2 className="text-[10px] font-black uppercase tracking-[0.2em] text-slate-500 mb-2">
+                                <h2 className="text-[10px] font-black uppercase tracking-[0.2em] text-muted-foreground mb-2">
                                     Community
                                 </h2>
-                                <div className="h-px w-full bg-white/5"></div>
+                                <div className="h-px w-full bg-border"></div>
                             </div>
                             
                             <div className="space-y-1">
@@ -124,12 +125,12 @@ export default function Sidebar({ isOpen, onClose }: SidebarProps) {
                                         transition-all duration-200 group
                                         ${pathname === '/public-rooms'
                                             ? 'bg-blue-600/10 text-blue-400'
-                                            : 'text-slate-400 hover:bg-white/5 hover:text-white'
+                                            : 'text-muted-foreground hover:bg-accent hover:text-foreground'
                                         }
                                     `}
                                 >
-                                    <div className={`p-1.5 rounded-lg bg-slate-900 border border-white/5 group-hover:border-white/10 transition-colors`}>
-                                        <MessageSquare className={`w-4 h-4 ${pathname === '/public-rooms' ? 'text-blue-400' : 'text-slate-500'}`} />
+                                    <div className="p-1.5 rounded-lg bg-muted border border-border transition-colors">
+                                        <MessageSquare className={`w-4 h-4 ${pathname === '/public-rooms' ? 'text-blue-400' : 'text-muted-foreground'}`} />
                                     </div>
                                     <span className="text-sm font-medium">Public Doubts</span>
                                     {pathname === '/public-rooms' && (
@@ -158,12 +159,12 @@ export default function Sidebar({ isOpen, onClose }: SidebarProps) {
                                         transition-all duration-200 group
                                         ${pathname === '/ask-ai'
                                             ? 'bg-cyan-600/10 text-cyan-400'
-                                            : 'text-slate-400 hover:bg-white/5 hover:text-white'
+                                            : 'text-muted-foreground hover:bg-accent hover:text-foreground'
                                         }
                                     `}
                                 >
-                                    <div className={`p-1.5 rounded-lg bg-slate-900 border border-white/5 group-hover:border-white/10 transition-colors`}>
-                                        <Zap className={`w-4 h-4 ${pathname === '/ask-ai' ? 'text-cyan-400 fill-cyan-400/20' : 'text-slate-500 group-hover:text-cyan-400 transition-colors'}`} />
+                                    <div className="p-1.5 rounded-lg bg-muted border border-border transition-colors">
+                                        <Zap className={`w-4 h-4 ${pathname === '/ask-ai' ? 'text-cyan-400 fill-cyan-400/20' : 'text-muted-foreground group-hover:text-cyan-400 transition-colors'}`} />
                                     </div>
                                     <span className="text-sm font-medium">Ask AI Solver</span>
                                     {pathname === '/ask-ai' && (
@@ -175,8 +176,12 @@ export default function Sidebar({ isOpen, onClose }: SidebarProps) {
                     </nav>
 
                     {/* Footer */}
-                    <div className="p-4 border-t border-white/5">
-                        <div className="text-[10px] text-slate-600 text-center font-bold uppercase tracking-widest">
+                    <div className="p-4 border-t border-border space-y-3">
+                        <div className="flex items-center justify-between">
+                            <span className="text-xs font-bold text-muted-foreground">Theme</span>
+                            <ThemeToggle />
+                        </div>
+                        <div className="text-[10px] text-muted-foreground text-center font-bold uppercase tracking-widest">
                             © 2026 DoubtDesk
                         </div>
                     </div>

--- a/components/ThemeToggle.tsx
+++ b/components/ThemeToggle.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Moon, Sun } from "lucide-react";
+import { useTheme } from "next-themes";
+
+import { cn } from "@/lib/utils";
+
+type ThemeToggleProps = {
+    className?: string;
+};
+
+export function ThemeToggle({ className }: ThemeToggleProps) {
+    const { resolvedTheme, setTheme } = useTheme();
+    const [mounted, setMounted] = useState(false);
+
+    useEffect(() => {
+        setMounted(true);
+    }, []);
+
+    const isDark = mounted ? resolvedTheme === "dark" : true;
+    const nextTheme = isDark ? "light" : "dark";
+
+    return (
+        <button
+            type="button"
+            aria-label={`Switch to ${nextTheme} mode`}
+            title={`Switch to ${nextTheme} mode`}
+            onClick={() => setTheme(nextTheme)}
+            className={cn(
+                "relative inline-flex h-10 w-10 items-center justify-center rounded-xl border border-slate-200/70 bg-white/80 text-slate-700 shadow-sm transition-all hover:bg-slate-100 hover:text-slate-950 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-offset-background dark:border-white/10 dark:bg-white/5 dark:text-slate-300 dark:hover:bg-white/10 dark:hover:text-white",
+                className
+            )}
+        >
+            <Sun className="h-5 w-5 scale-100 rotate-0 transition-all dark:scale-0 dark:-rotate-90" />
+            <Moon className="absolute h-5 w-5 scale-0 rotate-90 transition-all dark:scale-100 dark:rotate-0" />
+        </button>
+    );
+}

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -14,6 +14,12 @@ global.MessagePort = MessagePort as any;
 global.Blob = Blob as any;
 global.FormData = FormData as any;
 
+if (!String.prototype.toWellFormed) {
+    String.prototype.toWellFormed = function () {
+        return this.toString();
+    };
+}
+
 const { Request, Response, Headers, fetch } = require('undici');
 
 Object.defineProperties(globalThis, {


### PR DESCRIPTION
## Description
Adds a dark mode toggle across the application using `next-themes`, with theme persistence, accessible sun/moon toggle controls, smooth theme transitions, and light/dark-aware shared layout styling.

## Related Issue
Closes #29

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Documentation update (README, guides, comments)
- [x] Style / UI change (no logic change)
- [ ] Code refactor (no behavior change)
- [ ] Test addition or update
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Screenshots (if UI change)
Light Mode
<img width="959" height="259" alt="image" src="https://github.com/user-attachments/assets/af0f4fa4-4624-4411-b478-a97dbb3cff76" />
Dark Mode
<img width="953" height="251" alt="image" src="https://github.com/user-attachments/assets/8e553031-f170-4062-b898-e1549290ff5f" />


## How Has This Been Tested?
- [x] Tested locally with `npm run dev`
- [ ] Verified on mobile viewport (375px)
- [ ] Verified on desktop viewport (1440px)

## Checklist
- [x] I have tested my changes locally (`npm run dev`)
- [x] My code follows the existing code style (TypeScript, Tailwind, no `any` types)
- [x] I have not introduced unrelated changes (each PR should address one issue)
- [ ] I have added comments where necessary
- [x] My branch is up to date with `main`
- [x] I have linked the related issue above
- [ ] Screenshots are included (if this is a UI change)
