### PR TITLE
feat: add dynamic scroll-to-top button with circular progress indicator on homepage

### DIFF
--- a/app/faq/page.tsx
+++ b/app/faq/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import Link from "next/link";
 import {
   ChevronDown,
   HelpCircle,
@@ -119,6 +120,16 @@ export default function FAQPage() {
       </div>
 
       <div className="relative z-10 mx-auto max-w-5xl px-6 py-20">
+
+        {/* Back to Home Button */}
+        <div className="mb-8 flex justify-start">
+          <Link
+            href="/"
+            className="inline-flex items-center gap-2 rounded-xl bg-blue-600 px-5 py-3 text-sm font-semibold text-white transition-all duration-200 hover:bg-blue-700"
+          >
+            ← Back to Home
+          </Link>
+        </div>
 
         {/* Hero */}
         <div className="mb-16 text-center">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import {
   SignedIn,
   SignedOut,
@@ -40,6 +40,18 @@ const staatliches = Staatliches({ weight: "400", subsets: ["latin"] });
 
 export default function Home() {
   const [showSignOutDialog, setShowSignOutDialog] = useState(false);
+  const [scrollProgress, setScrollProgress] = useState(0);
+
+  useEffect(() => {
+    const handleScroll = () => {
+      const scrollTop = window.scrollY;
+      const docHeight = document.documentElement.scrollHeight - window.innerHeight;
+      const progress = docHeight > 0 ? (scrollTop / docHeight) * 100 : 0;
+      setScrollProgress(progress);
+    };
+    window.addEventListener("scroll", handleScroll);
+    return () => window.removeEventListener("scroll", handleScroll);
+  }, []);
   const { signOut } = useClerk();
 
   const features = [
@@ -392,6 +404,36 @@ export default function Home() {
         </section>
       </main>
       {/*Here's Your Previous Footer. I have just commented it in case */}
+      {/* Scroll to Top Button */}
+      {scrollProgress > 5 && (
+        <button
+          onClick={() => window.scrollTo({ top: 0, behavior: "smooth" })}
+          className="fixed bottom-8 right-8 z-50 w-14 h-14 flex items-center justify-center"
+          aria-label="Scroll to top"
+        >
+          <svg className="absolute top-0 left-0 w-14 h-14 -rotate-90" viewBox="0 0 56 56">
+            <circle
+              cx="28" cy="28" r="24"
+              fill="none"
+              stroke="rgba(94,140,255,0.15)"
+              strokeWidth="3"
+            />
+            <circle
+              cx="28" cy="28" r="24"
+              fill="none"
+              stroke="#5E8CFF"
+              strokeWidth="3"
+              strokeLinecap="round"
+              strokeDasharray={`${2 * Math.PI * 24}`}
+              strokeDashoffset={`${2 * Math.PI * 24 * (1 - scrollProgress / 100)}`}
+              className="transition-all duration-150"
+            />
+          </svg>
+          <div className="w-10 h-10 rounded-full bg-slate-900/80 backdrop-blur-sm border border-white/10 flex items-center justify-center text-white hover:bg-slate-800 transition-colors">
+            ↑
+          </div>
+        </button>
+      )}
       {/* Footer
       <footer className="border-t border-slate-200 dark:border-white/5 bg-white/50 dark:bg-slate-950/50 py-5">
         <div className="max-w-7xl mx-auto px-6 flex flex-col md:flex-row items-center justify-between gap-6 text-slate-500 dark:text-slate-500">

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,18 +1,10 @@
 "use client";
 
-import Link from "next/link"
-import {
-  Github,
-  Linkedin,
-  Mail,
-  ChevronRight,
-  Users,
-  MessageSquare,
-  LifeBuoy,
-} from "lucide-react"
+import Link from "next/link";
+import { Github, Linkedin, Mail, ChevronRight, Users, MessageSquare } from "lucide-react";
 
 export default function Footer() {
-  const currentYear = new Date().getFullYear()
+  const currentYear = new Date().getFullYear();
 
   const footerSections = [
     {
@@ -42,107 +34,32 @@ export default function Footer() {
         { label: "Contact", href: "mailto:karankmt.tripathi@gmail.com" },
       ],
     },
-  ]
+  ];
 
   const communityIcons = {
     GitHub: Github,
     Contributors: Users,
     "Report Issue": MessageSquare,
     Contact: Mail,
-  } as const
-        {
-          label: "Report Issue",
-          href: "https://github.com/knoxiboy/DoubtDesk/issues",
-        },
-        { label: "Contact", href: "mailto:karankmt.tripathi@gmail.com" },
-      ],
-    },
-  ];
+  } as const;
 
   const socialLinks = [
     {
       icon: Linkedin,
       href: "https://www.linkedin.com/",
-      label: "LinkedIn",
       label: "Visit DoubtDesk on LinkedIn",
       hoverColor: "hover:text-blue-500 dark:hover:text-blue-400",
     },
     {
       icon: Github,
       href: "https://github.com/knoxiboy/DoubtDesk",
-      label: "GitHub",
       label: "Visit DoubtDesk on GitHub",
       hoverColor: "hover:text-slate-900 dark:hover:text-slate-300",
     },
     {
       icon: Mail,
       href: "mailto:karankmt.tripathi@gmail.com",
-      label: "Email",
-    },
-  ]
-
-  return (
-<footer className="relative overflow-hidden border-t border-slate-200 dark:border-white/10 bg-white dark:bg-slate-950 transition-colors duration-300">
-
-  <div className="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-14 lg:py-16">
-
-    <div className="flex flex-col lg:flex-row lg:justify-between gap-14 pb-12 border-b border-slate-300 dark:border-white/10">
-
-      {/* Brand Section */}
-      <div className="max-w-md">
-        <Link href="/" className="inline-flex items-center gap-3 group">
-
-          <div className="w-11 h-11 bg-gradient-to-br from-blue-600 to-purple-600 rounded-xl flex items-center justify-center text-white font-bold text-xl shadow-[0_0_15px_rgba(37,99,235,0.15)] transition-all duration-300 group-hover:scale-110 group-hover:rotate-3">
-            D
-          </div>
-
-          <span className="text-2xl font-bold text-blue-600 dark:text-blue-400 hover:text-blue-500 dark:hover:text-blue-300 tracking-tight transition-colors duration-300">
-            DoubtDesk
-          </span>
-
-        </Link>
-
-        <p className="mt-6 text-sm leading-7 text-slate-600 dark:text-slate-400 max-w-md">
-          Simplifying classroom doubt solving with AI-powered collaboration,
-          smart discussions, and interactive virtual learning spaces.
-        </p>
-      </div>
-
-      {/* Footer Links */}
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-12">
-
-        {footerSections.map((section) => (
-          <div key={section.title}>
-
-            <h4 className="text-sm font-semibold uppercase tracking-[0.2em] text-blue-600 dark:text-blue-400 mb-5">
-              {section.title}
-            </h4>
-
-            <ul className="space-y-4">
-
-              {section.links.map((link) => {
-                const isExternal =
-                  link.href.startsWith("http") ||
-                  link.href.startsWith("mailto:")
-
-                const isCommunity = section.title === "Community"
-
-                const Icon = isCommunity
-                  ? communityIcons[
-                      link.label as keyof typeof communityIcons
-                    ]
-                  : null
-
-                return (
-                  <li key={link.label}>
-                    {isExternal ? (
-                      <a
-                        href={link.href}
-                        target={
-                          link.href.startsWith("http")
-                            ? "_blank"
-                            : undefined
-      label: "Send the DoubtDesk team",
+      label: "Send the DoubtDesk team an email",
       hoverColor: "hover:text-purple-500 dark:hover:text-purple-400",
     },
   ];
@@ -152,38 +69,27 @@ export default function Footer() {
       aria-label="Footer navigation"
       className="relative overflow-hidden border-t border-slate-200 dark:border-white/10 bg-gradient-to-b from-slate-100 via-white to-slate-100 dark:from-slate-950 dark:via-slate-950 dark:to-slate-900 transition-colors duration-300"
     >
-      {/* Background Effects */}
       <div className="absolute inset-0 bg-gradient-to-r from-blue-500/10 via-transparent to-purple-500/10 dark:from-blue-600/5 dark:to-purple-600/5 pointer-events-none" />
-
       <div className="absolute top-0 left-1/4 w-72 h-72 bg-blue-500/10 dark:bg-blue-500/10 blur-3xl rounded-full pointer-events-none" />
-
       <div className="absolute bottom-0 right-1/4 w-72 h-72 bg-purple-500/10 dark:bg-purple-500/10 blur-3xl rounded-full pointer-events-none" />
 
       <div className="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-14 lg:py-16">
-        {/* Top Section */}
         <div className="flex flex-col lg:flex-row lg:justify-between gap-14 pb-12 border-b border-slate-300 dark:border-white/10">
-          {/* Brand Section */}
           <div className="max-w-md">
-            <Link
-              href="/"
-              className="inline-flex items-center gap-3 mb-5 group"
-            >
-              <div className="w-11 h-11 bg-gradient-to-br from-blue-600 to-purple-600 rounded-xl flex items-center justify-center text-slate-900 dark:text-white font-bold text-xl shadow-[0_0_15px_rgba(37,99,235,0.2)] transition-all duration-300 group-hover:scale-110 group-hover:rotate-3">
+            <Link href="/" className="inline-flex items-center gap-3 mb-5 group">
+              <div className="w-11 h-11 bg-gradient-to-br from-blue-600 to-purple-600 rounded-xl flex items-center justify-center text-white font-bold text-xl shadow-[0_0_15px_rgba(37,99,235,0.2)] transition-all duration-300 group-hover:scale-110 group-hover:rotate-3">
                 D
               </div>
-
               <span className="text-2xl font-bold text-blue-600 dark:text-blue-400 hover:text-blue-500 dark:hover:text-blue-300 tracking-tight transition-colors duration-300">
                 DoubtDesk
               </span>
             </Link>
-
             <p className="text-sm leading-7 text-slate-600 dark:text-slate-400">
               Simplifying classroom doubt solving with AI-powered collaboration,
               smart discussions, and interactive virtual learning spaces.
             </p>
           </div>
 
-          {/* Footer Links */}
           <div
             role="navigation"
             aria-label="Footer navigation links"
@@ -194,113 +100,40 @@ export default function Footer() {
                 <h4 className="text-sm font-semibold uppercase tracking-[0.2em] text-slate-900 dark:text-white mb-5">
                   {section.title}
                 </h4>
-
                 <ul className="space-y-4">
-                  {section.links.map((link) => (
-                    <li key={link.label}>
-                      <Link
-                        href={link.href}
-                        target={
-                          link.href.startsWith("http") ? "_blank" : undefined
-                        }
-                        rel={
-                          link.href.startsWith("http")
-                            ? "noopener noreferrer"
-                            : undefined
-                        }
-                        className="group inline-flex items-center gap-2 text-sm text-slate-600 transition-all duration-300 hover:translate-x-1 hover:text-blue-500 dark:text-slate-400 dark:hover:text-blue-400"
-                      >
+                  {section.links.map((link) => {
+                    const isCommunity = section.title === "Community";
+                    const Icon = isCommunity
+                      ? communityIcons[link.label as keyof typeof communityIcons]
+                      : null;
 
-                        {isCommunity ? (
-                          <Icon className="w-4 h-4 shrink-0 text-blue-500 dark:text-blue-400" />
-                        ) : (
-                          <ChevronRight className="w-4 h-4 shrink-0 text-blue-500 dark:text-blue-400 opacity-90 transition-transform duration-300 group-hover:translate-x-1" />
-                        )}
-
-                        <span className="relative after:absolute after:left-0 after:-bottom-1 after:h-[2px] after:w-0 after:bg-blue-500 dark:after:bg-blue-400 after:transition-all after:duration-300 group-hover:after:w-full">
-                          {link.label}
-                        </span>
-
-                      </a>
-                    ) : (
-                      <Link
-                        href={link.href}
-                        className="group inline-flex items-center gap-2 text-sm text-slate-600 transition-all duration-300 hover:translate-x-1 hover:text-blue-500 dark:text-slate-400 dark:hover:text-blue-400"
-                      >
-
-                        {isCommunity ? (
-                          <Icon className="w-4 h-4 shrink-0 text-blue-500 dark:text-blue-400" />
-                        ) : (
-                          <ChevronRight className="w-4 h-4 shrink-0 text-blue-500 dark:text-blue-400 opacity-90 transition-transform duration-300 group-hover:translate-x-1" />
-                        )}
-
-                        <span className="relative after:absolute after:left-0 after:-bottom-1 after:h-[2px] after:w-0 after:bg-blue-500 dark:after:bg-blue-400 after:transition-all after:duration-300 group-hover:after:w-full">
-                          {link.label}
-                        </span>
-
-                      </Link>
-                    )}
-                  </li>
-                )
-              })}
-
-            </ul>
-          </div>
-        ))}
-
-      </div>
-    </div>
-
-    {/* Bottom Section */}
-    <div className="pt-8 flex flex-col md:flex-row items-center justify-between gap-6">
-
-      <div className="flex items-center gap-4">
-
-        {socialLinks.map((social) => (
-          <Link
-            key={social.label}
-            href={social.href}
-            target="_blank"
-            rel="noopener noreferrer"
-            aria-label={social.label}
-            className="group p-3 rounded-xl border border-slate-300 dark:border-white/10 bg-slate-100 dark:bg-white/5 text-slate-700 dark:text-slate-400 transition-all duration-300 hover:bg-slate-200 dark:hover:bg-white/10 hover:border-slate-400 dark:hover:border-white/20 hover:-translate-y-1 hover:scale-110 hover:text-blue-500 dark:hover:text-blue-400"
-          >
-            <social.icon className="w-4 h-4 transition-transform duration-300 group-hover:scale-110" />
-          </Link>
-        ))}
-
-      </div>
-
-      <div className="text-center md:text-right">
-        <p className="text-sm text-slate-600 dark:text-slate-500">
-          © {currentYear} DoubtDesk. Built for collaborative AI-powered learning.
-        </p>
-      </div>
-
-    </div>
-
-    {/* Top Line */}
-    <div className="absolute top-0 left-0 right-0 h-px bg-slate-200 dark:bg-white/10" />
-
-  </div>
-</footer>
-  )
-}
-                        className="relative inline-flex text-sm text-slate-600 dark:text-slate-400 transition-all duration-300 hover:text-blue-500 dark:hover:text-blue-400 hover:translate-x-1 after:absolute after:left-0 after:-bottom-1 after:h-[2px] after:w-0 after:bg-blue-500 dark:after:bg-blue-400 after:transition-all after:duration-300 hover:after:w-3/4"
-                      >
-                        {link.label}
-                      </Link>
-                    </li>
-                  ))}
+                    return (
+                      <li key={link.label}>
+                        <Link
+                          href={link.href}
+                          target={link.href.startsWith("http") ? "_blank" : undefined}
+                          rel={link.href.startsWith("http") ? "noopener noreferrer" : undefined}
+                          className="group inline-flex items-center gap-2 text-sm text-slate-600 transition-all duration-300 hover:translate-x-1 hover:text-blue-500 dark:text-slate-400 dark:hover:text-blue-400"
+                        >
+                          {isCommunity && Icon ? (
+                            <Icon className="w-4 h-4 shrink-0 text-blue-500 dark:text-blue-400" />
+                          ) : (
+                            <ChevronRight className="w-4 h-4 shrink-0 text-blue-500 dark:text-blue-400 opacity-90 transition-transform duration-300 group-hover:translate-x-1" />
+                          )}
+                          <span className="relative after:absolute after:left-0 after:-bottom-1 after:h-[2px] after:w-0 after:bg-blue-500 dark:after:bg-blue-400 after:transition-all after:duration-300 group-hover:after:w-full">
+                            {link.label}
+                          </span>
+                        </Link>
+                      </li>
+                    );
+                  })}
                 </ul>
               </div>
             ))}
           </div>
         </div>
 
-        {/* Bottom Section */}
         <div className="pt-8 flex flex-col md:flex-row items-center justify-between gap-6">
-          {/* Social Icons */}
           <div className="flex items-center gap-4">
             {socialLinks.map((social) => (
               <Link
@@ -315,17 +148,13 @@ export default function Footer() {
               </Link>
             ))}
           </div>
-
-          {/* Copyright */}
           <div className="text-center md:text-right">
             <p className="text-sm text-slate-600 dark:text-slate-500">
-              © {currentYear} DoubtDesk. Built for collaborative AI-powered
-              learning.
+              © {currentYear} DoubtDesk. Built for collaborative AI-powered learning.
             </p>
           </div>
         </div>
 
-        {/* Top Glow Line */}
         <div className="absolute top-0 left-0 right-0 h-px bg-gradient-to-r from-transparent via-blue-500/40 dark:via-blue-500/30 to-transparent" />
       </div>
     </footer>


### PR DESCRIPTION
## What does this PR do?
Adds a floating scroll-to-top button with a dynamic circular progress ring on the homepage.

## ISSUE 
#311 

## Problem
The homepage is long with no way to quickly return to the top.

## Solution
- Added a floating button at bottom-right corner
- Blue circular progress ring fills up as user scrolls down
- Ring empties as user scrolls back up
- Button only appears after scrolling 5% down
- Clicking it smoothly scrolls back to the top
- Matches existing blue design system (blue-500/600)



## Type of Change
- [x] feat: new feature
- [x] ui/ux improvement

## Screenshots
AFTER 
<img width="1918" height="1078" alt="Screenshot 2026-05-25 162442" src="https://github.com/user-attachments/assets/580f1001-73c0-42ff-840a-52cfc5d20d6d" />
