### PR TITLE
fix: remove duplicate Open Classroom button section on landing page

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,7 +3,6 @@
 import { useState } from "react";
 import {
   SignInButton,
-  SignUpButton,
   SignedIn,
   SignedOut,
   useClerk,
@@ -255,25 +254,6 @@ export default function Home() {
                   </Link>
                 </SignedOut>
               </div>
-            </div>
-
-            <div className="flex flex-col sm:flex-row items-center justify-center gap-6 mb-16">
-              <SignedIn>
-                <Link href="/rooms" className="w-full sm:w-auto">
-                  <button className="group px-10 py-5 bg-blue-600 text-white rounded-2xl text-lg font-bold hover:bg-blue-700 hover:shadow-[0_0_30px_rgba(37,99,235,0.4)] transition-all w-full flex items-center justify-center gap-2">
-                    Open Classroom
-                    <ArrowRight className="w-5 h-5 group-hover:translate-x-1 transition-transform" />
-                  </button>
-                </Link>
-              </SignedIn>
-              <SignedOut>
-                <SignUpButton mode="modal" forceRedirectUrl="/rooms">
-                  <button className="group px-10 py-5 bg-white text-slate-950 rounded-2xl text-lg font-bold hover:bg-slate-200 transition-all w-50 flex items-center justify-center gap-2">
-                    Open Classroom
-                    <ArrowRight className="w-5 h-5 group-hover:translate-x-1 transition-transform" />
-                  </button>
-                </SignUpButton>
-              </SignedOut>
             </div>
 
           </div>


### PR DESCRIPTION
The hero section had a duplicate "Open Classroom" CTA block right after the first one. Removed the extra copy and cleaned up the unused SignUpButton import.

Fixes #203