### PR TITLE
Rename package to doubtdesk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "nextjs-boilerplate-1",
+  "name": "doubtdesk",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "nextjs-boilerplate-1",
+      "name": "doubtdesk",
       "version": "0.1.0",
       "dependencies": {
         "@clerk/nextjs": "^6.39.3",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "nextjs-boilerplate-1",
+  "name": "doubtdesk",
   "version": "0.1.0",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## Summary
- rename the package from nextjs-boilerplate-1 to doubtdesk
- keep package-lock metadata in sync

Closes #168

## Checks
- npx tsc --noEmit