### PR TITLE
fix: add authentication to video script endpoint

### DIFF
--- a/app/api/video/script/route.ts
+++ b/app/api/video/script/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import Groq from 'groq-sdk';
+import { currentUser } from '@clerk/nextjs/server';
 
 const groq = new Groq({
     apiKey: process.env.GROQ_API_KEY,
@@ -7,8 +8,12 @@ const groq = new Groq({
 
 export async function POST(req: Request) {
     try {
-        const { content } = await req.json();
+        const user = await currentUser();
+        if (!user) {
+            return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+        }
 
+        const { content } = await req.json();
         if (!content) {
             return NextResponse.json({ error: 'Content is required' }, { status: 400 });
         }
@@ -18,7 +23,6 @@ Each scene must have:
 1. "title": A short title for the slide.
 2. "text": The explanation text to be shown on the slide and narrated.
 3. "duration": estimated duration in seconds (usually 5-10s).
-
 Return ONLY a JSON array of objects.`;
 
         const completion = await groq.chat.completions.create({
@@ -33,7 +37,6 @@ Return ONLY a JSON array of objects.`;
 
         const scriptJson = JSON.parse(completion.choices[0]?.message?.content || "{\"scenes\": []}");
         return NextResponse.json(scriptJson);
-
     } catch (error: any) {
         console.error('Script generation failed:', error);
         return NextResponse.json({ error: 'Failed to generate script' }, { status: 500 });

--- a/app/api/video/script/route.ts
+++ b/app/api/video/script/route.ts
@@ -2,16 +2,16 @@ import { NextResponse } from 'next/server';
 import Groq from 'groq-sdk';
 import { currentUser } from '@clerk/nextjs/server';
 
-const groq = new Groq({
-    apiKey: process.env.GROQ_API_KEY,
-});
-
 export async function POST(req: Request) {
     try {
         const user = await currentUser();
         if (!user) {
             return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
         }
+
+        const groq = new Groq({
+            apiKey: process.env.GROQ_API_KEY,
+        });
 
         const { content } = await req.json();
         if (!content) {


### PR DESCRIPTION
## Description
`POST /api/video/script` had no authentication check, allowing unauthenticated users to freely consume Groq AI credits without a valid Clerk session. This PR adds `currentUser()` from Clerk at the top of the handler, returning `401 Unauthorized` for unauthenticated requests — consistent with `/api/video/generate` and all other protected routes in the project.

Also moved the Groq client instantiation inside the handler to prevent a module-level crash when `GROQ_API_KEY` is not set in the environment.

Note: The issue originally identified both `/api/video/generate` and `/api/video/script` as unprotected. After pulling the latest `main`, `/api/video/generate/route.ts` already had auth added. This PR addresses the remaining unprotected endpoint.

## Related Issue
Closes #240

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Documentation update (README, guides, comments)
- [ ] Style / UI change (no logic change)
- [ ] Code refactor (no behavior change)
- [ ] Test addition or update
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Screenshots (if UI change)
N/A — API-level fix, no UI changes.

## How Has This Been Tested?
- [x] Tested locally with `npm run dev`
- [ ] Verified on mobile viewport (375px)
- [ ] Verified on desktop viewport (1440px)

Sent a POST request to `/api/video/script` without a Clerk session — endpoint returns `{"error":"Unauthorized"}` with status `401` as expected.

## Checklist
- [x] I have tested my changes locally (`npm run dev`)
- [x] My code follows the existing code style (TypeScript, Tailwind, no `any` types)
- [x] I have not introduced unrelated changes (each PR should address one issue)
- [x] I have added comments where necessary
- [x] My branch is up to date with `main`
- [x] I have linked the related issue above
- [ ] Screenshots are included (if this is a UI change)