### PR TITLE
feat(seo): add page-specific metadata for static routes

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -62,6 +62,11 @@ const techStack = [
   "Inngest",
 ];
 
+export const metadata = {
+  title: "About",
+  description: "Learn more about DoubtDesk - an AI-powered educational platform.",
+};
+
 export default function AboutPage() {
   return (
     <div className="min-h-screen bg-white dark:bg-slate-950 text-slate-900 dark:text-white overflow-hidden transition-colors duration-300">

--- a/app/contributors/page.tsx
+++ b/app/contributors/page.tsx
@@ -41,6 +41,11 @@ const stats = [
   },
 ];
 
+export const metadata = {
+  title: "Contributors",
+  description: "Meet the open-source contributors who build and maintain DoubtDesk.",
+};
+
 export default async function ContributorsPage() {
   const contributors = await getContributors();
 

--- a/app/faq/layout.tsx
+++ b/app/faq/layout.tsx
@@ -1,0 +1,8 @@
+export const metadata = {
+  title: "Frequently Asked Questions",
+  description: "Find answers to common questions about DoubtDesk classrooms, AI solving, and platform usage.",
+};
+
+export default function FAQLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/app/privacy-policy/page.tsx
+++ b/app/privacy-policy/page.tsx
@@ -7,6 +7,11 @@ import {
   Mail,
 } from "lucide-react";
 
+export const metadata = {
+  title: "Privacy Policy",
+  description: "Understand how DoubtDesk collects, stores, and protects your data.",
+};
+
 export default function PrivacyPolicyPage() {
   const sections = [
     {

--- a/app/terms-of-service/page.tsx
+++ b/app/terms-of-service/page.tsx
@@ -7,6 +7,11 @@ import {
   AlertTriangle,
 } from "lucide-react";
 
+export const metadata = {
+  title: "Terms of Service",
+  description: "Read the rules, responsibilities, and conditions for using DoubtDesk.",
+};
+
 export default function TermsOfServicePage() {
   const sections = [
     {


### PR DESCRIPTION
## Description
This PR improves SEO and browser tab clarity by implementing page-specific metadata exports for static informational pages that previously relied on the generic site title fallback.

The update ensures each page now has a unique title and description, improving discoverability and user experience across the application.

## Changes Made

- Added dedicated metadata exports to:
      - app/about/page.tsx
      - app/contributors/page.tsx
      - app/terms-of-service/page.tsx
      - app/privacy-policy/page.tsx

- Added app/faq/layout.tsx to provide metadata support for the FAQ page while preserving the existing "use client" implementation.
- Added unique SEO-friendly:
   - page titles
   - page descriptions
- Verified compatibility with the existing global metadata template:
   - About | DoubtDesk
   - Privacy Policy | DoubtDesk
   - etc.

## Related Issue
<!-- Link the issue this PR addresses. Use "Closes #<number>" to auto-close the issue on merge. -->
Closes #170 

## Type of Change
<!-- Check the relevant option. -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Documentation update (README, guides, comments)
- [x] Style / UI change (no logic change)
- [ ] Code refactor (no behavior change)
- [ ] Test addition or update
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## How Has This Been Tested?
<!-- Describe the tests you ran to verify your changes. -->
- [x] Tested locally with `npm run dev`
- [x] Verified on mobile viewport (375px)
- [x] Verified on desktop viewport (1440px)

## Checklist
- [x] I have tested my changes locally (`npm run dev`)
- [x] My code follows the existing code style (TypeScript, Tailwind, no `any` types)
- [x] I have not introduced unrelated changes (each PR should address one issue)
- [x] I have added comments where necessary
- [x] My branch is up to date with `main`
- [x] I have linked the related issue above
- [ ] Screenshots are included (if this is a UI change)
