### PR TITLE
feat: add robots crawl control

### DIFF
--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,23 @@
+import type { MetadataRoute } from "next";
+
+export default function robots(): MetadataRoute.Robots {
+  const baseUrl = process.env.NEXT_PUBLIC_APP_URL || "https://doubtdesk.vercel.app";
+
+  return {
+    rules: {
+      userAgent: "*",
+      allow: "/",
+      disallow: [
+        "/api/",
+        "/dashboard/",
+        "/profile/",
+        "/sign-in/",
+        "/sign-up/",
+        "/onboarding/",
+        "/rooms/",
+        "/bookmarks/",
+      ],
+    },
+    sitemap: `${baseUrl}/sitemap.xml`,
+  };
+}


### PR DESCRIPTION
## Summary
- add pp/robots.ts using the Next.js Metadata API
- allow public pages while disallowing private/internal routes such as /api/, /dashboard/, /profile/, and /rooms/`n- reference the generated sitemap URL from the configured public app URL

## Verification
- 
px tsc --noEmit --pretty false`n
Closes #165