### PR TITLE
fix: use MIN instead of MAX for chatTitle aggregation (GSSOC 26)

### DIFF
--- a/scripts/test-db.ts
+++ b/scripts/test-db.ts
@@ -21,7 +21,7 @@ async function testQuery() {
         const sessions = await db
             .select({
                 chatId: chatHistoryTable.chatId,
-                chatTitle: sql<string>`MAX(${chatHistoryTable.chatTitle})`,
+                chatTitle: sql<string>`MIN(${chatHistoryTable.chatTitle})`,
                 createdAt: sql<string>`MAX(${chatHistoryTable.createdAt})`,
             })
             .from(chatHistoryTable)


### PR DESCRIPTION
## Description
Replaced `MAX(chatTitle)` with `MIN(chatTitle)` in the chat history 
session query. `MAX()` on a string column returns the alphabetically 
last value instead of the original chat title, causing incorrect 
titles to be displayed.

## Related Issue
Closes #289 

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Screenshots (if UI change)
N/A — this is a backend query fix with no UI change.

## How Has This Been Tested?
- [x] Tested locally with `npm run dev`
- [ ] Verified on mobile viewport (375px)
- [ ] Verified on desktop viewport (1440px)

Manually verified that the returned `chatTitle` matches the original 
title created for the chat session after switching to `MIN()`.

## Checklist
- [x] I have tested my changes locally (`npm run dev`)
- [x] My code follows the existing code style (TypeScript, Tailwind, no `any` types)
- [x] I have not introduced unrelated changes (each PR should address one issue)
- [x] I have added comments where necessary
- [x] My branch is up to date with `main`
- [x] I have linked the related issue above
- [ ] Screenshots are included (if this is a UI change)