### PR TITLE
fix: resolve double scrollbar and layout overflow on ask-ai page

### DIFF
--- a/app/ask-ai/page.tsx
+++ b/app/ask-ai/page.tsx
@@ -232,10 +232,10 @@ export default function AskAIPage() {
     };
 
     return (
-        <div className="flex h-screen bg-[#020617] text-white overflow-hidden">
+        <div className="flex min-h-screen bg-[#020617] text-white min-w-0">
             <Sidebar isOpen={isSidebarOpen} onClose={() => setIsSidebarOpen(false)} />
 
-            <main className="flex-1 flex flex-col overflow-y-auto">
+            <main className="flex-1 flex flex-col min-w-0">
                 {/* Mobile Header */}
                 <header className="flex lg:hidden items-center gap-3 px-4 py-3 border-b border-white/5 bg-slate-950/80 backdrop-blur-xl sticky top-0 z-20">
                     <button onClick={() => setIsSidebarOpen(true)} className="p-2 hover:bg-white/5 rounded-lg" aria-label="Open sidebar">
@@ -430,7 +430,7 @@ export default function AskAIPage() {
 
                     {/* ── Answer Sections & Chat ── */}
                     {messages.length > 0 && (
-                        <div className="space-y-6 pb-24">
+                        <div className="space-y-6 pb-16">
                             {messages.map((msg, msgIdx) => {
                                 if (msg.role === 'user' && msgIdx > 0) {
                                     // Render follow-up user message

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -49,7 +49,7 @@ export default function Sidebar({ isOpen, onClose }: SidebarProps) {
             {/* Sidebar */}
             <aside
                 className={`
-          fixed lg:static inset-y-0 left-0 z-40
+          fixed lg:sticky lg:top-0 lg:h-screen shrink-0 inset-y-0 left-0 z-40
           w-64 bg-slate-950 border-r border-white/5
           transform transition-transform duration-300 ease-in-out
           ${isOpen ? 'translate-x-0' : '-translate-x-full lg:translate-x-0'}


### PR DESCRIPTION
## Description
Fixed the layout overflow issue on the Ask AI page that caused a double vertical scrollbar and excessive empty scrollable space after AI responses rendered.

Changes include:
- Removed nested scrolling behavior from the main content area
- Replaced rigid `h-screen` layout handling with natural page expansion using `min-h-screen`
- Fixed excessive bottom spacing below generated content
- Preserved sticky desktop sidebar behavior while allowing the page to scroll naturally
- Improved overall scrolling and footer alignment behavior

These changes maintain the existing DoubtDesk dark/neon UI aesthetic while improving layout stability and user experience.

## Related Issue
Closes #76 

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Style / UI change (no logic change)

## Screenshots (if UI change)

| Before |

<img width="1919" height="939" alt="Screenshot 2026-05-17 050359" src="https://github.com/user-attachments/assets/8f922e3f-7efb-45ac-ab8c-e3753aa62bbb" />

| After |

<img width="1919" height="936" alt="Screenshot 2026-05-17 050155" src="https://github.com/user-attachments/assets/923b05bf-8617-4134-95ef-8a1c818f1a64" />


## How Has This Been Tested?
- [x] Tested locally with `npm run dev`
- [x] Verified on mobile viewport (375px)
- [x] Verified on desktop viewport (1440px)

## Checklist
- [x] I have tested my changes locally (`npm run dev`)
- [x] My code follows the existing code style (TypeScript, Tailwind, no `any` types)
- [x] I have not introduced unrelated changes (each PR should address one issue)
- [x] I have added comments where necessary
- [x] My branch is up to date with `main`
- [x] I have linked the related issue above
- [x] Screenshots are included (if this is a UI change)