### PR TITLE
fix: rename package.json name from nextjs-boilerplate-1 to doubtdesk

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "nextjs-boilerplate-1",
+  "name": "doubtdesk",
   "version": "0.1.0",
   "private": true,
   "scripts": {


### PR DESCRIPTION
### Changes

Changed the `package.json` name field from `"nextjs-boilerplate-1"` (leftover from template) to `"doubtdesk"`.

### Related

Closes #168