### PR TITLE
fix: use production URL for social metadata

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,9 @@
 # Database (Neon PostgreSQL)
 DATABASE_URL=postgresql://user:password@host/database?sslmode=require
 
+# Public site URL for canonical, OpenGraph, and Twitter metadata
+NEXT_PUBLIC_SITE_URL=http://localhost:3000
+
 # Authentication (Clerk)
 NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_your_key_here
 CLERK_SECRET_KEY=sk_test_your_key_here

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -14,11 +14,24 @@ const AppFont = DM_Sans({
   subsets: ['latin'],
   variable: '--font-app',
 })
+
+const DEFAULT_SITE_URL = "https://doubt-desk-seven.vercel.app";
+
+function getSiteUrl() {
+  const siteUrl =
+    process.env.NEXT_PUBLIC_SITE_URL ||
+    process.env.NEXT_PUBLIC_APP_URL ||
+    process.env.VERCEL_PROJECT_PRODUCTION_URL ||
+    process.env.VERCEL_URL ||
+    DEFAULT_SITE_URL;
+
+  return siteUrl.startsWith("http") ? siteUrl : `https://${siteUrl}`;
+}
+
+const siteUrl = getSiteUrl();
+
 export const metadata: Metadata = {
-  metadataBase: new URL(
-    process.env.NEXT_PUBLIC_APP_URL || 
-    (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : "http://localhost:3000")
-  ),
+  metadataBase: new URL(siteUrl),
   title: {
     default: "DoubtDesk | AI Doubt Solver",
     template: "%s | DoubtDesk",
@@ -48,11 +61,11 @@ export const metadata: Metadata = {
     title: "DoubtDesk | AI Doubt Solver",
     description:
       "DoubtDesk enables students to solve engineering doubts instantly with AI, join interactive classrooms, and view clear learning analytics.",
-    url: "/",
+    url: siteUrl,
     siteName: "DoubtDesk",
     images: [
       {
-        url: "/og-image.png",
+        url: `${siteUrl}/og-image.png`,
         width: 1200,
         height: 630,
         alt: "DoubtDesk - AI classroom doubt-solving platform",
@@ -66,7 +79,7 @@ export const metadata: Metadata = {
     title: "DoubtDesk | AI Doubt Solver",
     description:
       "DoubtDesk enables students to solve engineering doubts instantly with AI, join interactive classrooms, and view clear learning analytics.",
-    images: ["/og-image.png"],
+    images: [`${siteUrl}/og-image.png`],
   },
   robots: {
     index: true,


### PR DESCRIPTION
## Description
Fixes production OpenGraph and Twitter metadata URLs so shared links no longer point to `localhost:3000`. The metadata now uses `NEXT_PUBLIC_SITE_URL` when provided, supports existing Vercel URL environment variables, and falls back to the deployed production URL.

## Related Issue
Closes #139

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Documentation update (README, guides, comments)
- [ ] Style / UI change (no logic change)
- [ ] Code refactor (no behavior change)
- [ ] Test addition or update
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Screenshots (if UI change)
Not applicable. This PR updates metadata configuration only and does not change the UI.

## How Has This Been Tested?
- [ ] Tested locally with `npm run dev`
- [ ] Verified on mobile viewport (375px)
- [ ] Verified on desktop viewport (1440px)
- [x] Verified `app/layout.tsx` no longer uses `localhost:3000` for production metadata
- [x] Ran `git diff --check`

Additional checks attempted:
- `npm.cmd run lint` was blocked by the existing `next lint` script incompatibility with the installed Next.js version.
- `npm.cmd test -- --runTestsByPath __tests__\components\Footer.test.tsx` was blocked by existing Jest/SWC setup issues.
- `npx.cmd tsc --noEmit` was blocked by existing missing `jspdf` type declarations.
- `npm.cmd run build` and `npx.cmd next build --webpack` were blocked by existing Next/SWC/Clerk build issues.

## Checklist
- [ ] I have tested my changes locally (`npm run dev`)
- [x] My code follows the existing code style (TypeScript, Tailwind, no `any` types)
- [x] I have not introduced unrelated changes (each PR should address one issue)
- [x] I have added comments where necessary
- [x] My branch is up to date with `main`
- [x] I have linked the related issue above
- [x] Screenshots are included (if this is a UI change)