### PR TITLE
feat: add floating scroll-to-top button for infinite doubt feeds

### DIFF
--- a/app/public-rooms/[subject]/page.tsx
+++ b/app/public-rooms/[subject]/page.tsx
@@ -7,6 +7,7 @@ import AskDoubt from "@/components/AskDoubt";
 import DoubtCard from "@/components/DoubtCard";
 import useSWRInfinite from "swr/infinite";
 import { useInView } from "react-intersection-observer";
+import ScrollToTopButton from "@/components/ScrollToTopButton";
 
 export default function PublicRoomPage() {
     const params = useParams();
@@ -37,6 +38,7 @@ export default function PublicRoomPage() {
 
     return (
         <div className="p-6 md:p-12 space-y-8 max-w-7xl mx-auto pb-24">
+            <ScrollToTopButton />
             <header className="flex flex-col md:flex-row md:items-end justify-between gap-6 pb-6 border-b border-slate-200 dark:border-white/5">
                 <div className="space-y-1">
                     <h1 className="text-5xl font-black text-slate-900 dark:text-white tracking-tighter uppercase italic">

--- a/app/public-rooms/page.tsx
+++ b/app/public-rooms/page.tsx
@@ -6,6 +6,7 @@ import AskDoubt from "@/components/AskDoubt";
 import DoubtCard from "@/components/DoubtCard";
 import useSWRInfinite from "swr/infinite";
 import { useInView } from "react-intersection-observer";
+import ScrollToTopButton from "@/components/ScrollToTopButton";
 
 export default function PublicRoomsPage() {
     const [isAskModalOpen, setIsAskModalOpen] = useState(false);
@@ -102,6 +103,9 @@ export default function PublicRoomsPage() {
 
     return (
         <div className="p-4 md:p-8 space-y-6 max-w-[1000px] mx-auto pb-24">
+
+            <ScrollToTopButton />
+
             <header className="flex flex-col md:flex-row md:items-end justify-between gap-6 pb-6 border-b border-slate-200 dark:border-white/5">
                 <div className="space-y-1">
                     <h1 className="text-6xl font-black text-slate-900 dark:text-white tracking-tighter uppercase italic">

--- a/components/InfiniteDoubtFeed.tsx
+++ b/components/InfiniteDoubtFeed.tsx
@@ -3,6 +3,7 @@
 import { MessageSquare, Loader2, ChevronDown } from "lucide-react";
 import DoubtCard from "@/components/DoubtCard";
 import useSWRInfinite from "swr/infinite";
+import ScrollToTopButton from "./ScrollToTopButton";
 
 const fetcher = (url: string) => fetch(url).then((res) => res.json());
 
@@ -90,6 +91,7 @@ export default function InfiniteDoubtFeed({
 
     return (
         <div className="space-y-8 animate-in fade-in duration-500">
+            <ScrollToTopButton />
             <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
                 {doubts.map((doubt: any, index: number) => (
                     <DoubtCard

--- a/components/ScrollToTopButton.tsx
+++ b/components/ScrollToTopButton.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { ArrowUp } from "lucide-react";
+
+export default function ScrollToTopButton() {
+  const [isVisible, setIsVisible] = useState(false);
+
+  useEffect(() => {
+    const handleScroll = () => {
+      setIsVisible(window.scrollY > 300);
+    };
+
+    handleScroll();
+    window.addEventListener("scroll", handleScroll, { passive: true });
+
+    return () => window.removeEventListener("scroll", handleScroll);
+  }, []);
+
+  if (!isVisible) return null;
+
+  return (
+    <button
+      type="button"
+      onClick={() => window.scrollTo({ top: 0, behavior: "smooth" })}
+      aria-label="Scroll to top"
+      className="fixed bottom-6 right-6 z-50 flex h-12 w-12 items-center justify-center rounded-2xl border border-blue-500/30 bg-blue-600 text-white shadow-2xl shadow-blue-600/25 transition-all hover:-translate-y-1 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-400 focus:ring-offset-2 focus:ring-offset-white dark:focus:ring-offset-slate-950"
+    >
+      <ArrowUp className="h-5 w-5" />
+    </button>
+  );
+}


### PR DESCRIPTION
## Description
Implemented a reusable floating "Scroll to Top" button for long infinite-scroll doubt feeds across the DoubtDesk application.

The button appears after the user scrolls more than 300px and smoothly scrolls the page back to the top when clicked, improving navigation and overall user experience on long feed pages.

## Related Issue

Closes #173 

## Type of Change
<!-- Check the relevant option. -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Documentation update (README, guides, comments)
- [x] Style / UI change (no logic change)
- [ ] Code refactor (no behavior change)
- [ ] Test addition or update
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Screenshots

<img width="2481" height="1481" alt="image" src="https://github.com/user-attachments/assets/c3d9d6bf-b5d7-42c2-9f3b-dd0395b6e1e3" />


## How Has This Been Tested?
<!-- Describe the tests you ran to verify your changes. -->
- [x] Tested locally with `npm run dev`
- [x] Verified on mobile viewport (375px)
- [x] Verified on desktop viewport (1440px)

## Checklist
- [x] I have tested my changes locally (`npm run dev`)
- [x] My code follows the existing code style (TypeScript, Tailwind, no `any` types)
- [x] I have not introduced unrelated changes (each PR should address one issue)
- [x] I have added comments where necessary
- [x] My branch is up to date with `main`
- [x] I have linked the related issue above
- [x] Screenshots are included (if this is a UI change)
