### PR TITLE
Add robots route

### DIFF
--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,23 @@
+import type { MetadataRoute } from "next";
+
+const baseUrl = process.env.NEXT_PUBLIC_APP_URL || "https://doubtdesk.vercel.app";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: "*",
+      allow: "/",
+      disallow: [
+        "/api/",
+        "/dashboard/",
+        "/profile/",
+        "/sign-in/",
+        "/sign-up/",
+        "/onboarding/",
+        "/rooms/",
+        "/bookmarks/",
+      ],
+    },
+    sitemap: `${baseUrl}/sitemap.xml`,
+  };
+}


### PR DESCRIPTION
## Summary
- add a Next.js Metadata API robots route
- disallow private app areas and API routes from crawling
- reference the public sitemap URL

Closes #165

## Checks
- npx tsc --noEmit