### PR TITLE
refactor: rename package to doubtdesk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "nextjs-boilerplate-1",
+  "name": "doubtdesk",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "nextjs-boilerplate-1",
+      "name": "doubtdesk",
       "version": "0.1.0",
       "dependencies": {
         "@clerk/nextjs": "^6.39.3",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "nextjs-boilerplate-1",
+  "name": "doubtdesk",
   "version": "0.1.0",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## Summary
- rename package metadata from 
extjs-boilerplate-1 to doubtdesk`n- keep package-lock.json root package metadata in sync

## Verification
- 
pm ci completed
- 
pm run build compiled successfully and completed TypeScript, then stopped during page data collection because DATABASE_URL/Neon connection string is not configured in this local environment
- 
pm run lint currently fails because the repo script runs 
ext lint, which is not valid in this Next.js 16 setup

Closes #168