### PR TITLE
fix: add block check and fix double body parse in video generate endpoint

### DIFF
--- a/app/api/video/generate/route.ts
+++ b/app/api/video/generate/route.ts
@@ -10,6 +10,7 @@ import Tesseract from 'tesseract.js';
 import { parseAndValidateRequest } from '@/lib/validations/validate';
 import { generateVideoSchema } from '@/lib/validations/video';
 import { currentUser } from '@clerk/nextjs/server';
+import { checkUserBlock } from '@/lib/auth-utils';
 import { redisClient } from '@/lib/ratelimit';
 
 const groq = new Groq({
@@ -22,26 +23,33 @@ export async function POST(req: Request) {
         return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
+    const email = user.primaryEmailAddress?.emailAddress;
+    if (!email) {
+        return NextResponse.json({ error: 'Email required' }, { status: 400 });
+    }
+
+    const { isBlocked, errorResponse: blockResponse } = await checkUserBlock(email);
+    if (isBlocked) return blockResponse;
+
     let lockKey = null;
     try {
         const { errorResponse, data } = await parseAndValidateRequest(req, generateVideoSchema);
         if (errorResponse) return errorResponse;
-        
+
         lockKey = `video_lock:${user.id}`;
         const lockAcquired = await redisClient.setnx(lockKey, "1");
-        
+
         if (!lockAcquired || lockAcquired === 0) {
-            return NextResponse.json({ 
-                error: 'A video generation is already in progress for your account. Please wait for it to finish.' 
+            return NextResponse.json({
+                error: 'A video generation is already in progress for your account. Please wait for it to finish.'
             }, { status: 429 });
         }
-        
-        // Ensure lock expires after 5 minutes to prevent deadlocks if process crashes
+
         if (redisClient.expire) {
             await redisClient.expire(lockKey, 300);
         }
 
-        let { content, imageUrl } = await req.json();
+        let { content, imageUrl } = data;
 
         // 1. OCR if image is provided
         if (imageUrl && !content) {


### PR DESCRIPTION
## Description
The video generation endpoint was missing a block check, allowing blocked users to trigger an expensive compute. The body was also being parsed twice. parseAndValidateRequest already consumes the request stream, so the subsequent req.json() call always returned an empty object, meaning content and imageUrl were always undefined from that point on. Added  a checkUserBlock after the auth check so blocked users receive 403 before any compute is triggered. Replaced req.json() with data from parseAndValidateRequest to fix the double body parse bug.

## Related Issue
<!-- Link the issue this PR addresses. Use "Closes #<number>" to auto-close the issue on merge. -->
Closes #147 

## Type of Change
<!-- Check the relevant option. -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Documentation update (README, guides, comments)
- [ ] Style / UI change (no logic change)
- [ ] Code refactor (no behavior change)
- [ ] Test addition or update
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Screenshots (if UI change)
<!-- Add before/after screenshots for any UI changes. Delete this section if not applicable. -->

N/A

## How Has This Been Tested?
<!-- Describe the tests you ran to verify your changes. -->
- [x] Tested locally with `npm run dev`
- [ ] Verified on mobile viewport (375px)
- [ ] Verified on desktop viewport (1440px)

## Checklist
- [x] I have tested my changes locally (`npm run dev`)
- [x] My code follows the existing code style (TypeScript, Tailwind, no `any` types)
- [x] I have not introduced unrelated changes (each PR should address one issue)
- [ ] I have added comments where necessary
- [x] My branch is up to date with `main`
- [x] I have linked the related issue above
- [ ] Screenshots are included (if this is a UI change)
