### PR TITLE
Feature/add doubt sorting options 181

### DIFF
--- a/__tests__/api/doubts.test.ts
+++ b/__tests__/api/doubts.test.ts
@@ -26,20 +26,42 @@ jest.mock('@/configs/db', () => ({
     db: {
         select: jest.fn().mockImplementation((fields: any) => {
             if (fields && fields.count) {
-                return createQueryMock([{ count: 2 }]);
+                return createQueryMock([
+                    { doubtId: 1, count: 4 },
+                    { doubtId: 2, count: 1 }
+                ]);
             }
             // Return the mock data wrapped in an array
-            return createQueryMock([{
-                id: 1,
-                doubtId: 1,
-                count: 2,
-                userName: 'Student_1',
-                subject: 'Physics',
-                content: 'What is speed of light?',
-                createdAt: new Date().toISOString(),
-                name: 'Physics',
-                normalizedName: 'physics'
-            }]);
+            return createQueryMock([
+                {
+                    id: 1,
+                    doubtId: 1,
+                    count: 2,
+                    userName: 'Student_1',
+                    subject: 'Physics',
+                    content: 'What is speed of light?',
+                    createdAt: '2026-01-01T00:00:00.000Z',
+                    likes: 4,
+                    isSolved: 'unsolved',
+                    isPinned: false,
+                    name: 'Physics',
+                    normalizedName: 'physics'
+                },
+                {
+                    id: 2,
+                    doubtId: 2,
+                    count: 1,
+                    userName: 'Student_2',
+                    subject: 'Physics',
+                    content: 'How does a lens work?',
+                    createdAt: '2026-01-02T00:00:00.000Z',
+                    likes: 10,
+                    isSolved: 'solved',
+                    isPinned: false,
+                    name: 'Physics',
+                    normalizedName: 'physics'
+                }
+            ]);
         }),
         
         insert: jest.fn().mockImplementation(() => ({
@@ -64,8 +86,36 @@ describe('Doubts API Endpoints', () => {
         const res = await GET(req);
         const json = await res.json();
         expect(res.status).toBe(200);
-        expect(json).toHaveLength(1);            
+        expect(json).toHaveLength(2);            
         expect(json[0].subject).toBe('Physics'); 
+    });
+
+    it('GET should support popular sorting', async () => {
+        const req = new Request('http://localhost/api/doubts?subject=Physics&sort=popular');
+        const res = await GET(req);
+        const json = await res.json();
+
+        expect(res.status).toBe(200);
+        expect(json[0].id).toBe(2);
+    });
+
+    it('GET should support most-replied sorting', async () => {
+        const req = new Request('http://localhost/api/doubts?subject=Physics&sort=most-replied');
+        const res = await GET(req);
+        const json = await res.json();
+
+        expect(res.status).toBe(200);
+        expect(json[0].id).toBe(1);
+    });
+
+    it('GET should support unsolved filtering', async () => {
+        const req = new Request('http://localhost/api/doubts?subject=Physics&sort=unsolved');
+        const res = await GET(req);
+        const json = await res.json();
+
+        expect(res.status).toBe(200);
+        expect(json).toHaveLength(1);
+        expect(json[0].isSolved).toBe('unsolved');
     });
 
     it('POST should create a new doubt', async () => {

--- a/app/api/doubts/route.ts
+++ b/app/api/doubts/route.ts
@@ -1,7 +1,7 @@
 import { db } from "@/configs/db";
 import { bookmarksTable, doubtTagsTable, doubtsTable, likesTable, repliesTable, membershipsTable, classroomsTable, tagsTable, usersTable } from "@/configs/schema";
 import { categorizeDoubt } from "@/lib/ai/categorizer";
-import { and, eq, desc, inArray, isNull, or, not, sql, ilike } from "drizzle-orm";
+import { and, eq, inArray, isNull, or, not, sql, ilike } from "drizzle-orm";
 import { NextResponse } from "next/server";
 import { currentUser } from "@clerk/nextjs/server";
 import { moderateContent, handleModerationViolation } from "@/lib/moderation";
@@ -16,6 +16,7 @@ export async function GET(req: Request) {
     const classroomId = classroomIdStr ? parseInt(classroomIdStr) : null;
     const type = searchParams.get("type") || 'community';
     const tag = searchParams.get("tag");
+    const sort = searchParams.get("sort") || "newest";
 
     try {
         const user = await currentUser();
@@ -93,12 +94,13 @@ export async function GET(req: Request) {
         }
 
         const pageStr = searchParams.get("page");
+        const offsetStr = searchParams.get("offset");
         const limitStr = searchParams.get("limit");
         const page = pageStr ? parseInt(pageStr) : 1;
         const limit = limitStr ? parseInt(limitStr) : 20;
-        const offset = (page - 1) * limit;
+        const offset = offsetStr ? parseInt(offsetStr) : (page - 1) * limit;
 
-        let doubts = await query.where(and(...conditions)).orderBy(desc(doubtsTable.createdAt)).limit(limit).offset(offset);
+        let doubts = await query.where(and(...conditions));
 
         if (tag && tag !== "All" && doubts.length > 0) {
             const normalizedTag = tag.trim().replace(/\s+/g, " ").toLowerCase();
@@ -114,6 +116,46 @@ export async function GET(req: Request) {
             const taggedDoubtIds = new Set(taggedDoubts.map((row) => row.doubtId));
             doubts = doubts.filter((doubt) => taggedDoubtIds.has(doubt.id));
         }
+
+        if (sort === "unsolved") {
+            doubts = doubts.filter((doubt) => doubt.isSolved === "unsolved");
+        }
+
+        const replyCounts = doubts.length > 0
+            ? await db.select({
+                doubtId: repliesTable.doubtId,
+                count: sql<number>`count(*)`.mapWith(Number)
+            })
+            .from(repliesTable)
+            .groupBy(repliesTable.doubtId)
+            : [];
+
+        const countsMap = Object.fromEntries(replyCounts.map(r => [r.doubtId, r.count]));
+
+        doubts = doubts.map(doubt => ({
+            ...doubt,
+            replyCount: countsMap[doubt.id] || 0
+        }));
+
+        const createdAtValue = (value: any) => new Date(value).getTime() || 0;
+        const pinnedScore = (value: any) => (value ? 1 : 0);
+
+        doubts = doubts.sort((a, b) => {
+            const pinnedDiff = pinnedScore(b.isPinned) - pinnedScore(a.isPinned);
+            if (pinnedDiff !== 0) return pinnedDiff;
+
+            if (sort === "popular") {
+                const likesDiff = (b.likes ?? 0) - (a.likes ?? 0);
+                if (likesDiff !== 0) return likesDiff;
+            } else if (sort === "most-replied") {
+                const repliesDiff = (b.replyCount ?? 0) - (a.replyCount ?? 0);
+                if (repliesDiff !== 0) return repliesDiff;
+            }
+
+            return createdAtValue(b.createdAt) - createdAtValue(a.createdAt);
+        });
+
+        doubts = doubts.slice(offset, offset + limit);
 
         if (userName && doubts.length > 0) {
             const userLikes = await db.select({ doubtId: likesTable.doubtId })
@@ -140,21 +182,6 @@ export async function GET(req: Request) {
                 hasBookmarked: bookmarkedIds.has(doubt.id)
             }));
         }
-
-        // Fetch reply counts using an aggregate query
-        const replyCounts = await db.select({
-            doubtId: repliesTable.doubtId,
-            count: sql<number>`count(*)`.mapWith(Number)
-        })
-        .from(repliesTable)
-        .groupBy(repliesTable.doubtId);
-
-        const countsMap = Object.fromEntries(replyCounts.map(r => [r.doubtId, r.count]));
-
-        doubts = doubts.map(doubt => ({
-            ...doubt,
-            replyCount: countsMap[doubt.id] || 0
-        }));
 
         if (doubts.length > 0) {
             const tagRows = await db.select({

--- a/app/public-rooms/[subject]/page.tsx
+++ b/app/public-rooms/[subject]/page.tsx
@@ -5,18 +5,48 @@ import { useEffect, useState } from "react";
 import { Zap, MessageSquare, Plus, Loader2 } from "lucide-react";
 import AskDoubt from "@/components/AskDoubt";
 import DoubtCard from "@/components/DoubtCard";
+import DoubtSortSelect, { DoubtSortValue } from "@/components/DoubtSortSelect";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import useSWRInfinite from "swr/infinite";
 import { useInView } from "react-intersection-observer";
 
 export default function PublicRoomPage() {
     const params = useParams();
+    const pathname = usePathname();
+    const router = useRouter();
+    const searchParams = useSearchParams();
     const subject = params.subject as string;
     const [isAskModalOpen, setIsAskModalOpen] = useState(false);
 
+    const sort = (searchParams.get("sort") as DoubtSortValue) || "newest";
+
     const fetcher = (url: string) => fetch(url).then(res => res.json());
+    const updateSort = (nextSort: DoubtSortValue) => {
+        const nextParams = new URLSearchParams(searchParams.toString());
+        if (nextSort === "newest") {
+            nextParams.delete("sort");
+        } else {
+            nextParams.set("sort", nextSort);
+        }
+
+        const query = nextParams.toString();
+        router.replace(query ? `${pathname}?${query}` : pathname, { scroll: false });
+        setSize(1);
+    };
+
     const getKey = (pageIndex: number, previousPageData: any[]) => {
         if (previousPageData && !previousPageData.length) return null;
-        return `/api/doubts?subject=${subject}&page=${pageIndex + 1}&limit=20`;
+        const params = new URLSearchParams({
+            subject,
+            page: String(pageIndex + 1),
+            limit: "20",
+        });
+
+        if (sort !== "newest") {
+            params.append("sort", sort);
+        }
+
+        return `/api/doubts?${params.toString()}`;
     };
 
     const { data, isLoading, size, setSize, mutate } = useSWRInfinite(getKey, fetcher, {
@@ -54,6 +84,10 @@ export default function PublicRoomPage() {
                     Ask a Doubt
                 </button>
             </header>
+
+            <div className="flex justify-end">
+                <DoubtSortSelect value={sort} onValueChange={updateSort} />
+            </div>
 
             {isLoading && doubts.length === 0 ? (
                 <div className="flex flex-col items-center justify-center py-20 space-y-4">

--- a/app/public-rooms/page.tsx
+++ b/app/public-rooms/page.tsx
@@ -4,10 +4,15 @@ import { useEffect, useState } from "react";
 import { MessageSquare, Plus, SlidersHorizontal, Loader2 } from "lucide-react";
 import AskDoubt from "@/components/AskDoubt";
 import DoubtCard from "@/components/DoubtCard";
+import DoubtSortSelect, { DoubtSortValue } from "@/components/DoubtSortSelect";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import useSWRInfinite from "swr/infinite";
 import { useInView } from "react-intersection-observer";
 
 export default function PublicRoomsPage() {
+    const pathname = usePathname();
+    const router = useRouter();
+    const searchParams = useSearchParams();
     const [isAskModalOpen, setIsAskModalOpen] = useState(false);
     const [filter, setFilter] = useState("All");
     const [tagFilter, setTagFilter] = useState("");
@@ -27,7 +32,22 @@ export default function PublicRoomsPage() {
         return () => clearTimeout(timer);
     }, [searchVal]);
 
+    const sort = (searchParams.get("sort") as DoubtSortValue) || "newest";
+
     const fetcher = (url: string) => fetch(url).then(res => res.json());
+
+    const updateSort = (nextSort: DoubtSortValue) => {
+        const params = new URLSearchParams(searchParams.toString());
+        if (nextSort === "newest") {
+            params.delete("sort");
+        } else {
+            params.set("sort", nextSort);
+        }
+
+        const query = params.toString();
+        router.replace(query ? `${pathname}?${query}` : pathname, { scroll: false });
+        setSize(1);
+    };
 
     const getKey = (pageIndex: number, previousPageData: any[]) => {
         if (previousPageData && !previousPageData.length) return null;
@@ -46,6 +66,10 @@ export default function PublicRoomsPage() {
 
         if (appliedTagFilter.trim()) {
             params.append("tag", appliedTagFilter.trim());
+        }
+
+        if (sort !== "newest") {
+            params.append("sort", sort);
         }
 
         if (userName) params.append("userName", userName);
@@ -204,6 +228,8 @@ export default function PublicRoomsPage() {
                         >
                             Tag
                         </button>
+
+                        <DoubtSortSelect value={sort} onValueChange={updateSort} className="ml-auto" />
                     </div>
                 </div>
             </div>

--- a/app/rooms/[id]/page.tsx
+++ b/app/rooms/[id]/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { useParams, useRouter } from "next/navigation";
+import { useParams, useRouter, usePathname, useSearchParams } from "next/navigation";
 import { useHotkeys } from "react-hotkeys-hook";
 import { useAppUser } from "../../provider";
 import {
@@ -37,6 +37,7 @@ import DoubtCard from "@/components/DoubtCard";
 import Dashboard from "@/app/dashboard/page"; // We can reuse or adapt the Analytics view
 import AskAIView from "../../../components/AskAIView";
 import ExportButton from "@/components/ExportButton";
+import DoubtSortSelect, { DoubtSortValue } from "@/components/DoubtSortSelect";
 import { toast } from "sonner";
 import useSWRInfinite from "swr/infinite";
 import { useInView } from "react-intersection-observer";
@@ -54,6 +55,8 @@ interface Classroom {
 export default function ClassroomPage() {
     const { id } = useParams();
     const router = useRouter();
+    const pathname = usePathname();
+    const searchParams = useSearchParams();
     const { appUser } = useAppUser();
 
     const [classroom, setClassroom] = useState<Classroom | null>(null);
@@ -68,6 +71,7 @@ export default function ClassroomPage() {
     const [searchQuery, setSearchQuery] = useState("");
     const [subjectFilter, setSubjectFilter] = useState("All");
     const [tagFilter, setTagFilter] = useState("");
+    const sort = (searchParams.get("sort") as DoubtSortValue) || "newest";
 
     useEffect(() => {
         const timer = setTimeout(() => {
@@ -80,6 +84,19 @@ export default function ClassroomPage() {
     const userName = typeof window !== 'undefined' ? localStorage.getItem("anonymous_user") : "";
 
     const fetcher = (url: string) => fetch(url).then(res => res.json());
+    const updateSort = (nextSort: DoubtSortValue) => {
+        const nextParams = new URLSearchParams(searchParams.toString());
+        if (nextSort === "newest") {
+            nextParams.delete("sort");
+        } else {
+            nextParams.set("sort", nextSort);
+        }
+
+        const query = nextParams.toString();
+        router.replace(query ? `${pathname}?${query}` : pathname, { scroll: false });
+        setSize(1);
+    };
+
     const getKey = (pageIndex: number, previousPageData: any[]) => {
         if (previousPageData && !previousPageData.length) return null; // reached the end
         if (activeTab === 'insights') return null;
@@ -93,6 +110,7 @@ export default function ClassroomPage() {
         if (tagFilter.trim()) params.append("tag", tagFilter.trim());
         if (searchQuery) params.append("search", searchQuery);
         if (subjectFilter !== "All") params.append("subject", subjectFilter);
+        if (sort !== "newest") params.append("sort", sort);
         return `/api/doubts?${params.toString()}`;
     };
 
@@ -252,6 +270,12 @@ export default function ClassroomPage() {
             </div>
 
             {/* Content Area */}
+            <div className="max-w-7xl mx-auto px-4 md:px-12 pb-2 flex justify-end">
+                {activeTab !== "ask-ai" && activeTab !== "insights" && (
+                    <DoubtSortSelect value={sort} onValueChange={updateSort} />
+                )}
+            </div>
+
             <div className="max-w-7xl mx-auto p-4 md:py-8 md:px-12">
                 {activeTab === "ask-ai" && (
                     <div className="animate-in fade-in slide-in-from-bottom-4 duration-500 space-y-10">

--- a/components/DoubtSortSelect.tsx
+++ b/components/DoubtSortSelect.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { ArrowUpDown } from "lucide-react";
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from "@/components/ui/select";
+
+export type DoubtSortValue = "newest" | "popular" | "most-replied" | "unsolved";
+
+const sortOptions: Array<{ value: DoubtSortValue; label: string; description: string }> = [
+    { value: "newest", label: "Newest", description: "Pinned first, then latest doubts" },
+    { value: "popular", label: "Popular", description: "Most likes first" },
+    { value: "most-replied", label: "Most replied", description: "Most engagement first" },
+    { value: "unsolved", label: "Unsolved", description: "Open doubts only" },
+];
+
+interface DoubtSortSelectProps {
+    value: DoubtSortValue;
+    onValueChange: (value: DoubtSortValue) => void;
+    className?: string;
+}
+
+export default function DoubtSortSelect({ value, onValueChange, className }: DoubtSortSelectProps) {
+    return (
+        <div className={`flex items-center gap-3 ${className || ""}`}>
+            <div className="hidden sm:flex h-11 items-center gap-2 rounded-2xl border border-slate-200 dark:border-white/10 bg-slate-100/80 dark:bg-white/5 px-4 text-[10px] font-black uppercase tracking-[0.3em] text-slate-500 dark:text-slate-400">
+                <ArrowUpDown className="w-4 h-4 text-blue-500" />
+                Sort
+            </div>
+            <Select value={value} onValueChange={(nextValue) => onValueChange(nextValue as DoubtSortValue)}>
+                <SelectTrigger className="h-11 min-w-[12rem] rounded-2xl border-slate-200 dark:border-white/10 bg-white/70 dark:bg-slate-950/60 text-slate-900 dark:text-white shadow-sm">
+                    <SelectValue placeholder="Newest" />
+                </SelectTrigger>
+                <SelectContent>
+                    {sortOptions.map((option) => (
+                        <SelectItem key={option.value} value={option.value}>
+                            <span className="flex flex-col items-start">
+                                <span>{option.label}</span>
+                                <span className="text-[10px] text-slate-500 dark:text-slate-400">{option.description}</span>
+                            </span>
+                        </SelectItem>
+                    ))}
+                </SelectContent>
+            </Select>
+        </div>
+    );
+}

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev --webpack",
     "build": "next build --webpack",
     "start": "next start",
     "lint": "next lint",


### PR DESCRIPTION
## Description
This PR adds full sorting support to the doubt feed so users can find the most relevant doubts more easily. It introduces a `sort` query parameter in the backend, adds a reusable sort dropdown in the frontend, and keeps the selected sort option in the URL for shareable links.

The supported sorting modes are:
- `newest` as the default order
- `popular` by likes
- `most-replied` by reply count
- `unsolved` filtered to unresolved doubts first

## Related Issue
Closes #181 

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Documentation update (README, guides, comments)
- [x] Style / UI change (no logic change)
- [ ] Code refactor (no behavior change)
- [x] Test addition or update
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Changes Made
- Added backend sorting support in the doubts GET API.
- Added a reusable sort dropdown component for the doubt feed UI.
- Wired the sort state into the public rooms, subject feed, and classroom board pages.
- Updated the frontend to preserve sort choice in the URL for shareable links.
- Expanded API test coverage for the new sort options.

## Screenshots
<img width="1915" height="979" alt="Screenshot 2026-05-24 133019" src="https://github.com/user-attachments/assets/fc088c34-57fb-43c3-bb05-1570c1a6c43c" />
<img width="1916" height="983" alt="Screenshot 2026-05-24 133036" src="https://github.com/user-attachments/assets/6afec7e4-3f70-4069-9803-89760796bb16" />


## How Has This Been Tested?
- [x] Tested locally with `npm test`
- [x] Tested locally with `npm run dev -- --webpack`
- [x] Verified on desktop viewport
- [ ] Verified on mobile viewport

## Checklist
- [x] I have tested my changes locally
- [x] My code follows the existing code style
- [x] I have not introduced unrelated changes
- [x] I have added comments where necessary
- [x] My branch is up to date with `main`
- [x] I have linked the related issue above
- [x] Screenshots are included if this is a UI change

## GSSoC'26 Contributor Declaration
- [x] I confirm that I am a participant of GSSoC'26
- [x] I have followed the contribution guidelines of this project
- [x] This PR is ready for review