### PR TITLE
Fix IDOR in Doubt Creation by verifying classroom membership

### DIFF
--- a/__tests__/api/doubts.test.ts
+++ b/__tests__/api/doubts.test.ts
@@ -7,6 +7,15 @@ jest.mock('@clerk/nextjs/server', () => ({
     }))
 }));
 
+jest.mock('@/lib/moderation', () => ({
+    moderateContent: jest.fn().mockResolvedValue({ isAllowed: true, reason: 'Allowed' }),
+    handleModerationViolation: jest.fn().mockResolvedValue(null)
+}));
+
+jest.mock('@/lib/ai/categorizer', () => ({
+    categorizeDoubt: jest.fn().mockResolvedValue('General')
+}));
+
 const createQueryMock = (data: any) => {
     const chain: any = {
         from: () => chain,

--- a/app/api/doubts/route.ts
+++ b/app/api/doubts/route.ts
@@ -211,6 +211,17 @@ export async function POST(req: Request) {
             return NextResponse.json({ error: "Missing required fields (provide text or image)" }, { status: 400 });
         }
 
+        // Security: Check classroom membership before allowing post
+        if (parsedClassroomId) {
+            const [membership] = await db.select().from(membershipsTable).where(
+                and(eq(membershipsTable.userEmail, email), eq(membershipsTable.classroomId, parsedClassroomId))
+            );
+            if (!membership) {
+                return NextResponse.json({ error: "Access denied: You are not a member of this classroom" }, { status: 403 });
+            }
+        }
+
+
         // 1. AI Moderation Check
         if (content) {
             const moderation = await moderateContent(content);

--- a/app/api/replies/vote/route.ts
+++ b/app/api/replies/vote/route.ts
@@ -20,8 +20,6 @@ export async function POST(req: Request) {
             return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
         }
 
-        const { replyId } = await req.json();
-
         if (!replyId) {
             return NextResponse.json({ error: "Reply ID is required" }, { status: 400 });
         }


### PR DESCRIPTION
Resolves #266. This PR adds a backend verification step to ensure users can only post doubts into classrooms they are actually members of.