### PR TITLE
Add scroll to top button for doubt feeds

### DIFF
--- a/app/public-rooms/[subject]/page.tsx
+++ b/app/public-rooms/[subject]/page.tsx
@@ -5,6 +5,7 @@ import { useEffect, useState } from "react";
 import { Zap, MessageSquare, Plus, Loader2 } from "lucide-react";
 import AskDoubt from "@/components/AskDoubt";
 import DoubtCard from "@/components/DoubtCard";
+import ScrollToTopButton from "@/components/ScrollToTopButton";
 import useSWRInfinite from "swr/infinite";
 import { useInView } from "react-intersection-observer";
 
@@ -37,6 +38,8 @@ export default function PublicRoomPage() {
 
     return (
         <div className="p-6 md:p-12 space-y-8 max-w-7xl mx-auto pb-24">
+            <ScrollToTopButton />
+
             <header className="flex flex-col md:flex-row md:items-end justify-between gap-6 pb-6 border-b border-slate-200 dark:border-white/5">
                 <div className="space-y-1">
                     <h1 className="text-5xl font-black text-slate-900 dark:text-white tracking-tighter uppercase italic">

--- a/app/public-rooms/page.tsx
+++ b/app/public-rooms/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import { MessageSquare, Plus, SlidersHorizontal, Loader2 } from "lucide-react";
 import AskDoubt from "@/components/AskDoubt";
 import DoubtCard from "@/components/DoubtCard";
+import ScrollToTopButton from "@/components/ScrollToTopButton";
 import useSWRInfinite from "swr/infinite";
 import { useInView } from "react-intersection-observer";
 
@@ -79,6 +80,8 @@ export default function PublicRoomsPage() {
 
     return (
         <div className="p-4 md:p-8 space-y-6 max-w-[1000px] mx-auto pb-24">
+            <ScrollToTopButton />
+
             <header className="flex flex-col md:flex-row md:items-end justify-between gap-6 pb-6 border-b border-slate-200 dark:border-white/5">
                 <div className="space-y-1">
                     <h1 className="text-6xl font-black text-slate-900 dark:text-white tracking-tighter uppercase italic">

--- a/components/InfiniteDoubtFeed.tsx
+++ b/components/InfiniteDoubtFeed.tsx
@@ -2,6 +2,7 @@
 
 import { MessageSquare, Loader2, ChevronDown } from "lucide-react";
 import DoubtCard from "@/components/DoubtCard";
+import ScrollToTopButton from "@/components/ScrollToTopButton";
 import useSWRInfinite from "swr/infinite";
 
 const fetcher = (url: string) => fetch(url).then((res) => res.json());
@@ -90,6 +91,8 @@ export default function InfiniteDoubtFeed({
 
     return (
         <div className="space-y-8 animate-in fade-in duration-500">
+            <ScrollToTopButton />
+
             <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
                 {doubts.map((doubt: any, index: number) => (
                     <DoubtCard

--- a/components/ScrollToTopButton.tsx
+++ b/components/ScrollToTopButton.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { ArrowUp } from "lucide-react";
+
+export default function ScrollToTopButton() {
+  const [isVisible, setIsVisible] = useState(false);
+
+  useEffect(() => {
+    const handleScroll = () => {
+      setIsVisible(window.scrollY > 300);
+    };
+
+    handleScroll();
+    window.addEventListener("scroll", handleScroll, { passive: true });
+
+    return () => window.removeEventListener("scroll", handleScroll);
+  }, []);
+
+  if (!isVisible) return null;
+
+  return (
+    <button
+      type="button"
+      onClick={() => window.scrollTo({ top: 0, behavior: "smooth" })}
+      aria-label="Scroll to top"
+      className="fixed bottom-6 right-6 z-50 flex h-12 w-12 items-center justify-center rounded-2xl border border-blue-500/30 bg-blue-600 text-white shadow-2xl shadow-blue-600/25 transition-all hover:-translate-y-1 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-400 focus:ring-offset-2 focus:ring-offset-white dark:focus:ring-offset-slate-950"
+    >
+      <ArrowUp className="h-5 w-5" />
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary
- add a reusable floating scroll-to-top button that appears after 300px
- mount it on public doubt feeds and reusable infinite doubt feeds
- support smooth scrolling and light/dark mode styling

Closes #173

## Checks
- npx tsc --noEmit