### PR TITLE
Add character count and limit to doubt submission textarea

### DIFF
--- a/components/AskDoubt.tsx
+++ b/components/AskDoubt.tsx
@@ -57,6 +57,15 @@ const suggestTags = (text: string, subject: string) => {
  */
 export default function AskDoubt({ defaultSubject = "", isOpen, onClose, onSuccess, doubtToEdit, classroomId = null, type = 'community' }: AskDoubtProps) {
     const [content, setContent] = useState(doubtToEdit?.content || "");
+    const maxlength = 500;
+    const charCount = content.length;
+    let colorClass = "text-slate-400";
+
+if (charCount >= maxLength) {
+  colorClass = "text-red-500";
+} else if (charCount >= maxLength * 0.8) {
+  colorClass = "text-yellow-400";
+}
     const [subject, setSubject] = useState(doubtToEdit?.subject || defaultSubject);
     const [imageUrl, setImageUrl] = useState(doubtToEdit?.imageUrl || "");
     const [fileName, setFileName] = useState(
@@ -198,6 +207,10 @@ export default function AskDoubt({ defaultSubject = "", isOpen, onClose, onSucce
 
     const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault();
+        if (charCount > maxLength) {
+            toast.error("Character limit exceeded (500)");
+            return;
+            }
         if ((!content.trim() && !imageUrl) || !subject.trim()) return;
 
         setIsSubmitting(true);
@@ -330,6 +343,9 @@ export default function AskDoubt({ defaultSubject = "", isOpen, onClose, onSucce
                                 placeholder="Type your question here... (Markdown supported)"
                                 className="w-full h-32 bg-white/5 border border-white/10 rounded-2xl p-4 text-white placeholder:text-slate-600 focus:outline-none focus:border-blue-500/50 focus:ring-1 focus:ring-blue-500/20 transition-all resize-none"
                             />
+                   <p className={`text-xs text-right mt-1 ${colorClass}`}>
+                     {charCount} / {maxLength}
+                     </p>
                         )}
                     </div>
 

--- a/components/AskDoubt.tsx
+++ b/components/AskDoubt.tsx
@@ -57,7 +57,7 @@ const suggestTags = (text: string, subject: string) => {
  */
 export default function AskDoubt({ defaultSubject = "", isOpen, onClose, onSuccess, doubtToEdit, classroomId = null, type = 'community' }: AskDoubtProps) {
     const [content, setContent] = useState(doubtToEdit?.content || "");
-    const maxlength = 500;
+    const maxLength = 500;
     const charCount = content.length;
     let colorClass = "text-slate-400";
 
@@ -328,24 +328,26 @@ if (charCount >= maxLength) {
                                 <MarkdownRenderer content={content || "*Nothing to preview*"} />
                             </div>
                         ) : (
-                            <textarea
-                                ref={contentTextareaRef}
-                                value={content}
-                                onChange={(e) => setContent(e.target.value)}
-                                onKeyDown={(e) => {
-                                    if (e.key === "Enter" && (e.ctrlKey || e.metaKey)) {
-                                        e.preventDefault();
-                                        if (content.trim() || imageUrl) {
-                                            handleSubmit(e as any);
+                            <>
+                                <textarea
+                                    ref={contentTextareaRef}
+                                    value={content}
+                                    onChange={(e) => setContent(e.target.value)}
+                                    onKeyDown={(e) => {
+                                        if (e.key === "Enter" && (e.ctrlKey || e.metaKey)) {
+                                            e.preventDefault();
+                                            if (content.trim() || imageUrl) {
+                                                handleSubmit(e as any);
+                                            }
                                         }
-                                    }
-                                }}
-                                placeholder="Type your question here... (Markdown supported)"
-                                className="w-full h-32 bg-white/5 border border-white/10 rounded-2xl p-4 text-white placeholder:text-slate-600 focus:outline-none focus:border-blue-500/50 focus:ring-1 focus:ring-blue-500/20 transition-all resize-none"
-                            />
-                   <p className={`text-xs text-right mt-1 ${colorClass}`}>
-                     {charCount} / {maxLength}
-                     </p>
+                                    }}
+                                    placeholder="Type your question here... (Markdown supported)"
+                                    className="w-full h-32 bg-white/5 border border-white/10 rounded-2xl p-4 text-white placeholder:text-slate-600 focus:outline-none focus:border-blue-500/50 focus:ring-1 focus:ring-blue-500/20 transition-all resize-none"
+                                />
+                                <p className={`text-xs text-right mt-1 ${colorClass}`}>
+                                    {charCount} / {maxLength}
+                                </p>
+                            </>
                         )}
                     </div>
 


### PR DESCRIPTION
This PR adds a live character counter and a 500 character limit to the doubt submission textarea.
Changes:
* Displays character count below textarea
* Adds color indicators (yellow at 80%, red at 100%)
* Prevents submission when character limit is exceeded

This improves user experience and avoids overly long inputs.