### PR TITLE
fix: resolve broken footer navigation links

### DIFF
--- a/__tests__/components/Footer.test.tsx
+++ b/__tests__/components/Footer.test.tsx
@@ -6,13 +6,30 @@ describe('Footer Component', () => {
     it('renders platform name and tagline', () => {
         render(<Footer />);
         expect(screen.getByText('DoubtDesk')).toBeInTheDocument();
-        expect(screen.getByText('Simplifying classroom doubt solving with AI.')).toBeInTheDocument();
+        expect(screen.getByText(/Simplifying classroom doubt solving with AI-powered collaboration/)).toBeInTheDocument();
     });
 
-    it('renders navigation links', () => {
+    it('renders navigation links to existing pages', () => {
         render(<Footer />);
-        expect(screen.getByText('Dashboard')).toBeInTheDocument();
-        expect(screen.getByText('Virtual Campus')).toBeInTheDocument();
+        expect(screen.getByRole('link', { name: 'Dashboard' })).toHaveAttribute('href', '/dashboard');
+        expect(screen.getByRole('link', { name: 'Virtual Campus' })).toHaveAttribute('href', '/rooms');
+        expect(screen.getByRole('link', { name: 'AI Solver' })).toHaveAttribute('href', '/ask-ai');
+        expect(screen.getByRole('link', { name: 'Analytics' })).toHaveAttribute('href', '/dashboard/analytics');
+        expect(screen.getByRole('link', { name: 'Public Doubts' })).toHaveAttribute('href', '/public-rooms');
+        expect(screen.getByRole('link', { name: 'Bookmarks' })).toHaveAttribute('href', '/bookmarks');
+    });
+
+    it('does not render links for unimplemented standalone pages', () => {
+        render(<Footer />);
+        expect(screen.queryByRole('link', { name: 'Help Center' })).not.toBeInTheDocument();
+        expect(screen.queryByRole('link', { name: 'Discussions' })).not.toBeInTheDocument();
+        expect(screen.queryByRole('link', { name: 'Leaderboard' })).not.toBeInTheDocument();
+        expect(screen.queryByRole('link', { name: 'Contributors' })).not.toBeInTheDocument();
+    });
+
+    it('uses a working contact destination instead of a missing contact page', () => {
+        render(<Footer />);
+        expect(screen.getByRole('link', { name: 'Contact' })).toHaveAttribute('href', 'mailto:karankmt.tripathi@gmail.com');
     });
 
     it('renders current year copyright', () => {

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -12,26 +12,25 @@ export default function Footer() {
             links: [
                 { label: "Dashboard", href: "/dashboard" },
                 { label: "Virtual Campus", href: "/rooms" },
-                { label: "AI Solver", href: "/ai" },
-                { label: "Analytics", href: "/analytics" },
+                { label: "AI Solver", href: "/ask-ai" },
+                { label: "Analytics", href: "/dashboard/analytics" },
             ],
         },
         {
             title: "Resources",
             links: [
+                { label: "Public Doubts", href: "/public-rooms" },
+                { label: "Bookmarks", href: "/bookmarks" },
                 { label: "Privacy Policy", href: "/privacy-policy" },
                 { label: "Terms of Service", href: "/terms-of-service" },
-                { label: "Leaderboard", href: "/leaderboard" },
-                { label: "Help Center", href: "/help" },
             ],
         },
         {
             title: "Community",
             links: [
                 { label: "GitHub", href: "https://github.com/knoxiboy/DoubtDesk" },
-                { label: "Contributors", href: "/contributors" },
-                { label: "Discussions", href: "/discussions" },
-                { label: "Contact", href: "/contact" },
+                { label: "Report Issue", href: "https://github.com/knoxiboy/DoubtDesk/issues" },
+                { label: "Contact", href: "mailto:karankmt.tripathi@gmail.com" },
             ],
         },
     ]
@@ -107,6 +106,8 @@ export default function Footer() {
                                         <li key={link.label}>
                                             <Link
                                                 href={link.href}
+                                                target={link.href.startsWith("http") ? "_blank" : undefined}
+                                                rel={link.href.startsWith("http") ? "noopener noreferrer" : undefined}
                                                 className="relative inline-flex text-sm text-slate-600 dark:text-slate-400 transition-all duration-300 hover:text-blue-500 dark:hover:text-blue-400 hover:translate-x-1 after:absolute after:left-0 after:-bottom-1 after:h-[2px] after:w-0 after:bg-blue-500 dark:after:bg-blue-400 after:transition-all after:duration-300 hover:after:w-3/4"
                                             >
                                                 {link.label}


### PR DESCRIPTION
## Description
Fixed broken footer navigation links that were routing users to 404 pages. Updated footer links to point to existing routes, removed unimplemented footer links, and replaced the missing contact page route with a working email link.

## Related Issue
Closes #138

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Documentation update (README, guides, comments)
- [x] Style / UI change (no logic change)
- [ ] Code refactor (no behavior change)
- [x] Test addition or update
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## How Has This Been Tested?
- [ ] Tested locally with `npm run dev`
- [ ] Verified on mobile viewport (375px)
- [ ] Verified on desktop viewport (1440px)

Additional verification:
- Checked existing App Router pages and matched footer links to valid routes.
- Ran `git diff --check`.
- Confirmed removed broken footer hrefs are no longer present in the code.

## Checklist
- [ ] I have tested my changes locally (`npm run dev`)
- [x] My code follows the existing code style (TypeScript, Tailwind, no `any` types)
- [x] I have not introduced unrelated changes (each PR should address one issue)
- [x] I have added comments where necessary
- [x] My branch is up to date with `main`
- [x] I have linked the related issue above
- [ ] Screenshots are included (if this is a UI change)