### PR TITLE
feat: Add email digest notifications for unread replies

### DIFF
--- a/app/api/inngest/route.ts
+++ b/app/api/inngest/route.ts
@@ -1,6 +1,6 @@
 import { serve } from "inngest/next";
 import { inngest } from "../../../inngest/client";
-import { helloWorld, cleanupTempAssets, sendReplyNotification } from "../../../inngest/functions";
+import { helloWorld, cleanupTempAssets, sendReplyNotification, sendDailyDigest, sendWeeklyDigest } from "../../../inngest/functions";
 
 // Create an API that serves zero functions
 export const { GET, POST, PUT } = serve({
@@ -9,6 +9,8 @@ export const { GET, POST, PUT } = serve({
         /* your functions will be passed here later! */
         helloWorld,
         cleanupTempAssets,
-        sendReplyNotification
+        sendReplyNotification,
+        sendDailyDigest,
+        sendWeeklyDigest
     ],
 });

--- a/app/api/profile/route.ts
+++ b/app/api/profile/route.ts
@@ -57,6 +57,8 @@ export async function GET(req: Request) {
             collegeEmail: dbUser?.collegeEmail || undefined,
             role: dbUser?.role || undefined,
             onboarded: dbUser?.onboarded || false,
+            emailNotificationsEnabled: dbUser?.emailNotificationsEnabled ?? true,
+            notificationPreference: dbUser?.notificationPreference || "instant",
             imageUrl: clerkUser?.imageUrl || undefined,
             joinDate: joinDate,
         };
@@ -98,15 +100,42 @@ export async function POST(req: NextRequest) {
             return NextResponse.json({ error: "No email found" }, { status: 400 });
         }
 
-        const { emailNotificationsEnabled } = await req.json();
+        const [dbUser] = await db.select().from(usersTable).where(eq(usersTable.email, email)).limit(1);
 
-        if (typeof emailNotificationsEnabled !== "boolean") {
-            return NextResponse.json({ error: "Invalid preference value" }, { status: 400 });
+        const { emailNotificationsEnabled, notificationPreference } = await req.json();
+
+        const updateData: Record<string, any> = {};
+
+        if (typeof emailNotificationsEnabled === "boolean") {
+            updateData.emailNotificationsEnabled = emailNotificationsEnabled;
+            // Sync notificationPreference if turning email notifications completely off/on
+            if (!emailNotificationsEnabled) {
+                updateData.notificationPreference = "none";
+            } else if (dbUser?.notificationPreference === "none") {
+                updateData.notificationPreference = "instant";
+            }
+        }
+
+        if (notificationPreference !== undefined) {
+            const validPreferences = ["instant", "daily", "weekly", "none"];
+            if (!validPreferences.includes(notificationPreference)) {
+                return NextResponse.json({ error: "Invalid preference value" }, { status: 400 });
+            }
+            updateData.notificationPreference = notificationPreference;
+            if (notificationPreference === "none") {
+                updateData.emailNotificationsEnabled = false;
+            } else {
+                updateData.emailNotificationsEnabled = true;
+            }
+        }
+
+        if (Object.keys(updateData).length === 0) {
+            return NextResponse.json({ error: "No fields to update" }, { status: 400 });
         }
 
         // Update the user preference in DB
         const updated = await db.update(usersTable)
-            .set({ emailNotificationsEnabled })
+            .set(updateData)
             .where(eq(usersTable.email, email))
             .returning();
 

--- a/app/api/replies/route.ts
+++ b/app/api/replies/route.ts
@@ -143,25 +143,37 @@ export async function POST(req: Request) {
                 if (d && d.userEmail && d.userEmail !== email) {
                     const [u] = await db.select().from(usersTable).where(eq(usersTable.email, d.userEmail)).limit(1);
                     const notificationsEnabled = u ? u.emailNotificationsEnabled : true;
+                    const preference = u ? u.notificationPreference : "instant";
                     
                     if (notificationsEnabled) {
-                        const { emailNotificationLimiter } = await import("@/lib/ratelimit");
-                        const rateLimitKey = `email_notify:${doubtId}`;
-                        const limitResult = await emailNotificationLimiter.limit(rateLimitKey);
-                        
-                        if (limitResult.success) {
-                            const { sendReplyNotificationEmail } = await import("@/lib/email");
-                            // Run non-blocking in background
-                            sendReplyNotificationEmail({
-                                toEmail: d.userEmail,
+                        if (preference === "instant") {
+                            const { emailNotificationLimiter } = await import("@/lib/ratelimit");
+                            const rateLimitKey = `email_notify:${doubtId}`;
+                            const limitResult = await emailNotificationLimiter.limit(rateLimitKey);
+                            
+                            if (limitResult.success) {
+                                const { sendReplyNotificationEmail } = await import("@/lib/email");
+                                // Run non-blocking in background
+                                sendReplyNotificationEmail({
+                                    toEmail: d.userEmail,
+                                    doubtId: d.id,
+                                    doubtSubject: d.subject,
+                                    doubtContent: d.content || "",
+                                    replierName: userName,
+                                    replyContent: content || ""
+                                }).catch(err => console.error("Immediate dev mailer failed:", err));
+                            } else {
+                                console.log(`[RATE LIMIT EXCEEDED] Immediate dev notification skipped for doubt ${doubtId} to prevent spam.`);
+                            }
+                        } else if (preference === "daily" || preference === "weekly") {
+                            // Queue pending notification in dev database directly for digest testing
+                            const { pendingNotificationsTable } = await import("@/configs/schema");
+                            await db.insert(pendingNotificationsTable).values({
+                                userEmail: d.userEmail,
                                 doubtId: d.id,
-                                doubtSubject: d.subject,
-                                doubtContent: d.content || "",
-                                replierName: userName,
-                                replyContent: content || ""
-                            }).catch(err => console.error("Immediate dev mailer failed:", err));
-                        } else {
-                            console.log(`[RATE LIMIT EXCEEDED] Immediate dev notification skipped for doubt ${doubtId} to prevent spam.`);
+                                replyId: newReply[0].id,
+                            }).catch(err => console.error("Dev fallback pending notification insert failed:", err));
+                            console.log(`[DEV EMAIL] Queued reply notification for digest (${preference}) for user ${d.userEmail}`);
                         }
                     }
                 }

--- a/app/api/unsubscribe/route.ts
+++ b/app/api/unsubscribe/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest, NextResponse } from "next/server";
+import { db } from "@/configs/db";
+import { usersTable } from "@/configs/schema";
+import { eq } from "drizzle-orm";
+
+export async function GET(req: NextRequest) {
+    try {
+        const { searchParams } = new URL(req.url);
+        const email = searchParams.get("email");
+
+        if (!email) {
+            return NextResponse.redirect(new URL("/profile?error=Email%20required", req.url));
+        }
+
+        // Update user preference in DB to 'none' and disable email notifications
+        await db.update(usersTable)
+            .set({ 
+                emailNotificationsEnabled: false, 
+                notificationPreference: "none" 
+            })
+            .where(eq(usersTable.email, email));
+
+        return NextResponse.redirect(new URL("/profile?unsubscribed=true", req.url));
+    } catch (error: any) {
+        console.error("Unsubscribe API Error:", error);
+        return NextResponse.redirect(new URL("/profile?error=Internal%20Server%20Error", req.url));
+    }
+}

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -11,6 +11,7 @@ import { format } from "date-fns";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import type { ProfileData, ProfileDoubt, ProfileReply, ProfileClassroom } from "@/types/profile";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 
 
 /** Skeleton placeholder that mirrors the profile page layout. */
@@ -90,7 +91,34 @@ export default function ProfilePage() {
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
     const [emailNotificationsEnabled, setEmailNotificationsEnabled] = useState(true);
+    const [notificationPreference, setNotificationPreference] = useState<"instant" | "daily" | "weekly" | "none">("instant");
     const [isSavingPref, setIsSavingPref] = useState(false);
+
+    const handlePrefChange = async (value: "instant" | "daily" | "weekly" | "none") => {
+        if (isSavingPref) return;
+        setIsSavingPref(true);
+        try {
+            const res = await fetch("/api/profile", {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                },
+                body: JSON.stringify({ notificationPreference: value }),
+            });
+            if (res.ok) {
+                setNotificationPreference(value);
+                setEmailNotificationsEnabled(value !== "none");
+                toast.success("Notification preferences updated!");
+            } else {
+                toast.error("Failed to update preferences");
+            }
+        } catch (error) {
+            console.error(error);
+            toast.error("Error updating preferences");
+        } finally {
+            setIsSavingPref(false);
+        }
+    };
 
     const fetchProfile = () => {
         setLoading(true);
@@ -105,6 +133,7 @@ export default function ProfilePage() {
                 if (data.user) {
                     setProfileData(data);
                     setEmailNotificationsEnabled(data.user.emailNotificationsEnabled ?? true);
+                    setNotificationPreference(data.user.notificationPreference ?? "instant");
                 } else {
                     setError("Profile data is unavailable. Please try again.");
                 }
@@ -127,6 +156,17 @@ export default function ProfilePage() {
         }
         fetchProfile();
     }, [isLoaded, userId, router]);
+
+    useEffect(() => {
+        if (typeof window !== "undefined") {
+            const searchParams = new URLSearchParams(window.location.search);
+            if (searchParams.get("unsubscribed") === "true") {
+                toast.success("Successfully unsubscribed from email notifications!");
+                const newUrl = window.location.pathname;
+                window.history.replaceState({}, document.title, newUrl);
+            }
+        }
+    }, []);
 
     if (!isLoaded || loading) {
         return <ProfileSkeleton />;
@@ -179,10 +219,10 @@ export default function ProfilePage() {
                     </div>
                 </div>
 
-                {/* Email Notification Settings Switch */}
-                <div className="flex items-center gap-4 bg-slate-950/40 border border-slate-800/80 rounded-xl p-4 md:self-center shadow-inner">
+                {/* Email Notification Settings Select */}
+                <div className="flex flex-col sm:flex-row items-start sm:items-center gap-4 bg-slate-950/40 border border-slate-800/80 rounded-xl p-4 md:self-center shadow-inner min-w-[280px] sm:min-w-[380px] w-full sm:w-auto">
                     <div className="flex flex-col max-w-[240px]">
-                        <span className="text-sm font-semibold text-slate-800 dark:text-slate-200 flex items-center gap-1.5">
+                        <span className="text-sm font-semibold text-slate-800 dark:text-slate-200 flex items-center gap-1.5 font-medium">
                             <Mail className="w-4 h-4 text-purple-400" />
                             Email Alerts
                         </span>
@@ -190,44 +230,23 @@ export default function ProfilePage() {
                             Get notified when someone replies to your doubts.
                         </span>
                     </div>
-                    <button
-                        onClick={async () => {
-                            if (isSavingPref) return;
-                            setIsSavingPref(true);
-                            const newValue = !emailNotificationsEnabled;
-                            try {
-                                const res = await fetch("/api/profile", {
-                                    method: "POST",
-                                    headers: {
-                                        "Content-Type": "application/json",
-                                    },
-                                    body: JSON.stringify({ emailNotificationsEnabled: newValue }),
-                                });
-                                if (res.ok) {
-                                    setEmailNotificationsEnabled(newValue);
-                                    toast.success(newValue ? "Email notifications enabled!" : "Email notifications disabled!");
-                                } else {
-                                    toast.error("Failed to update preferences");
-                                }
-                            } catch (error) {
-                                console.error(error);
-                                toast.error("Error updating preferences");
-                            } finally {
-                                setIsSavingPref(false);
-                            }
-                        }}
-                        className={`relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none ${ emailNotificationsEnabled ? "bg-purple-600" : "bg-slate-700" } ${isSavingPref ? "opacity-50 pointer-events-none" : ""}`}
-                    >
-                        <span
-                            className={`pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out flex items-center justify-center ${ emailNotificationsEnabled ? "translate-x-5" : "translate-x-0" }`}
+                    <div className="w-full sm:w-auto sm:ml-auto">
+                        <Select
+                            value={notificationPreference}
+                            onValueChange={handlePrefChange}
+                            disabled={isSavingPref}
                         >
-                            {isSavingPref ? (
-                                <Loader2 className="w-3 h-3 text-slate-600 animate-spin" />
-                            ) : emailNotificationsEnabled ? (
-                                <Bell className="w-3 h-3 text-purple-600" />
-                            ) : null}
-                        </span>
-                    </button>
+                            <SelectTrigger className="w-full sm:w-[160px] border-slate-700 bg-slate-900/60 dark:text-slate-200 focus:ring-purple-500">
+                                <SelectValue placeholder="Select frequency" />
+                            </SelectTrigger>
+                            <SelectContent className="border-slate-800 bg-slate-905 dark:bg-slate-900 text-slate-200">
+                                <SelectItem value="instant">Instant Alerts</SelectItem>
+                                <SelectItem value="daily">Daily Digest</SelectItem>
+                                <SelectItem value="weekly">Weekly Digest</SelectItem>
+                                <SelectItem value="none">Muted (None)</SelectItem>
+                            </SelectContent>
+                        </Select>
+                    </div>
                 </div>
             </div>
 

--- a/configs/schema.ts
+++ b/configs/schema.ts
@@ -18,6 +18,7 @@ export const usersTable = pgTable("users", {
     blockedUntil: timestamp(),
     blockCount: integer().default(0).notNull(),
     emailNotificationsEnabled: boolean().default(true).notNull(),
+    notificationPreference: varchar({ length: 50 }).default("instant").notNull(),
     createdAt: timestamp().defaultNow().notNull(),
 });
 
@@ -315,3 +316,29 @@ export const bookmarksTable = pgTable("bookmarks", {
     userEmailIndex: index("bookmark_userEmail_idx").on(table.userEmail),
     doubtIdIndex: index("bookmark_doubtId_idx").on(table.doubtId),
 }));
+
+export const pendingNotificationsTable = pgTable("pending_notifications", {
+    id: integer().primaryKey().generatedAlwaysAsIdentity(),
+    userEmail: varchar({ length: 255 }).notNull(),
+    doubtId: integer().notNull(),
+    replyId: integer().notNull(),
+    createdAt: timestamp().defaultNow().notNull(),
+}, (table) => {
+    return {
+        userEmailIdx: index("pending_notifications_user_email_idx").on(table.userEmail),
+        /** Remove pending notifications when user, doubt, or reply is deleted. */
+        userEmailFk: foreignKey({
+            columns: [table.userEmail],
+            foreignColumns: [usersTable.email],
+        }).onDelete("cascade"),
+        doubtIdFk: foreignKey({
+            columns: [table.doubtId],
+            foreignColumns: [doubtsTable.id],
+        }).onDelete("cascade"),
+        replyIdFk: foreignKey({
+            columns: [table.replyId],
+            foreignColumns: [repliesTable.id],
+        }).onDelete("cascade"),
+    };
+});
+

--- a/drizzle/0001_aspiring_warhawk.sql
+++ b/drizzle/0001_aspiring_warhawk.sql
@@ -1,0 +1,13 @@
+CREATE TABLE "pending_notifications" (
+	"id" integer PRIMARY KEY GENERATED ALWAYS AS IDENTITY (sequence name "pending_notifications_id_seq" INCREMENT BY 1 MINVALUE 1 MAXVALUE 2147483647 START WITH 1 CACHE 1),
+	"userEmail" varchar(255) NOT NULL,
+	"doubtId" integer NOT NULL,
+	"replyId" integer NOT NULL,
+	"createdAt" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "users" ADD COLUMN "notificationPreference" varchar(50) DEFAULT 'instant' NOT NULL;--> statement-breakpoint
+ALTER TABLE "pending_notifications" ADD CONSTRAINT "pending_notifications_userEmail_users_email_fk" FOREIGN KEY ("userEmail") REFERENCES "public"."users"("email") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "pending_notifications" ADD CONSTRAINT "pending_notifications_doubtId_doubts_id_fk" FOREIGN KEY ("doubtId") REFERENCES "public"."doubts"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "pending_notifications" ADD CONSTRAINT "pending_notifications_replyId_replies_id_fk" FOREIGN KEY ("replyId") REFERENCES "public"."replies"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "pending_notifications_user_email_idx" ON "pending_notifications" USING btree ("userEmail");

--- a/drizzle/meta/0001_snapshot.json
+++ b/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,1694 @@
+{
+  "id": "09452c86-4e29-48b5-bc4e-21bd61bd6e36",
+  "prevId": "1d012e7b-6b6e-4f23-991a-18d95750037d",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.bookmarks": {
+      "name": "bookmarks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "bookmarks_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "userEmail": {
+          "name": "userEmail",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "doubtId": {
+          "name": "doubtId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bookmark_userEmail_idx": {
+          "name": "bookmark_userEmail_idx",
+          "columns": [
+            {
+              "expression": "userEmail",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bookmark_doubtId_idx": {
+          "name": "bookmark_doubtId_idx",
+          "columns": [
+            {
+              "expression": "doubtId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_history": {
+      "name": "chat_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "chat_history_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "chatId": {
+          "name": "chatId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chatTitle": {
+          "name": "chatTitle",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userEmail": {
+          "name": "userEmail",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "chatHistory_chatId_idx": {
+          "name": "chatHistory_chatId_idx",
+          "columns": [
+            {
+              "expression": "chatId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_history_userEmail_users_email_fk": {
+          "name": "chat_history_userEmail_users_email_fk",
+          "tableFrom": "chat_history",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userEmail"
+          ],
+          "columnsTo": [
+            "email"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.classrooms": {
+      "name": "classrooms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "classrooms_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "university": {
+          "name": "university",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "year": {
+          "name": "year",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "teacherEmail": {
+          "name": "teacherEmail",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inviteCode": {
+          "name": "inviteCode",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "classrooms_inviteCode_unique": {
+          "name": "classrooms_inviteCode_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "inviteCode"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cover_letters": {
+      "name": "cover_letters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "cover_letters_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "userEmail": {
+          "name": "userEmail",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "jobDescription": {
+          "name": "jobDescription",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userDetails": {
+          "name": "userDetails",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "coverLetter": {
+          "name": "coverLetter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "cover_letters_userEmail_users_email_fk": {
+          "name": "cover_letters_userEmail_users_email_fk",
+          "tableFrom": "cover_letters",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userEmail"
+          ],
+          "columnsTo": [
+            "email"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.doubt_tags": {
+      "name": "doubt_tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "doubt_tags_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "doubtId": {
+          "name": "doubtId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tagId": {
+          "name": "tagId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "doubt_tag_doubtId_idx": {
+          "name": "doubt_tag_doubtId_idx",
+          "columns": [
+            {
+              "expression": "doubtId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "doubt_tag_tagId_idx": {
+          "name": "doubt_tag_tagId_idx",
+          "columns": [
+            {
+              "expression": "tagId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "doubt_tag_unique_idx": {
+          "name": "doubt_tag_unique_idx",
+          "columns": [
+            {
+              "expression": "doubtId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tagId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.doubts": {
+      "name": "doubts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "doubts_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "userName": {
+          "name": "userName",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userEmail": {
+          "name": "userEmail",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "classroomId": {
+          "name": "classroomId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subTopic": {
+          "name": "subTopic",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "imageUrl": {
+          "name": "imageUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "likes": {
+          "name": "likes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "isSolved": {
+          "name": "isSolved",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'unsolved'"
+        },
+        "solvedReplyId": {
+          "name": "solvedReplyId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'community'"
+        },
+        "isPinned": {
+          "name": "isPinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "doubt_classroomId_idx": {
+          "name": "doubt_classroomId_idx",
+          "columns": [
+            {
+              "expression": "classroomId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "type_idx": {
+          "name": "type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subject_idx": {
+          "name": "subject_idx",
+          "columns": [
+            {
+              "expression": "subject",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "doubts_userEmail_users_email_fk": {
+          "name": "doubts_userEmail_users_email_fk",
+          "tableFrom": "doubts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userEmail"
+          ],
+          "columnsTo": [
+            "email"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "doubts_classroomId_classrooms_id_fk": {
+          "name": "doubts_classroomId_classrooms_id_fk",
+          "tableFrom": "doubts",
+          "tableTo": "classrooms",
+          "columnsFrom": [
+            "classroomId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.likes": {
+      "name": "likes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "likes_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "userName": {
+          "name": "userName",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "doubtId": {
+          "name": "doubtId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "likes_doubtId_doubts_id_fk": {
+          "name": "likes_doubtId_doubts_id_fk",
+          "tableFrom": "likes",
+          "tableTo": "doubts",
+          "columnsFrom": [
+            "doubtId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "likes_userName_doubtId_unique": {
+          "name": "likes_userName_doubtId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userName",
+            "doubtId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.memberships": {
+      "name": "memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "memberships_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "userEmail": {
+          "name": "userEmail",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "classroomId": {
+          "name": "classroomId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "joinedAt": {
+          "name": "joinedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "userEmail_idx": {
+          "name": "userEmail_idx",
+          "columns": [
+            {
+              "expression": "userEmail",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "classroomId_idx": {
+          "name": "classroomId_idx",
+          "columns": [
+            {
+              "expression": "classroomId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "memberships_userEmail_users_email_fk": {
+          "name": "memberships_userEmail_users_email_fk",
+          "tableFrom": "memberships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userEmail"
+          ],
+          "columnsTo": [
+            "email"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "memberships_classroomId_classrooms_id_fk": {
+          "name": "memberships_classroomId_classrooms_id_fk",
+          "tableFrom": "memberships",
+          "tableTo": "classrooms",
+          "columnsFrom": [
+            "classroomId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "memberships_userEmail_classroomId_unique": {
+          "name": "memberships_userEmail_classroomId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userEmail",
+            "classroomId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.moderation_logs": {
+      "name": "moderation_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "moderation_logs_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "userEmail": {
+          "name": "userEmail",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "violationType": {
+          "name": "violationType",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contentSnippet": {
+          "name": "contentSnippet",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pending_notifications": {
+      "name": "pending_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "pending_notifications_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "userEmail": {
+          "name": "userEmail",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "doubtId": {
+          "name": "doubtId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "replyId": {
+          "name": "replyId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pending_notifications_user_email_idx": {
+          "name": "pending_notifications_user_email_idx",
+          "columns": [
+            {
+              "expression": "userEmail",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pending_notifications_userEmail_users_email_fk": {
+          "name": "pending_notifications_userEmail_users_email_fk",
+          "tableFrom": "pending_notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userEmail"
+          ],
+          "columnsTo": [
+            "email"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pending_notifications_doubtId_doubts_id_fk": {
+          "name": "pending_notifications_doubtId_doubts_id_fk",
+          "tableFrom": "pending_notifications",
+          "tableTo": "doubts",
+          "columnsFrom": [
+            "doubtId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pending_notifications_replyId_replies_id_fk": {
+          "name": "pending_notifications_replyId_replies_id_fk",
+          "tableFrom": "pending_notifications",
+          "tableTo": "replies",
+          "columnsFrom": [
+            "replyId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.replies": {
+      "name": "replies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "replies_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "doubtId": {
+          "name": "doubtId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userName": {
+          "name": "userName",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userEmail": {
+          "name": "userEmail",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "imageUrl": {
+          "name": "imageUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "upvotes": {
+          "name": "upvotes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "doubtId_idx": {
+          "name": "doubtId_idx",
+          "columns": [
+            {
+              "expression": "doubtId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "replies_doubtId_doubts_id_fk": {
+          "name": "replies_doubtId_doubts_id_fk",
+          "tableFrom": "replies",
+          "tableTo": "doubts",
+          "columnsFrom": [
+            "doubtId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reply_likes": {
+      "name": "reply_likes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "reply_likes_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "userName": {
+          "name": "userName",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "replyId": {
+          "name": "replyId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "reply_likes_replyId_replies_id_fk": {
+          "name": "reply_likes_replyId_replies_id_fk",
+          "tableFrom": "reply_likes",
+          "tableTo": "replies",
+          "columnsFrom": [
+            "replyId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "reply_likes_userName_replyId_unique": {
+          "name": "reply_likes_userName_replyId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userName",
+            "replyId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.resume_analysis": {
+      "name": "resume_analysis",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "resume_analysis_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "userEmail": {
+          "name": "userEmail",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resumeText": {
+          "name": "resumeText",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "jobDescription": {
+          "name": "jobDescription",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "analysisData": {
+          "name": "analysisData",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resumeName": {
+          "name": "resumeName",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "resume_analysis_userEmail_users_email_fk": {
+          "name": "resume_analysis_userEmail_users_email_fk",
+          "tableFrom": "resume_analysis",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userEmail"
+          ],
+          "columnsTo": [
+            "email"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.resumes": {
+      "name": "resumes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "resumes_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "userEmail": {
+          "name": "userEmail",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resumeName": {
+          "name": "resumeName",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resumeData": {
+          "name": "resumeData",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "resumes_userEmail_users_email_fk": {
+          "name": "resumes_userEmail_users_email_fk",
+          "tableFrom": "resumes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userEmail"
+          ],
+          "columnsTo": [
+            "email"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "resumes_userEmail_resumeName_unique": {
+          "name": "resumes_userEmail_resumeName_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userEmail",
+            "resumeName"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.roadmaps": {
+      "name": "roadmaps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "roadmaps_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "userEmail": {
+          "name": "userEmail",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "targetField": {
+          "name": "targetField",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "roadmapData": {
+          "name": "roadmapData",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "roadmaps_userEmail_users_email_fk": {
+          "name": "roadmaps_userEmail_users_email_fk",
+          "tableFrom": "roadmaps",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userEmail"
+          ],
+          "columnsTo": [
+            "email"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.shared_chats": {
+      "name": "shared_chats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "shared_chats_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "chatId": {
+          "name": "chatId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "shared_chats_chatId_unique": {
+          "name": "shared_chats_chatId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "chatId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "tags_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalizedName": {
+          "name": "normalizedName",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "classroomId": {
+          "name": "classroomId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdByEmail": {
+          "name": "createdByEmail",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tag_classroomId_idx": {
+          "name": "tag_classroomId_idx",
+          "columns": [
+            {
+              "expression": "classroomId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tag_scope_name_idx": {
+          "name": "tag_scope_name_idx",
+          "columns": [
+            {
+              "expression": "normalizedName",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "classroomId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "users_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "university": {
+          "name": "university",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "year": {
+          "name": "year",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collegeEmail": {
+          "name": "collegeEmail",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarded": {
+          "name": "onboarded",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "violationCount": {
+          "name": "violationCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "isBlocked": {
+          "name": "isBlocked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "blockedUntil": {
+          "name": "blockedUntil",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockCount": {
+          "name": "blockCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "emailNotificationsEnabled": {
+          "name": "emailNotificationsEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "notificationPreference": {
+          "name": "notificationPreference",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'instant'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1779121992842,
       "tag": "0000_bitter_tyger_tiger",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1779525663345,
+      "tag": "0001_aspiring_warhawk",
+      "breakpoints": true
     }
   ]
 }

--- a/inngest/functions.ts
+++ b/inngest/functions.ts
@@ -2,10 +2,10 @@ import { inngest } from "./client";
 import fs from "fs";
 import path from "path";
 import { db } from "../configs/db";
-import { doubtsTable, usersTable } from "../configs/schema";
-import { eq } from "drizzle-orm";
+import { doubtsTable, usersTable, pendingNotificationsTable, repliesTable } from "../configs/schema";
+import { eq, inArray } from "drizzle-orm";
 import { emailNotificationLimiter } from "../lib/ratelimit";
-import { sendReplyNotificationEmail } from "../lib/email";
+import { sendReplyNotificationEmail, sendDigestEmail } from "../lib/email";
 export const helloWorld = inngest.createFunction(
   { id: "hello-world", triggers: [{ event: "test/hello.world" }] },
   async ({ event, step }: { event: any; step: any }) => {
@@ -65,6 +65,7 @@ export const sendReplyNotification = inngest.createFunction(
         content: d.content || "",
         authorName: d.userName,
         notificationsEnabled: u ? u.emailNotificationsEnabled : true,
+        notificationPreference: u ? u.notificationPreference : "instant",
       };
     });
 
@@ -78,8 +79,21 @@ export const sendReplyNotification = inngest.createFunction(
     }
 
     // 3. User preference check: Opt-out verification
-    if (!doubt.notificationsEnabled) {
+    if (!doubt.notificationsEnabled || doubt.notificationPreference === "none") {
       return { success: true, reason: "Skipped: User has disabled email notifications." };
+    }
+
+    // 3.5. Queue digest notifications instead of sending immediately
+    if (doubt.notificationPreference === "daily" || doubt.notificationPreference === "weekly") {
+      const queueResult = await step.run("queue-pending-notification", async () => {
+        await db.insert(pendingNotificationsTable).values({
+          userEmail: doubt.email,
+          doubtId,
+          replyId,
+        });
+        return { success: true };
+      });
+      return { success: true, reason: "Queued for digest notification.", queueResult };
     }
 
     // 4. Rate-limiting check: Prevents spamming emails for rapid replies
@@ -110,5 +124,167 @@ export const sendReplyNotification = inngest.createFunction(
     });
 
     return { success: true, sendResult };
+  }
+);
+
+export const sendDailyDigest = inngest.createFunction(
+  { id: "send-daily-digest", triggers: [{ cron: "0 8 * * *" }] },
+  async ({ step }: { step: any }) => {
+    const digestedCount = await step.run("process-daily-digest", async () => {
+      // 1. Get all users with daily digest preference
+      const dailyUsers = await db
+        .select()
+        .from(usersTable)
+        .where(eq(usersTable.notificationPreference, "daily"));
+
+      if (dailyUsers.length === 0) return 0;
+
+      let sentCount = 0;
+
+      for (const user of dailyUsers) {
+        // Fetch all pending notifications for this user
+        const pending = await db
+          .select({
+            id: pendingNotificationsTable.id,
+            doubtId: pendingNotificationsTable.doubtId,
+            doubtSubject: doubtsTable.subject,
+            doubtContent: doubtsTable.content,
+            replyId: pendingNotificationsTable.replyId,
+            replierName: repliesTable.userName,
+            replyContent: repliesTable.content,
+          })
+          .from(pendingNotificationsTable)
+          .innerJoin(doubtsTable, eq(pendingNotificationsTable.doubtId, doubtsTable.id))
+          .innerJoin(repliesTable, eq(pendingNotificationsTable.replyId, repliesTable.id))
+          .where(eq(pendingNotificationsTable.userEmail, user.email));
+
+        if (pending.length === 0) continue;
+
+        // Group notifications by doubt
+        const doubtsMap = new Map<number, {
+          id: number;
+          subject: string;
+          content: string;
+          replies: Array<{ replierName: string; content: string }>;
+        }>();
+
+        for (const p of pending) {
+          if (!doubtsMap.has(p.doubtId)) {
+            doubtsMap.set(p.doubtId, {
+              id: p.doubtId,
+              subject: p.doubtSubject,
+              content: p.doubtContent || "",
+              replies: []
+            });
+          }
+          doubtsMap.get(p.doubtId)!.replies.push({
+            replierName: p.replierName,
+            content: p.replyContent || ""
+          });
+        }
+
+        // Send digest email
+        await sendDigestEmail({
+          toEmail: user.email,
+          subject: "[DoubtDesk] Your Daily Doubt Updates Digest",
+          totalReplies: pending.length,
+          totalDoubts: doubtsMap.size,
+          doubts: Array.from(doubtsMap.values()),
+        });
+
+        // Delete processed pending notifications for this user
+        const notificationIds = pending.map(p => p.id);
+        await db
+          .delete(pendingNotificationsTable)
+          .where(inArray(pendingNotificationsTable.id, notificationIds));
+
+        sentCount++;
+      }
+
+      return sentCount;
+    });
+
+    return { message: `Successfully sent daily digest to ${digestedCount} users.` };
+  }
+);
+
+export const sendWeeklyDigest = inngest.createFunction(
+  { id: "send-weekly-digest", triggers: [{ cron: "0 8 * * 1" }] },
+  async ({ step }: { step: any }) => {
+    const digestedCount = await step.run("process-weekly-digest", async () => {
+      // 1. Get all users with weekly digest preference
+      const weeklyUsers = await db
+        .select()
+        .from(usersTable)
+        .where(eq(usersTable.notificationPreference, "weekly"));
+
+      if (weeklyUsers.length === 0) return 0;
+
+      let sentCount = 0;
+
+      for (const user of weeklyUsers) {
+        // Fetch all pending notifications for this user
+        const pending = await db
+          .select({
+            id: pendingNotificationsTable.id,
+            doubtId: pendingNotificationsTable.doubtId,
+            doubtSubject: doubtsTable.subject,
+            doubtContent: doubtsTable.content,
+            replyId: pendingNotificationsTable.replyId,
+            replierName: repliesTable.userName,
+            replyContent: repliesTable.content,
+          })
+          .from(pendingNotificationsTable)
+          .innerJoin(doubtsTable, eq(pendingNotificationsTable.doubtId, doubtsTable.id))
+          .innerJoin(repliesTable, eq(pendingNotificationsTable.replyId, repliesTable.id))
+          .where(eq(pendingNotificationsTable.userEmail, user.email));
+
+        if (pending.length === 0) continue;
+
+        // Group notifications by doubt
+        const doubtsMap = new Map<number, {
+          id: number;
+          subject: string;
+          content: string;
+          replies: Array<{ replierName: string; content: string }>;
+        }>();
+
+        for (const p of pending) {
+          if (!doubtsMap.has(p.doubtId)) {
+            doubtsMap.set(p.doubtId, {
+              id: p.doubtId,
+              subject: p.doubtSubject,
+              content: p.doubtContent || "",
+              replies: []
+            });
+          }
+          doubtsMap.get(p.doubtId)!.replies.push({
+            replierName: p.replierName,
+            content: p.replyContent || ""
+          });
+        }
+
+        // Send digest email
+        await sendDigestEmail({
+          toEmail: user.email,
+          subject: "[DoubtDesk] Your Weekly Doubt Updates Digest",
+          totalReplies: pending.length,
+          totalDoubts: doubtsMap.size,
+          doubts: Array.from(doubtsMap.values()),
+        });
+
+        // Delete processed pending notifications for this user
+        const notificationIds = pending.map(p => p.id);
+        await db
+          .delete(pendingNotificationsTable)
+          .where(inArray(pendingNotificationsTable.id, notificationIds));
+
+        sentCount++;
+      }
+
+      return sentCount;
+    });
+
+    return { message: `Successfully sent weekly digest to ${digestedCount} users.` };
   }
 );

--- a/lib/email.ts
+++ b/lib/email.ts
@@ -253,3 +253,198 @@ export async function sendReplyNotificationEmail(params: {
     }
 }
 
+/**
+ * Sends a premium, responsive HTML email digest to the user.
+ */
+export async function sendDigestEmail(params: {
+    toEmail: string;
+    subject: string;
+    totalReplies: number;
+    totalDoubts: number;
+    doubts: Array<{
+        id: number;
+        subject: string;
+        content: string;
+        replies: Array<{
+            replierName: string;
+            content: string;
+        }>;
+    }>;
+}) {
+    const { toEmail, subject, totalReplies, totalDoubts, doubts } = params;
+    const appUrl = process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000";
+    const unsubscribeLink = `${appUrl}/api/unsubscribe?email=${encodeURIComponent(toEmail)}`;
+
+    let doubtsHtml = "";
+    for (const d of doubts) {
+        const doubtLink = `${appUrl}/rooms/${d.id}`;
+        const cleanDoubtContent = d.content.length > 100 ? `${d.content.slice(0, 97)}...` : d.content;
+        
+        let repliesHtml = "";
+        for (const r of d.replies) {
+            const cleanReplyContent = r.content.length > 180 ? `${r.content.slice(0, 177)}...` : r.content;
+            repliesHtml += `
+                <div style="margin-bottom: 12px; border-bottom: 1px solid #334155; padding-bottom: 12px; last-child { border-bottom: none; }">
+                    <div style="font-size: 14px; font-weight: 700; color: #f8fafc; margin-bottom: 4px;">Response from ${r.replierName}</div>
+                    <p style="font-size: 14px; line-height: 20px; color: #cbd5e1; background: #1e293b; border: 1px solid #334155; border-radius: 8px; padding: 12px; margin: 0;">"${cleanReplyContent}"</p>
+                </div>
+            `;
+        }
+
+        doubtsHtml += `
+            <div style="background: #0f172a; border: 1px solid #334155; border-radius: 12px; padding: 24px; margin-bottom: 24px;">
+                <div style="font-size: 12px; font-weight: 700; text-transform: uppercase; letter-spacing: 1px; color: #38bdf8; margin-top: 0; margin-bottom: 8px;">Doubt: ${d.subject}</div>
+                <div style="font-size: 14px; line-height: 22px; color: #94a3b8; font-style: italic; margin-bottom: 16px; border-left: 3px solid #38bdf8; padding-left: 12px;">"${cleanDoubtContent}"</div>
+                
+                <div style="font-size: 12px; font-weight: 700; text-transform: uppercase; letter-spacing: 1px; color: #a855f7; margin-bottom: 12px;">New Replies</div>
+                ${repliesHtml}
+                
+                <div style="text-align: right; margin-top: 16px;">
+                    <a href="${doubtLink}" style="display: inline-block; background: #6366f1; color: #ffffff !important; text-decoration: none; font-size: 13px; font-weight: 600; padding: 8px 16px; border-radius: 6px; box-shadow: 0 2px 8px 0 rgba(99, 102, 241, 0.3);">Go to Doubt Room</a>
+                </div>
+            </div>
+        `;
+    }
+
+    const htmlContent = `
+    <!DOCTYPE html>
+    <html lang="en">
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <title>${subject}</title>
+        <style>
+            body {
+                margin: 0;
+                padding: 0;
+                background-color: #0f172a;
+                font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+                color: #e2e8f0;
+            }
+            .wrapper {
+                width: 100%;
+                background-color: #0f172a;
+                padding: 40px 20px;
+                box-sizing: border-box;
+            }
+            .container {
+                max-width: 600px;
+                margin: 0 auto;
+                background: #1e293b;
+                border: 1px solid #334155;
+                border-radius: 16px;
+                overflow: hidden;
+                box-shadow: 0 10px 25px -5px rgba(0, 0, 0, 0.3), 0 8px 10px -6px rgba(0, 0, 0, 0.3);
+            }
+            .header {
+                background: linear-gradient(135deg, #1e1b4b 0%, #311042 100%);
+                padding: 30px 40px;
+                text-align: center;
+                border-bottom: 1px solid #475569;
+            }
+            .logo {
+                font-size: 24px;
+                font-weight: 800;
+                color: #f1f5f9;
+                letter-spacing: 0.5px;
+                margin: 0 0 10px 0;
+            }
+            .header-subtitle {
+                font-size: 14px;
+                color: #94a3b8;
+                margin: 0;
+            }
+            .content {
+                padding: 40px;
+            }
+            .greeting {
+                font-size: 18px;
+                font-weight: 600;
+                color: #f8fafc;
+                margin-top: 0;
+                margin-bottom: 16px;
+            }
+            .message {
+                font-size: 15px;
+                line-height: 24px;
+                color: #cbd5e1;
+                margin-bottom: 24px;
+            }
+            .footer {
+                background: #0f172a;
+                padding: 24px 40px;
+                text-align: center;
+                font-size: 12px;
+                color: #64748b;
+                border-top: 1px solid #334155;
+            }
+            .footer a {
+                color: #38bdf8;
+                text-decoration: none;
+            }
+        </style>
+    </head>
+    <body>
+        <div class="wrapper">
+            <div class="container">
+                <div class="header">
+                    <div class="logo">⚡ DoubtDesk Digest</div>
+                    <p class="header-subtitle">Your peer-to-peer classroom resolution platform</p>
+                </div>
+                <div class="content">
+                    <h3 class="greeting">Hi there,</h3>
+                    <p class="message">You have <strong>${totalReplies}</strong> new replies across <strong>${totalDoubts}</strong> doubts. Here is a summary of your unread replies:</p>
+                    
+                    ${doubtsHtml}
+                </div>
+                <div class="footer">
+                    <p>You received this email because you are registered on DoubtDesk and opted to receive digests.</p>
+                    <p>Don't want to receive these digests? <a href="${unsubscribeLink}">Unsubscribe instantly</a> or manage settings in your <a href="${appUrl}/profile">User Profile</a>.</p>
+                    <p>&copy; ${new Date().getFullYear()} DoubtDesk. All rights reserved.</p>
+                </div>
+            </div>
+        </div>
+    </body>
+    </html>
+    `;
+
+    console.log(`[EMAIL SIMULATION] Sending digest notification email to: ${toEmail}`);
+    console.log(`Subject: ${subject}`);
+    console.log(`Total unread: ${totalReplies} replies across ${totalDoubts} doubts`);
+
+    const apiKey = process.env.RESEND_API_KEY;
+    if (!apiKey || apiKey === "re_your_actual_key_here") {
+        console.log("[EMAIL SIMULATION] Skipping real delivery. Resend API Key is not configured.");
+        return { success: true, simulated: true };
+    }
+
+    try {
+        const res = await fetch("https://api.resend.com/emails", {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+                "Authorization": `Bearer ${apiKey}`
+            },
+            body: JSON.stringify({
+                from: "DoubtDesk <onboarding@resend.dev>",
+                to: [toEmail],
+                subject,
+                html: htmlContent
+            })
+        });
+
+        if (res.ok) {
+            console.log(`[EMAIL SUCCESS] Digest email successfully delivered to: ${toEmail}`);
+            return { success: true, simulated: false };
+        } else {
+            const errText = await res.text();
+            console.error(`[EMAIL ERROR] Resend API responded with status ${res.status}:`, errText);
+            return { success: false, error: errText };
+        }
+    } catch (error: any) {
+        console.error("[EMAIL ERROR] Failed to send digest email via Resend:", error);
+        return { success: false, error: error?.message || error };
+    }
+}
+
+

--- a/types/profile.ts
+++ b/types/profile.ts
@@ -58,6 +58,7 @@ export interface ProfileUser {
     imageUrl: string;
     joinDate: string;
     emailNotificationsEnabled?: boolean;
+    notificationPreference?: "instant" | "daily" | "weekly" | "none";
     createdAt: string;
 }
 


### PR DESCRIPTION
## Summary
Implement daily/weekly email digests that bundle unread doubt reply notifications for students to prevent inbox spam. This PR updates the user profile preferences schema and UI, registers Inngest scheduled cron jobs, implements secure 1-click unsubscribe links in email footers, and groups notifications cleanly by doubt topic.

## Related Issue
Closes #185 

---

## Detailed Changes

### Database & Migration
*   **`configs/schema.ts`**:
    *   Added `notificationPreference` to `usersTable` (values: `'instant'`, `'daily'`, `'weekly'`, `'none'`). Defaults to `'instant'`.
    *   Added a new `pendingNotificationsTable` to queue unread replies for digest recipients (with cascading foreign keys for referential integrity).
*   **`drizzle/0001_aspiring_warhawk.sql`**: Auto-generated Drizzle database migration.

### Backend Routes
*   **`app/api/profile/route.ts`**: Updated GET to fetch and return the new preference and POST to update it (automatically syncing state with `emailNotificationsEnabled`).
*   **`app/api/unsubscribe/route.ts`**: Created a new GET route to support instant 1-click opt-outs from email footers (redirects back to `/profile` with a success toast parameter).
*   **`app/api/replies/route.ts`**: Updated the zero-setup development fallback to respect frequency preferences and queue unread replies for easier local digest testing.

### Background Jobs (Inngest)
*   **`inngest/functions.ts`**:
    *   Modified `sendReplyNotification` to log new replies to the database buffer if the recipient's preference is `'daily'` or `'weekly'`.
    *   Implemented `sendDailyDigest` (cron `"0 8 * * *"`) and `sendWeeklyDigest` (cron `"0 8 * * 1"`) to fetch, group, email, and clear the unread queue.
*   **`app/api/inngest/route.ts`**: Registered the new cron functions.

### Email Template & Utilities
*   **`lib/email.ts`**: Added `sendDigestEmail` helper displaying grouped doubt replies, direct doubt room hyperlinks, and unsubscribe footers.
*   **`types/profile.ts`**: Updated profile user interface types.

### Frontend UI
*   **`app/profile/page.tsx`**:
    *   Replaced the basic alerts Toggle Switch with a premium **Notification Frequency Select dropdown** (Instant, Daily, Weekly, Muted).
    *   Added `useEffect` to parse the `unsubscribed=true` param and show a green success toast when returning from the email unsubscribe action.

---

## Verification
- Built and compiled the application successfully with no TypeScript errors:
  ```bash
  npm run build
  ```