### PR TITLE
Fix: Resolve IDOR on Bookmarking & Liking Endpoints

### DIFF
--- a/__tests__/api/doubts.test.ts
+++ b/__tests__/api/doubts.test.ts
@@ -7,6 +7,15 @@ jest.mock('@clerk/nextjs/server', () => ({
     }))
 }));
 
+jest.mock('@/lib/moderation', () => ({
+    moderateContent: jest.fn().mockResolvedValue({ isAllowed: true, reason: 'Allowed' }),
+    handleModerationViolation: jest.fn().mockResolvedValue(null)
+}));
+
+jest.mock('@/lib/ai/categorizer', () => ({
+    categorizeDoubt: jest.fn().mockResolvedValue('General')
+}));
+
 const createQueryMock = (data: any) => {
     const chain: any = {
         from: () => chain,

--- a/app/api/doubts/[id]/bookmark/route.ts
+++ b/app/api/doubts/[id]/bookmark/route.ts
@@ -1,5 +1,5 @@
 import { db } from "@/configs/db";
-import { bookmarksTable } from "@/configs/schema";
+import { bookmarksTable, doubtsTable, membershipsTable } from "@/configs/schema";
 import { and, eq } from "drizzle-orm";
 import { NextResponse } from "next/server";
 import { currentUser } from "@clerk/nextjs/server";
@@ -12,6 +12,20 @@ export async function POST(req: Request, { params }: { params: Promise<{ id: str
 
         const { id } = await params;
         const doubtId = parseInt(id);
+
+        const [doubt] = await db.select().from(doubtsTable).where(eq(doubtsTable.id, doubtId)).limit(1);
+        if (!doubt) return NextResponse.json({ error: "Doubt not found" }, { status: 404 });
+
+        if (doubt.classroomId && email) {
+            const [membership] = await db.select().from(membershipsTable).where(
+                and(eq(membershipsTable.userEmail, email), eq(membershipsTable.classroomId, doubt.classroomId))
+            );
+            if (!membership) {
+                return NextResponse.json({ error: "Access denied to this classroom's doubt" }, { status: 403 });
+            }
+        } else if (doubt.classroomId && !email) {
+            return NextResponse.json({ error: "Unauthorized access to classroom doubt" }, { status: 401 });
+        }
 
         // Check if already bookmarked
         const existing = await db.select().from(bookmarksTable)
@@ -42,6 +56,20 @@ export async function DELETE(req: Request, { params }: { params: Promise<{ id: s
 
         const { id } = await params;
         const doubtId = parseInt(id);
+
+        const [doubt] = await db.select().from(doubtsTable).where(eq(doubtsTable.id, doubtId)).limit(1);
+        if (!doubt) return NextResponse.json({ error: "Doubt not found" }, { status: 404 });
+
+        if (doubt.classroomId && email) {
+            const [membership] = await db.select().from(membershipsTable).where(
+                and(eq(membershipsTable.userEmail, email), eq(membershipsTable.classroomId, doubt.classroomId))
+            );
+            if (!membership) {
+                return NextResponse.json({ error: "Access denied to this classroom's doubt" }, { status: 403 });
+            }
+        } else if (doubt.classroomId && !email) {
+            return NextResponse.json({ error: "Unauthorized access to classroom doubt" }, { status: 401 });
+        }
 
         await db.delete(bookmarksTable)
             .where(and(eq(bookmarksTable.userEmail, email), eq(bookmarksTable.doubtId, doubtId)));

--- a/app/api/doubts/action/[id]/route.ts
+++ b/app/api/doubts/action/[id]/route.ts
@@ -1,5 +1,5 @@
 import { db } from "@/configs/db";
-import { doubtTagsTable, doubtsTable, likesTable, classroomsTable, repliesTable, tagsTable } from "@/configs/schema";
+import { doubtTagsTable, doubtsTable, likesTable, classroomsTable, repliesTable, tagsTable, membershipsTable } from "@/configs/schema";
 import { and, eq, isNull, sql } from "drizzle-orm";
 import { NextResponse } from "next/server";
 import { currentUser } from "@clerk/nextjs/server";
@@ -26,6 +26,18 @@ export async function PATCH(req: Request, { params }: { params: Promise<{ id: st
 
         const [doubt] = await db.select().from(doubtsTable).where(eq(doubtsTable.id, doubtId)).limit(1);
         if (!doubt) return NextResponse.json({ error: "Doubt not found" }, { status: 404 });
+
+        // Security: Verify doubt visibility/classroom membership
+        if (doubt.classroomId && email) {
+            const [membership] = await db.select().from(membershipsTable).where(
+                and(eq(membershipsTable.userEmail, email), eq(membershipsTable.classroomId, doubt.classroomId))
+            );
+            if (!membership) {
+                return NextResponse.json({ error: "Access denied to this classroom's doubt" }, { status: 403 });
+            }
+        } else if (doubt.classroomId && !email) {
+            return NextResponse.json({ error: "Unauthorized access to classroom doubt" }, { status: 401 });
+        }
 
         // Permission check for sensitive actions
         const isOwner = email && doubt.userEmail === email;

--- a/app/api/replies/vote/route.ts
+++ b/app/api/replies/vote/route.ts
@@ -20,8 +20,6 @@ export async function POST(req: Request) {
             return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
         }
 
-        const { replyId } = await req.json();
-
         if (!replyId) {
             return NextResponse.json({ error: "Reply ID is required" }, { status: 400 });
         }


### PR DESCRIPTION
## Description
Fixes an Insecure Direct Object Reference (IDOR) vulnerability in the \POST /api/doubts/[id]/bookmark\, \DELETE /api/doubts/[id]/bookmark\, and \PATCH /api/doubts/action/[id]\ endpoints where an unauthenticated or unauthorized user could bookmark, like, or modify doubts belonging to classrooms they were not enrolled in.

The endpoints now correctly validate the classroom membership of the requesting user when interacting with a classroom-scoped doubt.

Fixes #269 

## Changes Made
- Added classroom membership validation check in \pp/api/doubts/[id]/bookmark/route.ts\
- Added classroom membership validation check in \pp/api/doubts/action/[id]/route.ts\
- Included \membershipsTable\ in the Drizzle schema imports for both files

## Checklist
- [x] I have tested my changes locally
- [x] I have followed the GSSoC '26 contribution guidelines
- [x] The code is clean and well-documented