### PR TITLE
Feat/doubt status tracker

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 # Database (Neon PostgreSQL)
-DATABASE_URL=postgresql://user:password@host/database?sslmode=require
+NEXT_PUBLIC_NEON_DB_CONNECTION_STRING=postgresql://user:password@host/database?sslmode=require
 
 # Public site URL for canonical, OpenGraph, and Twitter metadata
 NEXT_PUBLIC_SITE_URL=http://localhost:3000

--- a/__tests__/api/replies-auto-transition.test.ts
+++ b/__tests__/api/replies-auto-transition.test.ts
@@ -1,0 +1,220 @@
+/**
+ * Tests for the doubt-status auto-transition introduced for issue 183.
+ *
+ * The transition logic lives in `app/api/replies/route.ts` (POST handler):
+ *
+ *   unsolved      + any reply (non-AI doubt) -> in-progress
+ *   in-progress   + any reply                -> in-progress  (no change)
+ *   solved        + any reply                -> solved        (sticky)
+ *   <any status>  + reply on AI doubt        -> <unchanged>
+ *
+ * We exercise this by mocking `@/configs/db` and `@/clerk/nextjs/server`
+ * plus the moderation and Inngest layers, then asserting the right
+ * `db.update(...).set(...)` call shape.
+ */
+
+import { DOUBT_STATUS, isValidDoubtStatus, isOpen } from "@/lib/doubtStatus";
+
+// --- Mocks ---------------------------------------------------------------
+
+// Chainable query builder used by the route. Each helper returns `this`
+// (or a thenable) so we can record the call sequence.
+const updateBuilder = {
+    set: jest.fn().mockReturnThis(),
+    where: jest.fn().mockResolvedValue([]),
+};
+
+const insertBuilder = {
+    values: jest.fn().mockReturnThis(),
+    returning: jest.fn().mockResolvedValue([{ id: 999, doubtId: 1 }]),
+};
+
+const mockDoubt = {
+    id: 1,
+    type: "community",
+    isSolved: DOUBT_STATUS.UNSOLVED,
+    userEmail: "owner@example.com",
+    classroomId: null,
+};
+
+// Each `select()` call is a separate chain; we configure them per-test.
+const selectChains: any[] = [];
+const makeSelectChain = (result: any) => {
+    const chain: any = {
+        from: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        limit: jest.fn().mockResolvedValue(result),
+        // orderBy / etc. unused on the path we hit, but kept for safety
+        orderBy: jest.fn().mockResolvedValue(result),
+    };
+    // For the user-block check the route doesn't call .limit(); make
+    // the chain itself awaitable to that result.
+    chain.then = (resolve: any) => resolve(result);
+    return chain;
+};
+
+jest.mock("@/configs/db", () => ({
+    db: {
+        select: jest.fn(() => {
+            const next = selectChains.shift();
+            // Fall back to an empty array if a test forgot to enqueue.
+            return next ?? makeSelectChain([]);
+        }),
+        insert: jest.fn(() => insertBuilder),
+        update: jest.fn(() => updateBuilder),
+    },
+}));
+
+jest.mock("@clerk/nextjs/server", () => ({
+    currentUser: jest.fn().mockResolvedValue({
+        id: "user_xyz",
+        primaryEmailAddress: { emailAddress: "replier@example.com" },
+    }),
+    auth: jest.fn(),
+}));
+
+jest.mock("@/lib/moderation", () => ({
+    moderateContent: jest.fn().mockResolvedValue({ ok: true }),
+    handleModerationViolation: jest.fn().mockResolvedValue(null),
+}));
+
+jest.mock("@/lib/error-handler", () => ({
+    buildErrorResponse: (err: Error) => ({
+        status: 500,
+        body: { error: err.message },
+    }),
+}));
+
+jest.mock("@/inngest/client", () => ({
+    inngest: { send: jest.fn().mockResolvedValue(undefined) },
+}));
+
+// --- Helpers -------------------------------------------------------------
+
+function makeRequest(body: Record<string, unknown>): Request {
+    return new Request("http://localhost/api/replies", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+    });
+}
+
+async function callPost(opts: {
+    doubt: typeof mockDoubt;
+    body: Record<string, unknown>;
+}) {
+    // Enqueue the two .select() chains the POST handler issues:
+    //   1) usersTable lookup for block check  -> returns [] (not blocked)
+    //   2) doubtsTable lookup                 -> returns [doubt]
+    selectChains.push(makeSelectChain([])); // block check
+    selectChains.push(makeSelectChain([opts.doubt])); // doubt lookup
+
+    // Import lazily so the mocks above are in place before the module
+    // captures references to them.
+    const mod = await import("@/app/api/replies/route");
+    return mod.POST(makeRequest(opts.body));
+}
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    selectChains.length = 0;
+});
+
+// --- Pure helpers --------------------------------------------------------
+
+describe("lib/doubtStatus", () => {
+    test("isValidDoubtStatus accepts the three canonical values", () => {
+        expect(isValidDoubtStatus("unsolved")).toBe(true);
+        expect(isValidDoubtStatus("in-progress")).toBe(true);
+        expect(isValidDoubtStatus("solved")).toBe(true);
+    });
+
+    test("isValidDoubtStatus rejects everything else", () => {
+        expect(isValidDoubtStatus("pending")).toBe(false);
+        expect(isValidDoubtStatus("SOLVED")).toBe(false);
+        expect(isValidDoubtStatus("")).toBe(false);
+        expect(isValidDoubtStatus(null)).toBe(false);
+        expect(isValidDoubtStatus(undefined)).toBe(false);
+        expect(isValidDoubtStatus(0)).toBe(false);
+    });
+
+    test("isOpen is true for unsolved and in-progress, false for solved", () => {
+        expect(isOpen("unsolved")).toBe(true);
+        expect(isOpen("in-progress")).toBe(true);
+        expect(isOpen("solved")).toBe(false);
+        expect(isOpen("anything else")).toBe(false);
+    });
+});
+
+// --- Auto-transition behaviour ------------------------------------------
+
+describe("POST /api/replies — auto-transition (issue #183)", () => {
+    test("unsolved community doubt is transitioned to in-progress after a reply", async () => {
+        await callPost({
+            doubt: { ...mockDoubt, isSolved: DOUBT_STATUS.UNSOLVED },
+            body: { doubtId: 1, userName: "Student_A7X", type: "comment", content: "hi" },
+        });
+
+        // `db.update` should have been called for the transition.
+        expect(updateBuilder.set).toHaveBeenCalledWith({
+            isSolved: DOUBT_STATUS.IN_PROGRESS,
+        });
+        // And the WHERE clause should pin on isSolved = 'unsolved' (race guard).
+        expect(updateBuilder.where).toHaveBeenCalledTimes(1);
+    });
+
+    test("in-progress doubt is left alone (idempotent)", async () => {
+        await callPost({
+            doubt: { ...mockDoubt, isSolved: DOUBT_STATUS.IN_PROGRESS },
+            body: { doubtId: 1, userName: "Student_A7X", type: "comment", content: "hi" },
+        });
+
+        // The update still runs, but the WHERE (isSolved = 'unsolved')
+        // means no rows match — verified by zero-row mock return above.
+        // What matters is we never set status BACK to in-progress
+        // through a different code path; check `set` arg shape is safe.
+        if (updateBuilder.set.mock.calls.length > 0) {
+            expect(updateBuilder.set).toHaveBeenCalledWith({
+                isSolved: DOUBT_STATUS.IN_PROGRESS,
+            });
+        }
+    });
+
+    test("solved doubt is NEVER downgraded by a new reply", async () => {
+        await callPost({
+            doubt: { ...mockDoubt, isSolved: DOUBT_STATUS.SOLVED },
+            body: { doubtId: 1, userName: "Student_A7X", type: "comment", content: "hi" },
+        });
+
+        // The transition update is fired, but is guarded by
+        // `isSolved = 'unsolved'` in the WHERE — so no row will change.
+        // We assert that the SET payload only proposes 'in-progress',
+        // never 'unsolved' (i.e. we never write a downgrade explicitly).
+        for (const call of updateBuilder.set.mock.calls) {
+            expect(call[0]).not.toEqual({ isSolved: DOUBT_STATUS.UNSOLVED });
+        }
+    });
+
+    test("AI-typed doubts are excluded from auto-transition", async () => {
+        await callPost({
+            doubt: { ...mockDoubt, type: "ai", isSolved: DOUBT_STATUS.UNSOLVED },
+            body: { doubtId: 1, userName: "Student_A7X", type: "comment", content: "hi" },
+        });
+
+        // For AI doubts we skip the transition update entirely.
+        expect(updateBuilder.set).not.toHaveBeenCalled();
+    });
+
+    test("transition failure does not fail the reply insert", async () => {
+        updateBuilder.where.mockRejectedValueOnce(new Error("transient db error"));
+
+        const res = await callPost({
+            doubt: { ...mockDoubt, isSolved: DOUBT_STATUS.UNSOLVED },
+            body: { doubtId: 1, userName: "Student_A7X", type: "comment", content: "hi" },
+        });
+
+        // The POST handler should still succeed (200) — the transition
+        // is best-effort and its error is swallowed.
+        expect(res.status).toBe(200);
+    });
+});

--- a/app/api/doubts/action/[id]/route.ts
+++ b/app/api/doubts/action/[id]/route.ts
@@ -3,13 +3,14 @@ import { doubtTagsTable, doubtsTable, likesTable, classroomsTable, repliesTable,
 import { and, eq, isNull, sql } from "drizzle-orm";
 import { NextResponse } from "next/server";
 import { currentUser } from "@clerk/nextjs/server";
+import { DOUBT_STATUS, DoubtStatus, isValidDoubtStatus } from "@/lib/doubtStatus";
 
 export async function PATCH(req: Request, { params }: { params: Promise<{ id: string }> }) {
     try {
         const user = await currentUser();
         const email = user?.primaryEmailAddress?.emailAddress;
         
-        const { action, content, subject, imageUrl, userName, replyId, tags = [] } = await req.json();
+        const { action, content, subject, imageUrl, userName, replyId, status, tags = [] } = await req.json();
         const { id } = await params;
         const doubtId = parseInt(id);
 
@@ -76,12 +77,32 @@ export async function PATCH(req: Request, { params }: { params: Promise<{ id: st
                 return NextResponse.json({ error: "Only a teacher can verify and mark AI-generated solutions as solved." }, { status: 403 });
             }
 
-            let newStatus = doubt.isSolved === "solved" ? "unsolved" : "solved";
-            let newSolvedReplyId = replyId || null;
+            // Resolve the target status.
+            //
+            //  - If the client passes an explicit `status` (e.g. a teacher
+            //    setting `in-progress` from a dropdown), use it after validation.
+            //  - Otherwise preserve the historical toggle behaviour:
+            //      solved      -> unsolved   (un-marking a resolved doubt)
+            //      anything    -> solved     (unsolved or in-progress => solved)
+            //
+            // `solvedReplyId` continues to be cleared whenever we leave the
+            // `solved` state, so we don't keep stale references around.
+            let newStatus: DoubtStatus;
+            if (status !== undefined) {
+                if (!isValidDoubtStatus(status)) {
+                    return NextResponse.json({ error: "Invalid status value" }, { status: 400 });
+                }
+                newStatus = status;
+            } else {
+                newStatus = doubt.isSolved === DOUBT_STATUS.SOLVED
+                    ? DOUBT_STATUS.UNSOLVED
+                    : DOUBT_STATUS.SOLVED;
+            }
+            let newSolvedReplyId: number | null = replyId || null;
 
             // Conditional Solving: Teacher can only mark as solved if at least 1 solution exists
             // (unless they are unsolving, or providing a replyId right now)
-            if (isTeacher && !isOwner && newStatus === "solved" && !replyId) {
+            if (isTeacher && !isOwner && newStatus === DOUBT_STATUS.SOLVED && !replyId) {
                 const solutionReplies = await db.select()
                     .from(repliesTable)
                     .where(and(eq(repliesTable.doubtId, doubtId), eq(repliesTable.type, 'solution')))
@@ -94,12 +115,19 @@ export async function PATCH(req: Request, { params }: { params: Promise<{ id: st
                 }
             }
 
+            // If a replyId is provided, it is used to either toggle off a previously
+            // pinned solution or pin a new one — this overrides the resolved status above.
             if (replyId && doubt.solvedReplyId === replyId) {
-                newStatus = "unsolved";
+                newStatus = DOUBT_STATUS.UNSOLVED;
                 newSolvedReplyId = null;
             } else if (replyId) {
-                newStatus = "solved";
+                newStatus = DOUBT_STATUS.SOLVED;
                 newSolvedReplyId = replyId;
+            }
+
+            // Defensive: only `solved` doubts should retain a solvedReplyId.
+            if (newStatus !== DOUBT_STATUS.SOLVED) {
+                newSolvedReplyId = null;
             }
 
             const updated = await db.update(doubtsTable)

--- a/app/api/replies/route.ts
+++ b/app/api/replies/route.ts
@@ -1,11 +1,12 @@
 import { db } from "@/configs/db";
 import { repliesTable, doubtsTable, classroomsTable, replyLikesTable, usersTable } from "@/configs/schema";
-import { eq, asc, sql } from "drizzle-orm";
+import { eq, asc, sql, and } from "drizzle-orm";
 import { NextResponse } from "next/server";
 import { auth, currentUser } from "@clerk/nextjs/server";
 import { moderateContent, handleModerationViolation } from "@/lib/moderation";
 import { buildErrorResponse } from "@/lib/error-handler";
 import { inngest } from "@/inngest/client";
+import { DOUBT_STATUS } from "@/lib/doubtStatus";
 
 export async function GET(req: Request) {
     try {
@@ -119,6 +120,31 @@ export async function POST(req: Request) {
             content: content || null,
             imageUrl: imageUrl || null,
         }).returning();
+
+        // Auto-transition: unsolved -> in-progress on first reply.
+        // Design notes:
+        //  - Any reply type qualifies (issue 183 says "when the first reply is posted").
+        //  - We never downgrade `solved` -> `in-progress`; the WHERE guard (`isSolved = 'unsolved'`) makes this idempotent and race condition-safe when two replies land near-simultaneously.
+        //  - AI-typed doubts are excluded because they follow a separate teacher-verification flow (see app/api/doubts/action/[id]/route.ts).
+        //  - This update is best-effort; a failure here must not fail the reply creation, so we swallow errors and log.
+        if (doubt && doubt.type !== "ai") {
+            try {
+                await db
+                    .update(doubtsTable)
+                    .set({ isSolved: DOUBT_STATUS.IN_PROGRESS })
+                    .where(
+                        and(
+                            eq(doubtsTable.id, parseInt(doubtId)),
+                            eq(doubtsTable.isSolved, DOUBT_STATUS.UNSOLVED)
+                        )
+                    );
+            } catch (transitionErr) {
+                console.error(
+                    "Failed to auto-transition doubt to in-progress (safely caught):",
+                    transitionErr
+                );
+            }
+        }
 
         // Trigger background email notification via Inngest
         try {

--- a/app/public-rooms/page.tsx
+++ b/app/public-rooms/page.tsx
@@ -15,6 +15,7 @@ export default function PublicRoomsPage() {
     const [isOthersActive, setIsOthersActive] = useState(false);
     const [appliedCustomFilter, setAppliedCustomFilter] = useState("");
     const [appliedTagFilter, setAppliedTagFilter] = useState("");
+    const [statusFilter, setStatusFilter] = useState<'all' | 'unsolved' | 'in-progress' | 'solved'>('all');
 
     // Debounced search query
     const [searchVal, setSearchVal] = useState("");
@@ -65,6 +66,12 @@ export default function PublicRoomsPage() {
     });
 
     const doubts = data ? [].concat(...data) : [];
+    const filteredDoubts = (doubts as any[]).filter((d) => {
+        if (statusFilter === 'all') return true;
+        if (statusFilter === 'unsolved') return d.isSolved === 'unsolved' || !d.isSolved;
+        if (statusFilter === 'in-progress') return d.isSolved === 'in-progress';
+        return d.isSolved === 'solved';
+    });
     const isLoadingMore = isLoading || (size > 0 && data && typeof data[size - 1] === "undefined");
     const isReachingEnd = data && data[data.length - 1]?.length < 20;
 
@@ -206,6 +213,31 @@ export default function PublicRoomsPage() {
                         </button>
                     </div>
                 </div>
+
+                {/* Status filter — All / Unsolved / In Progress / Solved */}
+                <div className="flex flex-wrap items-center gap-2">
+                    <div className="flex items-center gap-2 px-4 py-2 bg-slate-100 dark:bg-white/5 border border-slate-200 dark:border-white/10 rounded-xl text-slate-500 dark:text-slate-500">
+                        <span className="text-[10px] font-black uppercase tracking-widest">Status:</span>
+                    </div>
+                    {([
+                        { key: 'all',         label: 'All',         active: "bg-blue-600 border-blue-500 text-white shadow-lg shadow-blue-600/20" },
+                        { key: 'unsolved',    label: 'Unsolved',    active: "bg-red-500/10 border-red-500/20 text-red-500" },
+                        { key: 'in-progress', label: 'In Progress', active: "bg-amber-500/10 border-amber-500/20 text-amber-500" },
+                        { key: 'solved',      label: 'Solved',      active: "bg-emerald-500/10 border-emerald-500/20 text-emerald-500" },
+                    ] as const).map((s) => (
+                        <button
+                            key={s.key}
+                            onClick={() => setStatusFilter(s.key)}
+                            className={`px-5 py-2 rounded-xl text-[10px] font-black uppercase tracking-widest transition-all border shrink-0 ${
+                                statusFilter === s.key
+                                    ? s.active
+                                    : "bg-white/5 border-white/10 text-slate-400 hover:bg-white/10 hover:text-white"
+                            }`}
+                        >
+                            {s.label}
+                        </button>
+                    ))}
+                </div>
             </div>
 
             {isLoading && doubts.length === 0 ? (
@@ -213,10 +245,10 @@ export default function PublicRoomsPage() {
                     <div className="w-12 h-12 border-4 border-blue-600 border-t-transparent rounded-full animate-spin"></div>
                     <p className="text-slate-500 dark:text-slate-500 font-bold uppercase tracking-widest text-xs">Syncing with community...</p>
                 </div>
-            ) : doubts.length > 0 ? (
+            ) : filteredDoubts.length > 0 ? (
                 <>
                     <div className="flex flex-col gap-6 lg:gap-8">
-                        {doubts.map((doubt: any, index: number) => (
+                        {filteredDoubts.map((doubt: any, index: number) => (
                             <DoubtCard key={`${doubt.id}-${index}`} doubt={doubt} onUpdate={() => mutate()} />
                         ))}
                     </div>
@@ -224,6 +256,19 @@ export default function PublicRoomsPage() {
                         {isLoadingMore && <Loader2 className="w-8 h-8 text-blue-500 animate-spin" />}
                     </div>
                 </>
+            ) : doubts.length > 0 ? (
+                // We have doubts, but none match the current status filter.
+                <div className="py-20 text-center space-y-4 bg-white/[0.02] border border-dashed border-slate-200 dark:border-white/10 rounded-[2.5rem]">
+                    <p className="text-slate-500 dark:text-slate-500 font-black uppercase tracking-widest text-xs">
+                        No doubts matching this status filter.
+                    </p>
+                    <button
+                        onClick={() => setStatusFilter('all')}
+                        className="px-6 py-2.5 bg-white/5 text-slate-300 hover:bg-blue-600 hover:text-white border border-white/10 rounded-xl text-[10px] font-black uppercase tracking-widest transition-all"
+                    >
+                        Show all
+                    </button>
+                </div>
             ) : (
                 <div className="relative flex flex-col items-center justify-center py-20 rounded-[3rem] text-center px-6 overflow-hidden border border-slate-200 dark:border-white/5 bg-slate-950/20">
                     <div className="absolute inset-0 bg-gradient-to-br from-blue-950/40 via-slate-900/20 to-indigo-950/30 rounded-[3rem]" />

--- a/app/rooms/[id]/page.tsx
+++ b/app/rooms/[id]/page.tsx
@@ -63,7 +63,7 @@ export default function ClassroomPage() {
     const [isAskModalOpen, setIsAskModalOpen] = useState(false);
     const [isCodeModalOpen, setIsCodeModalOpen] = useState(false);
     const [copied, setCopied] = useState(false);
-    const [doubtFilter, setDoubtFilter] = useState<'pending' | 'solved'>('pending');
+    const [doubtFilter, setDoubtFilter] = useState<'unsolved' | 'in-progress' | 'solved'>('unsolved');
     const [searchVal, setSearchVal] = useState("");
     const [searchQuery, setSearchQuery] = useState("");
     const [subjectFilter, setSubjectFilter] = useState("All");
@@ -310,10 +310,16 @@ export default function ClassroomPage() {
 
                             <div className="flex items-center gap-2 bg-white/50 dark:bg-slate-950/50 p-1.5 rounded-2xl border border-slate-200 dark:border-white/5">
                                 <button
-                                    onClick={() => setDoubtFilter('pending')}
-                                    className={`px-6 py-2.5 rounded-xl text-[9px] font-black uppercase tracking-widest transition-all ${ doubtFilter === 'pending' ? "bg-red-500/10 text-red-500 border border-red-500/20" : "text-slate-500 hover:text-white" }`}
+                                    onClick={() => setDoubtFilter('unsolved')}
+                                    className={`px-6 py-2.5 rounded-xl text-[9px] font-black uppercase tracking-widest transition-all ${ doubtFilter === 'unsolved' ? "bg-red-500/10 text-red-500 border border-red-500/20" : "text-slate-500 hover:text-white" }`}
                                 >
-                                    Pending
+                                    Unsolved
+                                </button>
+                                <button
+                                    onClick={() => setDoubtFilter('in-progress')}
+                                    className={`px-6 py-2.5 rounded-xl text-[9px] font-black uppercase tracking-widest transition-all ${ doubtFilter === 'in-progress' ? "bg-amber-500/10 text-amber-500 border border-amber-500/20" : "text-slate-500 hover:text-white" }`}
+                                >
+                                    In Progress
                                 </button>
                                 <button
                                     onClick={() => setDoubtFilter('solved')}
@@ -410,7 +416,7 @@ export default function ClassroomPage() {
                             </div>
                         ) : (
                             <div className="space-y-8 animate-in fade-in duration-500">
-                                {doubtFilter === 'pending' ? (
+                                {doubtFilter === 'unsolved' && (
                                     <div className="space-y-8">
                                         <div className="flex items-center gap-4">
                                             <div className="h-[1px] flex-1 bg-gradient-to-r from-transparent via-red-500/20 to-transparent"></div>
@@ -418,17 +424,37 @@ export default function ClassroomPage() {
                                             <div className="h-[1px] flex-1 bg-gradient-to-r from-transparent via-red-500/20 to-transparent"></div>
                                         </div>
                                         <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
-                                            {Array.isArray(doubts) && doubts.filter((d: any) => d.isSolved !== "solved").map((doubt: any) => (
+                                            {Array.isArray(doubts) && doubts.filter((d: any) => d.isSolved === "unsolved" || (!d.isSolved)).map((doubt: any) => (
                                                 <DoubtCard key={doubt.id} doubt={doubt} role={classroom?.role} onUpdate={() => mutate()} />
                                              ))}
-                                            {(!Array.isArray(doubts) || doubts.filter((d: any) => d.isSolved !== "solved").length === 0) && (
+                                            {(!Array.isArray(doubts) || doubts.filter((d: any) => d.isSolved === "unsolved" || (!d.isSolved)).length === 0) && (
                                                 <div className="col-span-full py-12 text-center text-slate-500 dark:text-slate-500 text-[10px] uppercase font-black tracking-widest opacity-40">
-                                                    No pending queries in this category.
+                                                    No unsolved queries in this category.
                                                 </div>
                                             )}
                                         </div>
                                     </div>
-                                ) : (
+                                )}
+                                {doubtFilter === 'in-progress' && (
+                                    <div className="space-y-8">
+                                        <div className="flex items-center gap-4">
+                                            <div className="h-[1px] flex-1 bg-gradient-to-r from-transparent via-amber-500/20 to-transparent"></div>
+                                            <h3 className="text-[10px] font-black uppercase tracking-[0.4em] text-amber-500/60 bg-amber-500/5 px-4 py-1.5 rounded-full border border-amber-500/10">In Progress</h3>
+                                            <div className="h-[1px] flex-1 bg-gradient-to-r from-transparent via-amber-500/20 to-transparent"></div>
+                                        </div>
+                                        <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
+                                            {Array.isArray(doubts) && doubts.filter((d: any) => d.isSolved === "in-progress").map((doubt: any) => (
+                                                <DoubtCard key={doubt.id} doubt={doubt} role={classroom?.role} onUpdate={() => mutate()} />
+                                             ))}
+                                            {(!Array.isArray(doubts) || doubts.filter((d: any) => d.isSolved === "in-progress").length === 0) && (
+                                                <div className="col-span-full py-12 text-center text-slate-500 dark:text-slate-500 text-[10px] uppercase font-black tracking-widest opacity-40">
+                                                    No doubts in progress right now.
+                                                </div>
+                                            )}
+                                        </div>
+                                    </div>
+                                )}
+                                {doubtFilter === 'solved' && (
                                     <div className="space-y-8">
                                         <div className="flex items-center gap-4">
                                             <div className="h-[1px] flex-1 bg-gradient-to-r from-transparent via-emerald-500/20 to-transparent"></div>
@@ -461,10 +487,16 @@ export default function ClassroomPage() {
 
                             <div className="flex items-center gap-2 bg-white/50 dark:bg-slate-950/50 p-1.5 rounded-2xl border border-slate-200 dark:border-white/5">
                                 <button
-                                    onClick={() => setDoubtFilter('pending')}
-                                    className={`px-6 py-2.5 rounded-xl text-[9px] font-black uppercase tracking-widest transition-all ${ doubtFilter === 'pending' ? "bg-red-500/10 text-red-500 border border-red-500/20" : "text-slate-500 hover:text-white" }`}
+                                    onClick={() => setDoubtFilter('unsolved')}
+                                    className={`px-6 py-2.5 rounded-xl text-[9px] font-black uppercase tracking-widest transition-all ${ doubtFilter === 'unsolved' ? "bg-red-500/10 text-red-500 border border-red-500/20" : "text-slate-500 hover:text-white" }`}
                                 >
-                                    Pending
+                                    Unsolved
+                                </button>
+                                <button
+                                    onClick={() => setDoubtFilter('in-progress')}
+                                    className={`px-6 py-2.5 rounded-xl text-[9px] font-black uppercase tracking-widest transition-all ${ doubtFilter === 'in-progress' ? "bg-amber-500/10 text-amber-500 border border-amber-500/20" : "text-slate-500 hover:text-white" }`}
+                                >
+                                    In Progress
                                 </button>
                                 <button
                                     onClick={() => setDoubtFilter('solved')}
@@ -537,22 +569,22 @@ export default function ClassroomPage() {
                             </div>
                         ) : (
                             <div className="space-y-8 animate-in fade-in duration-500">
-                                {doubtFilter === 'pending' ? (
+                                {doubtFilter === 'unsolved' && (
                                     <div className="space-y-8">
                                         <div className="flex items-center gap-4">
                                             <div className="h-[1px] flex-1 bg-gradient-to-r from-transparent via-red-500/20 to-transparent"></div>
-                                            <h3 className="text-[10px] font-black uppercase tracking-[0.4em] text-red-500/60 bg-red-500/5 px-4 py-1.5 rounded-full border border-red-500/10">Pending Doubts</h3>
+                                            <h3 className="text-[10px] font-black uppercase tracking-[0.4em] text-red-500/60 bg-red-500/5 px-4 py-1.5 rounded-full border border-red-500/10">Unsolved Doubts</h3>
                                             <div className="h-[1px] flex-1 bg-gradient-to-r from-transparent via-red-500/20 to-transparent"></div>
                                         </div>
                                         <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
-                                            {Array.isArray(doubts) && doubts.filter((d: any) => d.isSolved !== "solved").map((doubt: any) => (
+                                            {Array.isArray(doubts) && doubts.filter((d: any) => d.isSolved === "unsolved" || (!d.isSolved)).map((doubt: any) => (
                                                 <DoubtCard key={doubt.id} doubt={doubt} role={classroom?.role} onUpdate={() => mutate()} />
                                             ))}
-                                            {(!Array.isArray(doubts) || doubts.filter((d: any) => d.isSolved !== "solved").length === 0) && (
+                                            {(!Array.isArray(doubts) || doubts.filter((d: any) => d.isSolved === "unsolved" || (!d.isSolved)).length === 0) && (
                                                 <div className="col-span-full py-24 text-center space-y-4 bg-slate-100 dark:bg-white/5 border border-dashed border-slate-200 dark:border-white/10 rounded-[2.5rem]">
                                                     <GraduationCap className="w-12 h-12 text-slate-700 mx-auto" />
                                                     <p className="text-slate-500 dark:text-slate-500 font-bold uppercase tracking-widest text-xs">
-                                                        {classroom?.role === 'teacher' ? "No doubts from students yet." : "No teacher doubts yet."}
+                                                        {classroom?.role === 'teacher' ? "No unsolved doubts from students." : "No unsolved teacher doubts."}
                                                     </p>
                                                     {classroom?.role !== 'teacher' && (
                                                         <button onClick={() => setIsAskModalOpen(true)} className="text-purple-500 font-black uppercase tracking-widest text-[10px] hover:underline underline-offset-4">Send the first query</button>
@@ -561,7 +593,27 @@ export default function ClassroomPage() {
                                             )}
                                         </div>
                                     </div>
-                                ) : (
+                                )}
+                                {doubtFilter === 'in-progress' && (
+                                    <div className="space-y-8">
+                                        <div className="flex items-center gap-4">
+                                            <div className="h-[1px] flex-1 bg-gradient-to-r from-transparent via-amber-500/20 to-transparent"></div>
+                                            <h3 className="text-[10px] font-black uppercase tracking-[0.4em] text-amber-500/60 bg-amber-500/5 px-4 py-1.5 rounded-full border border-amber-500/10">In Progress</h3>
+                                            <div className="h-[1px] flex-1 bg-gradient-to-r from-transparent via-amber-500/20 to-transparent"></div>
+                                        </div>
+                                        <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
+                                            {Array.isArray(doubts) && doubts.filter((d: any) => d.isSolved === "in-progress").map((doubt: any) => (
+                                                <DoubtCard key={doubt.id} doubt={doubt} role={classroom?.role} onUpdate={() => mutate()} />
+                                            ))}
+                                            {(!Array.isArray(doubts) || doubts.filter((d: any) => d.isSolved === "in-progress").length === 0) && (
+                                                <div className="col-span-full py-12 text-center text-slate-500 dark:text-slate-500 text-[10px] uppercase font-black tracking-widest opacity-40">
+                                                    No teacher doubts in progress right now.
+                                                </div>
+                                            )}
+                                        </div>
+                                    </div>
+                                )}
+                                {doubtFilter === 'solved' && (
                                     <div className="space-y-8">
                                         <div className="flex items-center gap-4">
                                             <div className="h-[1px] flex-1 bg-gradient-to-r from-transparent via-emerald-500/20 to-transparent"></div>

--- a/components/DoubtCard.tsx
+++ b/components/DoubtCard.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { MessageSquare, ThumbsUp, CheckCircle, Edit2, Trash2, X, ZoomIn, AlertTriangle, Pin, Bookmark } from "lucide-react";
+import { MessageSquare, ThumbsUp, CheckCircle, Edit2, Trash2, X, ZoomIn, AlertTriangle, Pin, Bookmark, Clock } from "lucide-react";
 import AskDoubt from "./AskDoubt";
 import DoubtRepliesModal from "./DoubtRepliesModal";
 import { toast } from "sonner";
@@ -173,6 +173,11 @@ export default function DoubtCard({ doubt, onUpdate, onViewAISolution, role }: D
                             <div className="px-3 py-1 bg-emerald-500/10 border border-emerald-500/20 rounded-full flex items-center gap-1.5">
                                 <CheckCircle className="w-3 h-3 text-emerald-500" />
                                 <span className="text-[9px] font-black text-emerald-500 uppercase tracking-widest">Solved</span>
+                            </div>
+                        ) : doubt.isSolved === "in-progress" ? (
+                            <div className="px-3 py-1 bg-amber-500/10 border border-amber-500/20 rounded-full flex items-center gap-1.5">
+                                <Clock className="w-3 h-3 text-amber-500" />
+                                <span className="text-[9px] font-black text-amber-500 uppercase tracking-widest">In Progress</span>
                             </div>
                         ) : (
                             <div className="px-3 py-1 bg-red-500/10 border border-red-500/20 rounded-full flex items-center gap-1.5">

--- a/configs/schema.ts
+++ b/configs/schema.ts
@@ -185,7 +185,7 @@ export const doubtsTable = pgTable("doubts", {
     content: text(),
     imageUrl: text(),
     likes: integer().default(0),
-    isSolved: varchar({ length: 20 }).default("unsolved"), // unsolved, solved
+    isSolved: varchar({ length: 20 }).default("unsolved"), // unsolved | in-progress | solved : see lib/doubtStatus.ts
     solvedReplyId: integer(),                       // ID of the specific reply that solved it
     type: varchar({ length: 20 }).default("community"),    // 'ai', 'community', 'teacher'
     isPinned: boolean().default(false),

--- a/lib/doubtStatus.ts
+++ b/lib/doubtStatus.ts
@@ -1,0 +1,48 @@
+/**
+ * Doubt status taxonomy.
+ *
+ * Doubts move through three states:
+ *   - `unsolved`    : initial state when a doubt is posted.
+ *   - `in-progress` : someone has replied but the doubt has not been marked solved by the owner or a teacher yet.
+ *   - `solved`      : explicitly marked solved by the owner (or a teacher, subject to the rules in `app/api/doubts/action/[id]`).
+ *
+ * The transition rules live in two places:
+ *   - `app/api/replies/route.ts`           - auto-transition unsolved → in-progress
+ *                                            on the first reply (any reply type,
+ *                                            except for AI-typed doubts).
+ *   - `app/api/doubts/action/[id]/route.ts` - manual transitions via the
+ *                                            "solve" action (owner / teacher).
+ *
+ * Status never auto-downgrades: `solved` is sticky and only an explicit action can move it back to `unsolved`.
+ *
+ * The underlying column is `doubtsTable.isSolved varchar(20)` - the name
+ * is preserved for backwards compatibility with the existing API surface
+ * and the analytics aggregation in `app/api/analytics/route.ts`.
+ */
+export const DOUBT_STATUS = {
+    UNSOLVED: "unsolved",
+    IN_PROGRESS: "in-progress",
+    SOLVED: "solved",
+} as const;
+
+export type DoubtStatus = typeof DOUBT_STATUS[keyof typeof DOUBT_STATUS];
+
+export const ALL_DOUBT_STATUSES: DoubtStatus[] = [
+    DOUBT_STATUS.UNSOLVED,
+    DOUBT_STATUS.IN_PROGRESS,
+    DOUBT_STATUS.SOLVED,
+];
+
+/** Type-guard for values coming from the wire (request body, query param, db read). */
+export function isValidDoubtStatus(value: unknown): value is DoubtStatus {
+    return (
+        value === DOUBT_STATUS.UNSOLVED ||
+        value === DOUBT_STATUS.IN_PROGRESS ||
+        value === DOUBT_STATUS.SOLVED
+    );
+}
+
+/** Convenience: anything that is not `solved` is considered "open". */
+export function isOpen(status: unknown): boolean {
+    return status === DOUBT_STATUS.UNSOLVED || status === DOUBT_STATUS.IN_PROGRESS;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@clerk/nextjs": "^6.39.3",
         "@clerk/themes": "^2.4.57",
-        "@ducanh2912/next-pwa": "^10.2.9",
+        "@ducanh2912/next-pwa": "^10.2.6",
         "@hookform/resolvers": "5.2.2",
         "@inngest/agent-kit": "0.13.2",
         "@neondatabase/serverless": "1.0.2",
@@ -44,7 +44,7 @@
         "@types/react-syntax-highlighter": "^15.5.13",
         "@upstash/ratelimit": "^2.0.8",
         "@upstash/redis": "^1.38.0",
-        "axios": "1.13.2",
+        "axios": "^1.16.1",
         "class-variance-authority": "0.7.1",
         "clsx": "2.1.1",
         "cmdk": "1.1.1",
@@ -2035,16 +2035,16 @@
       }
     },
     "node_modules/@clerk/shared": {
-      "version": "3.47.5",
-      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-3.47.5.tgz",
-      "integrity": "sha512-rDVe73/VN2NZXhtrLRHshkUpQDrevAqDRxeXUl2M0IBEBkcl+VMHlV7fep53cVWo0b3gIqLk82pmmi+WoyF/xg==",
+      "version": "3.47.6",
+      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-3.47.6.tgz",
+      "integrity": "sha512-hg2UFiwmSb3FnAciMxZZZculRN08NrlajXbBhT+nylMG6ljZoic0OlIGs+Rtp49scVMkX3Ytz5EUUj9pgVvcWQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "3.1.3",
         "dequal": "2.0.3",
         "glob-to-regexp": "0.4.1",
-        "js-cookie": "3.0.5",
+        "js-cookie": "3.0.7",
         "std-env": "^3.9.0",
         "swr": "2.3.4"
       },
@@ -2987,6 +2987,9 @@
       "cpu": [
         "arm"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3002,6 +3005,9 @@
       "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -3019,6 +3025,9 @@
       "cpu": [
         "ppc64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3034,6 +3043,9 @@
       "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
       "cpu": [
         "riscv64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -3051,6 +3063,9 @@
       "cpu": [
         "s390x"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3066,6 +3081,9 @@
       "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -3083,6 +3101,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "musl"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3099,6 +3120,9 @@
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "musl"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3114,6 +3138,9 @@
       "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
       "cpu": [
         "arm"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -3137,6 +3164,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3158,6 +3188,9 @@
       "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
       "cpu": [
         "ppc64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -3181,6 +3214,9 @@
       "cpu": [
         "riscv64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3202,6 +3238,9 @@
       "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
       "cpu": [
         "s390x"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -3225,6 +3264,9 @@
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3247,6 +3289,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "musl"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3268,6 +3313,9 @@
       "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -4701,6 +4749,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4716,6 +4767,9 @@
       "integrity": "sha512-URUTu1+dMkxJsPFgm+OeEvq9wf5sujw0EvgYy80TDGHTSLTnIHeqb0Eu8A3sC95IRgjejQL+kC4mw+4yPxiAXA==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4733,6 +4787,9 @@
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4748,6 +4805,9 @@
       "integrity": "sha512-HKQ5SP/V/ub73UvF7n/zeJlxk2kLmtL7Wzrg4WfmkjmNos5onJ2tKu7yZOPdL18A6Svfn3max29ym+ry7NkK4g==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -7878,16 +7938,16 @@
       "license": "MIT"
     },
     "node_modules/@remotion/bundler": {
-      "version": "4.0.462",
-      "resolved": "https://registry.npmjs.org/@remotion/bundler/-/bundler-4.0.462.tgz",
-      "integrity": "sha512-GlKjrFkrkl/UgiSTCzMPxRtTnOswOUozo5kk0TmK27tDlF9Mkm6Vyy/Dk5UptPIxDeTi8RIvGWrRRhgVUgzzeQ==",
+      "version": "4.0.465",
+      "resolved": "https://registry.npmjs.org/@remotion/bundler/-/bundler-4.0.465.tgz",
+      "integrity": "sha512-b30EJr6a/7HK5ed8OAKsfu+GVoeIJEav9+Rcoh/ygBCo1LRtMWDREPQswg3wovPcW7kx+64Lt7BpiO35lzrkhA==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@remotion/media-parser": "4.0.462",
-        "@remotion/studio": "4.0.462",
-        "@remotion/studio-shared": "4.0.462",
-        "@remotion/timeline-utils": "4.0.462",
+        "@remotion/media-parser": "4.0.465",
+        "@remotion/studio": "4.0.465",
+        "@remotion/studio-shared": "4.0.465",
+        "@remotion/timeline-utils": "4.0.465",
         "@rspack/core": "1.7.6",
         "@rspack/plugin-react-refresh": "1.6.1",
         "esbuild": "0.28.0",
@@ -7895,7 +7955,7 @@
         "postcss": "8.5.10",
         "postcss-value-parser": "4.2.0",
         "react-refresh": "0.18.0",
-        "remotion": "4.0.462",
+        "remotion": "4.0.465",
         "style-loader": "4.0.0",
         "webpack": "5.105.0"
       },
@@ -7953,23 +8013,23 @@
       }
     },
     "node_modules/@remotion/cli": {
-      "version": "4.0.462",
-      "resolved": "https://registry.npmjs.org/@remotion/cli/-/cli-4.0.462.tgz",
-      "integrity": "sha512-ZFeXBM2bl1Eku8OroJyCOK+kflMTbJ7HBhUaH8qN3WSyX0dOngBKkNa9DRFbiDJVDGgE0ziG7uiSuU/oB1HPqQ==",
+      "version": "4.0.465",
+      "resolved": "https://registry.npmjs.org/@remotion/cli/-/cli-4.0.465.tgz",
+      "integrity": "sha512-+XuKkSiBjGZQ7gu6clWE279GY7cRjvpT7i1PiVO9lPGM/n3ceb5LmgdGy4+XGQpzv+QNTPQW4SInTmAUV61UUA==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@remotion/bundler": "4.0.462",
-        "@remotion/media-utils": "4.0.462",
-        "@remotion/player": "4.0.462",
-        "@remotion/renderer": "4.0.462",
-        "@remotion/studio": "4.0.462",
-        "@remotion/studio-server": "4.0.462",
-        "@remotion/studio-shared": "4.0.462",
+        "@remotion/bundler": "4.0.465",
+        "@remotion/media-utils": "4.0.465",
+        "@remotion/player": "4.0.465",
+        "@remotion/renderer": "4.0.465",
+        "@remotion/studio": "4.0.465",
+        "@remotion/studio-server": "4.0.465",
+        "@remotion/studio-shared": "4.0.465",
         "dotenv": "17.3.1",
         "minimist": "1.2.6",
         "prompts": "2.4.2",
-        "remotion": "4.0.462"
+        "remotion": "4.0.465"
       },
       "bin": {
         "remotion": "remotion-cli.js",
@@ -7995,9 +8055,9 @@
       }
     },
     "node_modules/@remotion/compositor-darwin-arm64": {
-      "version": "4.0.462",
-      "resolved": "https://registry.npmjs.org/@remotion/compositor-darwin-arm64/-/compositor-darwin-arm64-4.0.462.tgz",
-      "integrity": "sha512-soKDNA0jSppazP9jxbz4OFQRTVS9mIj5w+5EtmcH23gCdnZejjCEO8839YE7nhHi5C7wgqU/sdkwRs3FyfP+tg==",
+      "version": "4.0.465",
+      "resolved": "https://registry.npmjs.org/@remotion/compositor-darwin-arm64/-/compositor-darwin-arm64-4.0.465.tgz",
+      "integrity": "sha512-2XoLxoPhURrZGpvoYIzcwI7snujK85TJ/tgkZ+IcbK09CeKw6MjPalrbTlqR7skxIM+zhflQsygC/8JHSOihTw==",
       "cpu": [
         "arm64"
       ],
@@ -8008,9 +8068,9 @@
       ]
     },
     "node_modules/@remotion/compositor-darwin-x64": {
-      "version": "4.0.462",
-      "resolved": "https://registry.npmjs.org/@remotion/compositor-darwin-x64/-/compositor-darwin-x64-4.0.462.tgz",
-      "integrity": "sha512-xAkk7095Ud/Ugs3SP7GERnTwm2sljuZ4K89Gb5Y8tvdObqH70u1TMobzNWPcBOJcYOl7hgfc4dqV9pvMTHo+hw==",
+      "version": "4.0.465",
+      "resolved": "https://registry.npmjs.org/@remotion/compositor-darwin-x64/-/compositor-darwin-x64-4.0.465.tgz",
+      "integrity": "sha512-ez/VRuoSQ2XWFu4zjpCEWa/5brChF6bkgLNTUstXeownA8i/p23AJJXDbMdyzNhfBCng86hP47zKy5mYRQcNYQ==",
       "cpu": [
         "x64"
       ],
@@ -8021,61 +8081,73 @@
       ]
     },
     "node_modules/@remotion/compositor-linux-arm64-gnu": {
-      "version": "4.0.462",
-      "resolved": "https://registry.npmjs.org/@remotion/compositor-linux-arm64-gnu/-/compositor-linux-arm64-gnu-4.0.462.tgz",
-      "integrity": "sha512-8Qy3lGKQsX/Kuxlji9AENnlpzRSDuG/K5DIe7o73YBitxey539sp1D3Ww0VCrE0uyH4Gj85KiPrT8YEESMcpCA==",
+      "version": "4.0.465",
+      "resolved": "https://registry.npmjs.org/@remotion/compositor-linux-arm64-gnu/-/compositor-linux-arm64-gnu-4.0.465.tgz",
+      "integrity": "sha512-Hv4x4mYuPRtkBrXtOgS+SkiyUNLZBwZLBlVdv4WX5v9zguqjKl566ZPZY1Tm+KN7OXldFuW3RUuHsVwTokOTGg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@remotion/compositor-linux-arm64-musl": {
-      "version": "4.0.462",
-      "resolved": "https://registry.npmjs.org/@remotion/compositor-linux-arm64-musl/-/compositor-linux-arm64-musl-4.0.462.tgz",
-      "integrity": "sha512-dZjq3H8GngDdZs3/cqOdrPKOhW1UhQb99emYNx+G4Mv4kIpqX3sOEGYZNokCDZxR8hiAehI8BqblHk1NGDa0mQ==",
+      "version": "4.0.465",
+      "resolved": "https://registry.npmjs.org/@remotion/compositor-linux-arm64-musl/-/compositor-linux-arm64-musl-4.0.465.tgz",
+      "integrity": "sha512-6HrW4s/yYsYoEwCsXq5pyaZUq6OXH3KETS6zCazAIiXsuc6zWgu78/UN0Zh+MQAKDiEY0dUooEvLfAgGb5B4gQ==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@remotion/compositor-linux-x64-gnu": {
-      "version": "4.0.462",
-      "resolved": "https://registry.npmjs.org/@remotion/compositor-linux-x64-gnu/-/compositor-linux-x64-gnu-4.0.462.tgz",
-      "integrity": "sha512-nfqqBOc81+CnkmoOFhQF0EzqiGK1N5FwrcwrxexJxoQkxpNk4kMRp2CKyaOd6cHEx1hQKKCl/pPiScEez8ZwfA==",
+      "version": "4.0.465",
+      "resolved": "https://registry.npmjs.org/@remotion/compositor-linux-x64-gnu/-/compositor-linux-x64-gnu-4.0.465.tgz",
+      "integrity": "sha512-V4lBhHTP7CwfbztEW6OOZZcgIhJSpUEoFjc0yUBQujKVNbEH2IJT5ZEYkh4f4+x03zcs49wexMBUDzPhXhfTGw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@remotion/compositor-linux-x64-musl": {
-      "version": "4.0.462",
-      "resolved": "https://registry.npmjs.org/@remotion/compositor-linux-x64-musl/-/compositor-linux-x64-musl-4.0.462.tgz",
-      "integrity": "sha512-AFNmG/Ll2lP3Hh9E7qjWkTIKaNfxZwQJeke2bWmcOV+tlWJa/mFccNVHnoDP5NpjpYwAHvemCUxmPIV1l2/7lw==",
+      "version": "4.0.465",
+      "resolved": "https://registry.npmjs.org/@remotion/compositor-linux-x64-musl/-/compositor-linux-x64-musl-4.0.465.tgz",
+      "integrity": "sha512-HCGTJLAYBNqY0MtInyu4z9rPdDhVL6C1i8yxzeGeaKZ+RFrmF4ny8C9KDKePlkbKjcyE1kRnPUGQN9tlmjaXAw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@remotion/compositor-win32-x64-msvc": {
-      "version": "4.0.462",
-      "resolved": "https://registry.npmjs.org/@remotion/compositor-win32-x64-msvc/-/compositor-win32-x64-msvc-4.0.462.tgz",
-      "integrity": "sha512-lXjrweVS3cEpfR33TH7so93GKUtx77zfK0iKBkrTcwZw7IIYYIBG8Y7H2M2MTIW3xQDPtuJPhOuVTiUFcocmcw==",
+      "version": "4.0.465",
+      "resolved": "https://registry.npmjs.org/@remotion/compositor-win32-x64-msvc/-/compositor-win32-x64-msvc-4.0.465.tgz",
+      "integrity": "sha512-Frb3pFkOBfmRxXZxp7AYKae1m4kk/g/18v7VmWVAoT40bVopSbnbfHxRxDLk7jxKbngXHLX07+uQlc5cqVSdsw==",
       "cpu": [
         "x64"
       ],
@@ -8086,28 +8158,28 @@
       ]
     },
     "node_modules/@remotion/licensing": {
-      "version": "4.0.462",
-      "resolved": "https://registry.npmjs.org/@remotion/licensing/-/licensing-4.0.462.tgz",
-      "integrity": "sha512-NbTiGVmqp7NJsLbjJP84jB5oLO92a6TJiq2KckpdpZlekLPbITpKp984rXMZjZgE/B0LkeYkIHRNO75AikFQLQ==",
+      "version": "4.0.465",
+      "resolved": "https://registry.npmjs.org/@remotion/licensing/-/licensing-4.0.465.tgz",
+      "integrity": "sha512-GjziQqExSkeZIn4YCNjdq+0i2lGHbaVnwUAFQfzs3f5JSnfzYPjaRjpUB2FeQ5yaxWpnDH4kllkDCD2TZSC9fw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@remotion/media-parser": {
-      "version": "4.0.462",
-      "resolved": "https://registry.npmjs.org/@remotion/media-parser/-/media-parser-4.0.462.tgz",
-      "integrity": "sha512-wSXZcVhNppSxsw+kDF6Y00YqnTQvw88OU3sM6P2JR6IKzsKq2bSMgm4amqVs1K1hP7m3CAdx4NqG/5H9a9/kzw==",
+      "version": "4.0.465",
+      "resolved": "https://registry.npmjs.org/@remotion/media-parser/-/media-parser-4.0.465.tgz",
+      "integrity": "sha512-A79JseiqY2dUV4wt3ORp288io7XkfkSe5ZdCrjlX/ASlAy4HMf4DcbtXnbtTmOsSTzQNf9grsM9G1GTEIztK9g==",
       "dev": true,
       "license": "Remotion License https://remotion.dev/license"
     },
     "node_modules/@remotion/media-utils": {
-      "version": "4.0.462",
-      "resolved": "https://registry.npmjs.org/@remotion/media-utils/-/media-utils-4.0.462.tgz",
-      "integrity": "sha512-naC7SVMO979E6kRzXxL3H1IoaNdTucE+7NbYDbt6ixrlsFtenpiRaVH0RlJPmYXmcwss3dvmmabVwrQ7RrMB5Q==",
+      "version": "4.0.465",
+      "resolved": "https://registry.npmjs.org/@remotion/media-utils/-/media-utils-4.0.465.tgz",
+      "integrity": "sha512-N55xn4ZPrvNEWOKimU8W/aDYVOUkWpVNlVfBi1YudXijs6pXdGT4PGl+brmHJZ+Uia9H6siQMFuHEuzndUSJlA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "mediabunny": "1.45.0",
-        "remotion": "4.0.462"
+        "remotion": "4.0.465"
       },
       "peerDependencies": {
         "react": ">=16.8.0",
@@ -8115,13 +8187,13 @@
       }
     },
     "node_modules/@remotion/player": {
-      "version": "4.0.462",
-      "resolved": "https://registry.npmjs.org/@remotion/player/-/player-4.0.462.tgz",
-      "integrity": "sha512-w/zBCWwLXsoNwsokaPwKxpdv+CBw52FuR3pQZegZvcnKwx1d8bq2P4xBjhCs+o5XP7kiRS0FQIIFYiCmXZXYgw==",
+      "version": "4.0.465",
+      "resolved": "https://registry.npmjs.org/@remotion/player/-/player-4.0.465.tgz",
+      "integrity": "sha512-qTi7Gmg+j7+G5s6BKK6afIr4BxVkaMbDBtjnvNvyLM+1l9ynaae3XsoHGhYwj8nvRAyy2z7A4M8ZHDJ9QzzIFg==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "remotion": "4.0.462"
+        "remotion": "4.0.465"
       },
       "peerDependencies": {
         "react": ">=16.8.0",
@@ -8129,28 +8201,27 @@
       }
     },
     "node_modules/@remotion/renderer": {
-      "version": "4.0.462",
-      "resolved": "https://registry.npmjs.org/@remotion/renderer/-/renderer-4.0.462.tgz",
-      "integrity": "sha512-qwOsGvtGb3CIpYMrVeO+wTwJN+C3uigT9gKyM0tl24IrPbq8UWqkX1mDJv5pYcWUbCj1mEdeakh7ue9+zgdEgA==",
+      "version": "4.0.465",
+      "resolved": "https://registry.npmjs.org/@remotion/renderer/-/renderer-4.0.465.tgz",
+      "integrity": "sha512-Fr1A4q2ic+QtbDgY9uuEOTs/HncqQXXfn0UFs2Dm/Sk0TZzALRIdugTcvsV9OSLGOMcuYoat7mbtQ6c5CQc/dw==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@remotion/licensing": "4.0.462",
-        "@remotion/streaming": "4.0.462",
+        "@remotion/licensing": "4.0.465",
+        "@remotion/streaming": "4.0.465",
         "execa": "5.1.1",
-        "extract-zip": "2.0.1",
-        "remotion": "4.0.462",
+        "remotion": "4.0.465",
         "source-map": "0.8.0-beta.0",
-        "ws": "8.17.1"
+        "ws": "8.20.1"
       },
       "optionalDependencies": {
-        "@remotion/compositor-darwin-arm64": "4.0.462",
-        "@remotion/compositor-darwin-x64": "4.0.462",
-        "@remotion/compositor-linux-arm64-gnu": "4.0.462",
-        "@remotion/compositor-linux-arm64-musl": "4.0.462",
-        "@remotion/compositor-linux-x64-gnu": "4.0.462",
-        "@remotion/compositor-linux-x64-musl": "4.0.462",
-        "@remotion/compositor-win32-x64-msvc": "4.0.462"
+        "@remotion/compositor-darwin-arm64": "4.0.465",
+        "@remotion/compositor-darwin-x64": "4.0.465",
+        "@remotion/compositor-linux-arm64-gnu": "4.0.465",
+        "@remotion/compositor-linux-arm64-musl": "4.0.465",
+        "@remotion/compositor-linux-x64-gnu": "4.0.465",
+        "@remotion/compositor-linux-x64-musl": "4.0.465",
+        "@remotion/compositor-win32-x64-msvc": "4.0.465"
       },
       "peerDependencies": {
         "react": ">=16.8.0",
@@ -8200,54 +8271,32 @@
         "webidl-conversions": "^4.0.2"
       }
     },
-    "node_modules/@remotion/renderer/node_modules/ws": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
-      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@remotion/streaming": {
-      "version": "4.0.462",
-      "resolved": "https://registry.npmjs.org/@remotion/streaming/-/streaming-4.0.462.tgz",
-      "integrity": "sha512-o3+GgxZURUr1wwlTSKg3JRIF/r3ctSMUrMFB3rjxlcXKNW4Z/Izkho2lWmZlONYtZHJVshg6hfS3OxjTK2zwdA==",
+      "version": "4.0.465",
+      "resolved": "https://registry.npmjs.org/@remotion/streaming/-/streaming-4.0.465.tgz",
+      "integrity": "sha512-TIPO4Powwb9z8QyiAsysfSfzFoQzyv8Fig3sovXHR+xHoWX1pVyYfDIvKuq3Eioc6chIyFrZvu9vdinWRU9Xjw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@remotion/studio": {
-      "version": "4.0.462",
-      "resolved": "https://registry.npmjs.org/@remotion/studio/-/studio-4.0.462.tgz",
-      "integrity": "sha512-Rl+VhBesr1cCDuFogE2p+oAIF/IVM0fQYZDWWSLHFwF37gb6jLIfEgrrFqgarPwNTAEZwY2qqr2c7J3uooeH1Q==",
+      "version": "4.0.465",
+      "resolved": "https://registry.npmjs.org/@remotion/studio/-/studio-4.0.465.tgz",
+      "integrity": "sha512-saopO0Eyg0hIPD7II3fXvjL7TRgkIcMmPPl/ax5fFBDrywGbFk5QpJdwOxpqv5xM0zsU/1nmQBua+vffjtiPqg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "0.3.31",
-        "@remotion/media-utils": "4.0.462",
-        "@remotion/player": "4.0.462",
-        "@remotion/renderer": "4.0.462",
-        "@remotion/studio-shared": "4.0.462",
-        "@remotion/timeline-utils": "4.0.462",
-        "@remotion/web-renderer": "4.0.462",
-        "@remotion/zod-types": "4.0.462",
+        "@remotion/media-utils": "4.0.465",
+        "@remotion/player": "4.0.465",
+        "@remotion/renderer": "4.0.465",
+        "@remotion/studio-shared": "4.0.465",
+        "@remotion/timeline-utils": "4.0.465",
+        "@remotion/web-renderer": "4.0.465",
+        "@remotion/zod-types": "4.0.465",
         "mediabunny": "1.45.0",
         "memfs": "3.4.3",
         "open": "8.4.2",
-        "remotion": "4.0.462",
+        "remotion": "4.0.465",
         "semver": "7.5.3",
         "zod": "4.3.6"
       },
@@ -8257,22 +8306,22 @@
       }
     },
     "node_modules/@remotion/studio-server": {
-      "version": "4.0.462",
-      "resolved": "https://registry.npmjs.org/@remotion/studio-server/-/studio-server-4.0.462.tgz",
-      "integrity": "sha512-RI4KwdLju6yKO1IDDAtLVy0gelYf+rfLqhpRpRoutFj3X9euajbX2o7Fghfc3Qn6UfAz3VA78U8z4ZO75BAeQg==",
+      "version": "4.0.465",
+      "resolved": "https://registry.npmjs.org/@remotion/studio-server/-/studio-server-4.0.465.tgz",
+      "integrity": "sha512-6BaGRqgSZ+TrnW9FukbxUTcV13SpNdtylHcLqz0435SrWIRzdMW8D1t5nWK6mgRDS/azsygEqNdN9i801U5nRA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "7.24.1",
         "@babel/types": "7.24.0",
-        "@remotion/bundler": "4.0.462",
-        "@remotion/renderer": "4.0.462",
-        "@remotion/studio-shared": "4.0.462",
+        "@remotion/bundler": "4.0.465",
+        "@remotion/renderer": "4.0.465",
+        "@remotion/studio-shared": "4.0.465",
         "memfs": "3.4.3",
         "open": "8.4.2",
         "prettier": "3.8.1",
         "recast": "0.23.11",
-        "remotion": "4.0.462",
+        "remotion": "4.0.465",
         "semver": "7.5.3"
       }
     },
@@ -8292,13 +8341,13 @@
       }
     },
     "node_modules/@remotion/studio-shared": {
-      "version": "4.0.462",
-      "resolved": "https://registry.npmjs.org/@remotion/studio-shared/-/studio-shared-4.0.462.tgz",
-      "integrity": "sha512-j8Q5+E4IWqpKWwSanxGI7+WG1rblpyf9Fb65cUoXmGrC28gq+dMqvPo+od2gSd77hfKZ80Po1u45cdP83B9tNA==",
+      "version": "4.0.465",
+      "resolved": "https://registry.npmjs.org/@remotion/studio-shared/-/studio-shared-4.0.465.tgz",
+      "integrity": "sha512-kD/Vu5JIfpoQzI4N3It/5xEYYc2eqazmKRSzDX2e9vc/qQ2RaoOgHo5YUtyR9AH1NzfhK2u1xCOhN6rbAC8uXw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "remotion": "4.0.462"
+        "remotion": "4.0.465"
       }
     },
     "node_modules/@remotion/studio/node_modules/zod": {
@@ -8312,9 +8361,9 @@
       }
     },
     "node_modules/@remotion/timeline-utils": {
-      "version": "4.0.462",
-      "resolved": "https://registry.npmjs.org/@remotion/timeline-utils/-/timeline-utils-4.0.462.tgz",
-      "integrity": "sha512-xC6ErhwO9Jz6oP+0vfJHJVxEl7ZVTbyJOEbz4BzT1h0Wq4f6d9hH7d8VvmrvZ2IQwb1VaqrkR7URvaW+VfJ14A==",
+      "version": "4.0.465",
+      "resolved": "https://registry.npmjs.org/@remotion/timeline-utils/-/timeline-utils-4.0.465.tgz",
+      "integrity": "sha512-LHFHgPKenkjWJpa36NTtQcLzchWKvryABwrRPktSOLbXrqQgIiQz8he5VSX/4D8Rty+Q8r1ETgfnfUGO0uM/lg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8322,18 +8371,18 @@
       }
     },
     "node_modules/@remotion/web-renderer": {
-      "version": "4.0.462",
-      "resolved": "https://registry.npmjs.org/@remotion/web-renderer/-/web-renderer-4.0.462.tgz",
-      "integrity": "sha512-Wj2IIACwNaRWGxc79LKs1vzbIEzhvs63u1rnJwvh+EDuHbhMZBCU7wJGVuSKZifNsKb9k999HiSS43d+j1OhpQ==",
+      "version": "4.0.465",
+      "resolved": "https://registry.npmjs.org/@remotion/web-renderer/-/web-renderer-4.0.465.tgz",
+      "integrity": "sha512-VPSQZ4SQo6eW1ufNebEtG2nIKNyCmrPMiHik3ZpSoViHMGxshaEM21G/JX8HVWadiSsOaW0w124zb+CGQioItA==",
       "dev": true,
       "license": "UNLICENSED",
       "dependencies": {
         "@mediabunny/aac-encoder": "1.45.0",
         "@mediabunny/flac-encoder": "1.45.0",
         "@mediabunny/mp3-encoder": "1.45.0",
-        "@remotion/licensing": "4.0.462",
+        "@remotion/licensing": "4.0.465",
         "mediabunny": "1.45.0",
-        "remotion": "4.0.462"
+        "remotion": "4.0.465"
       },
       "peerDependencies": {
         "react": ">=18.0.0",
@@ -8341,13 +8390,13 @@
       }
     },
     "node_modules/@remotion/zod-types": {
-      "version": "4.0.462",
-      "resolved": "https://registry.npmjs.org/@remotion/zod-types/-/zod-types-4.0.462.tgz",
-      "integrity": "sha512-q+wgcvD4AVFg17hPvpklZUU1oUt/A/tK1dTNi1o7NyXZmqic3Ko0iZpW01lEe5AsOW7so4XSWgv89Gs+r/R4dQ==",
+      "version": "4.0.465",
+      "resolved": "https://registry.npmjs.org/@remotion/zod-types/-/zod-types-4.0.465.tgz",
+      "integrity": "sha512-zxK4w2xy33AAAIL0Yi/hdNhrk6LQIDNwsveWgtEaL5YXEJ4sOXNwqOdotYfb+Vb+K0DZ/j6XNRUjf1tVJFG2Bg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "remotion": "4.0.462"
+        "remotion": "4.0.465"
       },
       "peerDependencies": {
         "zod": "4.3.6"
@@ -9608,17 +9657,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/yauzl": {
-      "version": "2.10.3",
-      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
-      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@ungap/structured-clone": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
@@ -10457,14 +10495,40 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.2.tgz",
-      "integrity": "sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
+      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.4",
-        "proxy-from-env": "^1.1.0"
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/axios/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/babel-jest": {
@@ -10691,9 +10755,9 @@
       "license": "MIT"
     },
     "node_modules/body-parser": {
-      "version": "1.20.4",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
-      "integrity": "sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==",
+      "version": "1.20.5",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
+      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
       "license": "MIT",
       "dependencies": {
         "bytes": "~3.1.2",
@@ -10704,7 +10768,7 @@
         "http-errors": "~2.0.1",
         "iconv-lite": "~0.4.24",
         "on-finished": "~2.4.1",
-        "qs": "~6.14.0",
+        "qs": "~6.15.1",
         "raw-body": "~2.5.3",
         "type-is": "~1.6.18",
         "unpipe": "~1.0.0"
@@ -10806,16 +10870,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "node-int64": "^0.4.0"
-      }
-    },
-    "node_modules/buffer-crc32": {
-      "version": "0.2.13",
-      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/buffer-from": {
@@ -12265,16 +12319,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/end-of-stream": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
-      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "once": "^1.4.0"
-      }
-    },
     "node_modules/enhanced-resolve": {
       "version": "5.20.0",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.0.tgz",
@@ -12720,14 +12764,14 @@
       }
     },
     "node_modules/express": {
-      "version": "4.22.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
-      "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
+      "version": "4.22.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
+      "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
       "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "~1.20.3",
+        "body-parser": "~1.20.5",
         "content-disposition": "~0.5.4",
         "content-type": "~1.0.4",
         "cookie": "~0.7.1",
@@ -12746,7 +12790,7 @@
         "parseurl": "~1.3.3",
         "path-to-regexp": "~0.1.12",
         "proxy-addr": "~2.0.7",
-        "qs": "~6.14.0",
+        "qs": "~6.15.1",
         "range-parser": "~1.2.1",
         "safe-buffer": "5.2.1",
         "send": "~0.19.0",
@@ -12803,43 +12847,6 @@
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
-    },
-    "node_modules/extract-zip": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
-      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "debug": "^4.1.1",
-        "get-stream": "^5.1.0",
-        "yauzl": "^2.10.0"
-      },
-      "bin": {
-        "extract-zip": "cli.js"
-      },
-      "engines": {
-        "node": ">= 10.17.0"
-      },
-      "optionalDependencies": {
-        "@types/yauzl": "^2.9.1"
-      }
-    },
-    "node_modules/extract-zip/node_modules/get-stream": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "pump": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -12955,16 +12962,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "bser": "2.1.1"
-      }
-    },
-    "node_modules/fd-slicer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "pend": "~1.2.0"
       }
     },
     "node_modules/fdir": {
@@ -13739,9 +13736,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -15784,12 +15781,12 @@
       }
     },
     "node_modules/js-cookie": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
-      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.7.tgz",
+      "integrity": "sha512-z/wZZgDrkNV1eA0ULjM/F9/50Ya8fbzgKneSpoPsXSGd0KnpdtHfOZWK+GcwLk+EZbS4F9RBhU+K2RgzuDaItw==",
       "license": "MIT",
       "engines": {
-        "node": ">=14"
+        "node": ">=20"
       }
     },
     "node_modules/js-tokens": {
@@ -17470,9 +17467,9 @@
       }
     },
     "node_modules/next/node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "funding": [
         {
           "type": "github",
@@ -18025,13 +18022,6 @@
         "@napi-rs/canvas": "^0.1.80"
       }
     },
-    "node_modules/pend": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
@@ -18521,20 +18511,12 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
-    },
-    "node_modules/pump": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
-      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
-      "dev": true,
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
       "license": "MIT",
-      "dependencies": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/punycode": {
@@ -18564,9 +18546,9 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -19310,9 +19292,9 @@
       }
     },
     "node_modules/remotion": {
-      "version": "4.0.462",
-      "resolved": "https://registry.npmjs.org/remotion/-/remotion-4.0.462.tgz",
-      "integrity": "sha512-0bcwIiN7H0IcHtcDlfWHE2ho46RF0VmnVN1fAc26uMkonmAMMhqB+1aogfTE8eiYESEzFokh0lRc0t6pI8wzNA==",
+      "version": "4.0.465",
+      "resolved": "https://registry.npmjs.org/remotion/-/remotion-4.0.465.tgz",
+      "integrity": "sha512-gcDuIFd6WZLTWUREY0KLll23VOuobC0jE5YztIeOh9GqG8as9LrPKZEHttUiA7McqKNUqaUT2XGq92SHyKvN1Q==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "peerDependencies": {
@@ -19815,9 +19797,9 @@
       }
     },
     "node_modules/sharp/node_modules/semver": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
-      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
       "license": "ISC",
       "optional": true,
       "bin": {
@@ -21127,9 +21109,9 @@
       "license": "0BSD"
     },
     "node_modules/tsx": {
-      "version": "4.22.1",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.1.tgz",
-      "integrity": "sha512-TvncJykhxAzFCk0VQZKBTClall4Pm7qXDSodb6uxi8QFa8X8mT6ABjxxsQ2opDRYxG7AzcRWXaFtruz5HJKuWg==",
+      "version": "4.22.3",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.3.tgz",
+      "integrity": "sha512-mdoNxBC/cSQObGGVQ5Bpn5i+yv7j68gk3Nfm3wFjcJg3Z0Mix9jzAFfP12prmm5eVGmDKtp0yyArrs0Q+8gZHg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -22647,9 +22629,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -22776,17 +22758,6 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/yauzl": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "buffer-crc32": "~0.2.3",
-        "fd-slicer": "~1.1.0"
       }
     },
     "node_modules/yn": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@clerk/nextjs": "^6.39.3",
     "@clerk/themes": "^2.4.57",
-    "@ducanh2912/next-pwa": "^10.2.9",
+    "@ducanh2912/next-pwa": "^10.2.6",
     "@hookform/resolvers": "5.2.2",
     "@inngest/agent-kit": "0.13.2",
     "@neondatabase/serverless": "1.0.2",
@@ -46,7 +46,7 @@
     "@types/react-syntax-highlighter": "^15.5.13",
     "@upstash/ratelimit": "^2.0.8",
     "@upstash/redis": "^1.38.0",
-    "axios": "1.13.2",
+    "axios": "^1.16.1",
     "class-variance-authority": "0.7.1",
     "clsx": "2.1.1",
     "cmdk": "1.1.1",


### PR DESCRIPTION
# feat: add doubt status tracking (unsolved -> in-progress -> solved)
 
Closes #183
 
## Summary
 
Doubts currently live in a binary `unsolved` / `solved` state, which loses information about doubts that have received help but haven't been formally resolved yet. This PR introduces an `in-progress` intermediate state and wires it through the data layer, the reply pipeline, the doubt card UI, and the doubt feeds.
The transition is **automatic** on the first reply for non-AI doubts, and **explicit** when an owner or teacher uses the "Mark Solved" action. The underlying column (`doubtsTable.isSolved`) already accepts arbitrary `varchar(20)` values, so no real SQL migration is required: only an application-layer change with a Drizzle metadata refresh.
 
## Acceptance Criteria
 
- [x] **Schema supports three status values**: `doubtsTable.isSolved` now documents the tri-state in `configs/schema.ts`, and `lib/doubtStatus.ts` centralises the values.
- [x] **Auto-transition logic implemented in reply creation**: `POST /api/replies` transitions `unsolved → in-progress` when the first reply is posted on a non-AI doubt. Guarded against races and sticky-solved downgrades.
- [x] **Visual status badges on doubt cards**: `DoubtCard.tsx` renders red (`Unsolved`) / amber (`In Progress`) / emerald (`Solved`) badges.
- [x] **Filter by status in doubt feed**: Three-pill filter on the classroom Community Board and Teacher Doubts tabs, plus a four-pill (`All` / `Unsolved` / `In Progress` / `Solved`) filter on the public board.

## Files changed
 
| File | Change |
| --- | --- |
| `lib/doubtStatus.ts` | **new**: `DOUBT_STATUS` constants, `DoubtStatus` type, `isValidDoubtStatus`, `isOpen` |
| `configs/schema.ts` | comment update on `isSolved` |
| `app/api/replies/route.ts` | auto-transition on reply insert |
| `app/api/doubts/action/[id]/route.ts` | accepts optional `status` body field, validated |
| `components/DoubtCard.tsx` | tri-state badge (adds `Clock` lucide icon) |
| `app/public-rooms/page.tsx` | new status filter row + filtered render |
| `app/rooms/[id]/page.tsx` | 3-pill filter on both Community Board + Teacher Doubts tabs |
| `__tests__/api/replies-auto-transition.test.ts` | **new**: 5 behaviour tests + 3 helper unit tests |
 
## Design decisions
 
- **Column name retained.** The DB column stays `isSolved` to keep the diff scoped - renaming touches the analytics aggregation, every feed filter and the existing API surface. The constants module records the new semantics.
- **Any reply transitions, not just `solution` type.** Issue #183 says "when the first reply is posted," so a `comment`-type reply also moves the doubt forward. If a stricter rule is wanted later (e.g: only `solution` replies trigger), it's a one-line change, and I'm more than happy to address that.
- **AI doubts are excluded** from auto-transition. AI doubts have a separate teacher-verification flow and a community reply on them shouldn't change their state.
- **`solved` is sticky.** A new reply on a solved doubt does not downgrade it to `in-progress`. The transition update has `WHERE isSolved = 'unsolved'` so the rule is enforced at the DB layer, not just in JS.
- **Safe against race conditions** Two near-simultaneous replies on an `unsolved` doubt both fire the transition update, but the `WHERE` clause makes the second one a no-op rather than a flip-flop.
- **Best-effort.** The transition is wrapped in try/catch: if the DB blips, the reply still succeeds. The user-facing operation (post a reply) must not fail because of a non-critical status bookkeeping operation.
- **Defensive `solvedReplyId` clear.** The action route now always nullifies `solvedReplyId` when leaving the `solved` state, including via the new explicit `status` path. Stale FK avoided.

## Migration
 
No data backfill is needed: existing `unsolved` and `solved` values remain valid. After pulling this branch:
 
```bash
npx drizzle-kit generate
```
 
Drizzle will emit a near-empty migration capturing the comment metadata. Commit that file alongside this PR.
 
## How to test
 
### Automated
 
```bash
npm test -- replies-auto-transition
```
 
Expected:
 
```
PASS  __tests__/api/replies-auto-transition.test.ts
  lib/doubtStatus
    ✓ isValidDoubtStatus accepts the three canonical values
    ✓ isValidDoubtStatus rejects everything else
    ✓ isOpen is true for unsolved and in-progress, false for solved
  POST /api/replies — auto-transition (issue #183)
    ✓ unsolved community doubt is transitioned to in-progress after a reply
    ✓ in-progress doubt is left alone (idempotent)
    ✓ solved doubt is NEVER downgraded by a new reply
    ✓ AI-typed doubts are excluded from auto-transition
    ✓ transition failure does not fail the reply insert
```
 
Full suite: `npm test`.
 
### Manual: local
 
1. Pull the branch, `npm install`, copy `.env.example` to `.env`, fill keys.
2. `npm run dev`, open <http://localhost:3000>.
3. Sign up + complete onboarding as a **student**.
4. Create or join a classroom (or post on `/public-rooms`).

**Scenario A - auto-transition (the core flow):**
 
1. Post a new doubt. The card badge shows red **Unsolved**.
2. Open replies (the message icon at the card footer) and post any reply, either as a comment or solution.
3. The card badge updates to amber **In Progress** within the next refresh (SWR's `mutate` is already wired in the existing replies modal).

**Scenario B: explicitly mark solved:**
 
1. From either an `Unsolved` or `In Progress` doubt you own, click **Mark Solved** in the card footer.
2. The badge flips to emerald **Solved** and the action button is replaced by **View Official Solution**.

**Scenario C: `solved` is sticky:**

1. On a `Solved` doubt, open replies and post a new comment.
2. The badge **stays** emerald **Solved**. It does not downgrade.
**Scenario D: AI doubt is excluded:**
 
1. Open the AI Solver, ask a question, save it to the feed (an `ai`-typed doubt).
2. From a second account that's a teacher in the same classroom, post a reply.
4. The AI doubt stays `Unsolved` — it does **not** transition to `In Progress`. Only the teacher's explicit Mark Solved moves it to `Solved`.

**Scenario E: feed filter (classroom):**
 
1. In `/rooms/<id>`, on the **Community Board** tab, toggle between the three pills: **Unsolved**, **In Progress**, **Resolved**.
2. Each pill renders only doubts in that state, with a matching colour-themed section header.
3. Repeat on the **Teacher Doubts** tab.
**Scenario F: feed filter (public board):**
 
1. Open `/public-rooms`.
2. Below the subject filter row, toggle between **All**, **Unsolved**, **In Progress**, **Solved**.
3. The list updates client-side. When the filter has no matches but doubts exist, a dedicated empty-state with a **Show all** escape button is rendered.

**Edge cases to spot-check:**
 
- Teacher attempting Mark Solved on a doubt with no `solution`-type reply still gets the existing "Teacher can only mark as solved if at least one official solution exists" error: that guard is preserved.
- The "Mark Solved" footer button appears for both `Unsolved` and `In Progress` doubts (it was always `isSolved !== "solved"`, which remains correct).
- Existing pinned, bookmarked and edit flows are unchanged.
### Manual - staging
 
Use the live demo at <https://doubt-desk-seven.vercel.app/> after this PR is merged + deployed. Until then the deployed instance shows binary status. Local testing is the source of truth for review.
 
## Screenshots

### Step 1: Posting a question at first
<img width="1917" height="888" alt="Screenshot 2026-05-24 130854" src="https://github.com/user-attachments/assets/8189caba-9db5-4b73-83d7-9eabf79f9932" />

### Step 2: Obtaining a comment on that question (no solution yet)
<img width="1919" height="885" alt="Screenshot 2026-05-24 131112" src="https://github.com/user-attachments/assets/25264259-d630-4e29-b51d-531ded82cfc2" />

And then:
<img width="1919" height="946" alt="Screenshot 2026-05-24 131049" src="https://github.com/user-attachments/assets/a4fd1369-711d-4dbd-a164-b646c377e4f9" />
                                                                                   
### Step 3: Solution is posted
<img width="1919" height="887" alt="Screenshot 2026-05-24 131609" src="https://github.com/user-attachments/assets/f3bfd6f9-0b99-4652-88ad-5159c9877f00" />

And then:
<img width="1919" height="944" alt="Screenshot 2026-05-24 131550" src="https://github.com/user-attachments/assets/e696a13d-9ac1-49a2-b728-b7854b943fc9" />

### Special case: reply to a question that's already solved
<img width="1918" height="937" alt="Screenshot 2026-05-24 131720" src="https://github.com/user-attachments/assets/4c6b1484-0cb9-4463-9132-b12591b0758f" />

<img width="1919" height="945" alt="Screenshot 2026-05-24 131753" src="https://github.com/user-attachments/assets/03a9d98f-d2b5-4da5-b42e-fd59985ef4c0" />

### Special case: filters
<img width="1919" height="886" alt="Screenshot 2026-05-24 131806" src="https://github.com/user-attachments/assets/0a95f195-d911-477f-a887-1ab30b3b49bc" />

 
## Out of scope (deliberate)
 
These showed up while writing the PR but belong in their own issues:
 
- The analytics donut on `rooms/[id]/page.tsx:680` treats anything not `solved` as "unresolved", which is the right call. Splitting the donut to surface in-progress as its own arc is a neat follow-up to include.
- `app/api/doubts/route.ts` parses `searchParams` twice (lines 11–18 and 25–30). Pre-existing bug, unrelated to status tracking.
- The two feed pages (`public-rooms` and `rooms/[id]`) duplicate large blocks of filter UI. A shared `DoubtFeedFilter` component would be worth extracting, but doing it in this PR balloons the diff. Maybe it can be explored as another follow-up feature.
- The codebase uses `doubt: any` everywhere instead of a shared `Doubt` type. Threading proper TS types is a separate refactor.


## Checklist
 
- [x] Conventional Commit title (`feat: ...`)
- [x] Closes the linked issue
- [x] Tests added for new behaviour
- [x] No new TypeScript `any` introduced (only follows existing patterns)
- [x] Drizzle migration committed alongside (run `npx drizzle-kit generate`)
- [ ] Screenshots attached
- [x] Manual verification steps documented