### PR TITLE
feat: add scroll-to-top button on long doubt feeds

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,6 +6,7 @@ import {
 } from '@clerk/nextjs'
 import { Provider } from "./provider";
 import Footer from "@/components/Footer";
+import ScrollToTop from "@/components/ScrollToTop";
 
 
 
@@ -95,6 +96,7 @@ export default function RootLayout({
         >
           <Provider>
             {children}
+            <ScrollToTop />
             <Footer/>
           </Provider>
         </body>

--- a/components/ScrollToTop.tsx
+++ b/components/ScrollToTop.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { ChevronUp } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface ScrollToTopProps {
+    threshold?: number;
+    className?: string;
+}
+
+export default function ScrollToTop({ threshold = 300, className }: ScrollToTopProps) {
+    const [visible, setVisible] = useState(false);
+
+    useEffect(() => {
+        const handleScroll = () => {
+            setVisible(window.scrollY > threshold);
+        };
+
+        window.addEventListener("scroll", handleScroll, { passive: true });
+        handleScroll();
+
+        return () => window.removeEventListener("scroll", handleScroll);
+    }, [threshold]);
+
+    const scrollToTop = () => {
+        window.scrollTo({ top: 0, behavior: "smooth" });
+    };
+
+    return (
+        <button
+            onClick={scrollToTop}
+            aria-label="Scroll to top"
+            className={cn(
+                "fixed bottom-6 right-6 z-50",
+                "flex items-center justify-center",
+                "w-12 h-12 rounded-full",
+                "bg-blue-600/80 dark:bg-blue-500/80",
+                "border border-blue-500/30 dark:border-blue-400/30",
+                "text-white shadow-lg shadow-blue-600/30",
+                "transition-all duration-300",
+                "hover:bg-blue-600 hover:scale-110",
+                "active:scale-95",
+                "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500",
+                "backdrop-blur-md",
+                visible
+                    ? "opacity-100 translate-y-0"
+                    : "opacity-0 translate-y-4 pointer-events-none",
+                className
+            )}
+        >
+            <ChevronUp className="w-5 h-5" />
+        </button>
+    );
+}


### PR DESCRIPTION
## Fixes: knoxiboy/DoubtDesk#173

### Problem
Doubt feed pages (dashboard, public-rooms) use infinite scrolling. After scrolling through many doubts, there is no quick way to return to the top of the page.

### Solution
Add a floating "Scroll to Top" button (chevron-up icon) that:
- Appears after scrolling 300px+
- Smoothly scrolls to top on click
- Is styled with DoubtDesk design system (blue, rounded-full, dark/light mode support)
- Does not overlap with other UI elements (fixed bottom-right, z-50)

### Changes
- **new** `components/ScrollToTop.tsx` — client component with scroll listener and smooth scroll
- **modified** `app/layout.tsx` — imports and renders `<ScrollToTop />` globally

### Acceptance Criteria
- [x] Floating button appears after scrolling 300px+
- [x] Button smoothly scrolls to top on click
- [x] Button styled with DoubtDesk design system
- [x] Supports dark/light mode
- [x] Does not overlap with other UI elements

Closes #173