### PR TITLE
feat: add route error boundaries

### DIFF
--- a/app/ask-ai/error.tsx
+++ b/app/ask-ai/error.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { ErrorFallback } from "@/components/ErrorFallback";
+
+export default function AskAIError({
+  error,
+  reset,
+}: {
+  error: Error;
+  reset: () => void;
+}) {
+  return (
+    <ErrorFallback
+      title="AI solver could not load"
+      description="The AI workspace hit an unexpected error. Try again to restart this flow."
+      error={error}
+      reset={reset}
+    />
+  );
+}

--- a/app/dashboard/error.tsx
+++ b/app/dashboard/error.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { ErrorFallback } from "@/components/ErrorFallback";
+
+export default function DashboardError({
+  error,
+  reset,
+}: {
+  error: Error;
+  reset: () => void;
+}) {
+  return (
+    <ErrorFallback
+      title="Dashboard could not load"
+      description="We had trouble loading your dashboard data. Try again to refresh this view."
+      error={error}
+      reset={reset}
+    />
+  );
+}

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import { ErrorFallback } from "@/components/ErrorFallback";
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error;
+  reset: () => void;
+}) {
+  return <ErrorFallback error={error} reset={reset} />;
+}

--- a/app/rooms/error.tsx
+++ b/app/rooms/error.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { ErrorFallback } from "@/components/ErrorFallback";
+
+export default function RoomsError({
+  error,
+  reset,
+}: {
+  error: Error;
+  reset: () => void;
+}) {
+  return (
+    <ErrorFallback
+      title="Rooms could not load"
+      description="We could not load your classroom rooms right now. Try again to reload the page."
+      error={error}
+      reset={reset}
+    />
+  );
+}

--- a/components/ErrorFallback.tsx
+++ b/components/ErrorFallback.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { AlertTriangle, RotateCcw } from "lucide-react";
+
+type ErrorFallbackProps = {
+  title?: string;
+  description?: string;
+  error: Error;
+  reset: () => void;
+};
+
+export function ErrorFallback({
+  title = "Something went wrong",
+  description = "We could not load this part of DoubtDesk. Please try again.",
+  error,
+  reset,
+}: ErrorFallbackProps) {
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-slate-50 px-6 py-16 text-slate-900 dark:bg-slate-950 dark:text-white">
+      <div className="w-full max-w-lg rounded-3xl border border-slate-200 bg-white/90 p-8 text-center shadow-xl shadow-slate-200/70 backdrop-blur dark:border-slate-800 dark:bg-slate-900/80 dark:shadow-black/30">
+        <div className="mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-2xl border border-red-500/20 bg-red-500/10">
+          <AlertTriangle className="h-8 w-8 text-red-500" />
+        </div>
+
+        <h2 className="mb-3 text-2xl font-bold">{title}</h2>
+        <p className="mb-4 text-sm leading-6 text-slate-600 dark:text-slate-300">
+          {description}
+        </p>
+
+        {error.message ? (
+          <p className="mb-6 rounded-2xl bg-slate-100 px-4 py-3 text-sm text-slate-500 dark:bg-slate-800 dark:text-slate-400">
+            {error.message}
+          </p>
+        ) : null}
+
+        <button
+          type="button"
+          onClick={reset}
+          className="inline-flex items-center justify-center gap-2 rounded-xl bg-blue-600 px-5 py-3 font-semibold text-white shadow-lg shadow-blue-600/20 transition hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-slate-950"
+        >
+          <RotateCcw className="h-4 w-4" />
+          Try Again
+        </button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a reusable ErrorFallback UI with dark/light mode styling
- add root pp/error.tsx error boundary
- add route-specific error boundaries for dashboard, ask-ai, and rooms
- include Try Again reset actions for each boundary

## Verification
- 
px tsc --noEmit --pretty false`n
Closes #167