### PR TITLE
fix: harden reply vote endpoint with block check and consistent error handling

### DIFF
--- a/app/api/replies/vote/route.ts
+++ b/app/api/replies/vote/route.ts
@@ -23,6 +23,7 @@ export async function POST(req: Request) {
 
         if (email) {
             const { isBlocked, errorResponse: blockResponse } = await checkUserBlock(email);
+            if (blockResponse) return blockResponse;
             if (isBlocked) return blockResponse;
         }
 

--- a/app/api/replies/vote/route.ts
+++ b/app/api/replies/vote/route.ts
@@ -3,6 +3,8 @@ import { repliesTable, replyLikesTable } from "@/configs/schema";
 import { and, eq, sql } from "drizzle-orm";
 import { NextResponse } from "next/server";
 import { currentUser } from "@clerk/nextjs/server";
+import { checkUserBlock } from "@/lib/auth-utils";
+import { buildErrorResponse } from "@/lib/error-handler";
 import { parseAndValidateRequest } from "@/lib/validations/validate";
 import { voteReplySchema } from "@/lib/validations/reply";
 
@@ -11,45 +13,40 @@ export async function POST(req: Request) {
         const { errorResponse, data } = await parseAndValidateRequest(req, voteReplySchema);
         if (errorResponse) return errorResponse;
 
-        const { replyId, userName } = data;
+        const { replyId } = data;
 
         const user = await currentUser();
-        const authenticatedUserId = user?.id;
+        if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
-        if (!authenticatedUserId) {
-            return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+        const authenticatedUserId = user.id;
+        const email = user.primaryEmailAddress?.emailAddress;
+
+        if (email) {
+            const { isBlocked, errorResponse: blockResponse } = await checkUserBlock(email);
+            if (isBlocked) return blockResponse;
         }
 
-        if (!replyId) {
-            return NextResponse.json({ error: "Reply ID is required" }, { status: 400 });
-        }
-
-        // Check if reply exists
         const [reply] = await db.select().from(repliesTable).where(eq(repliesTable.id, replyId)).limit(1);
         if (!reply) {
             return NextResponse.json({ error: "Reply not found" }, { status: 404 });
         }
 
-        // Check if already upvoted (store stable identity: Clerk user id)
         const existingLike = await db.select()
             .from(replyLikesTable)
             .where(and(eq(replyLikesTable.userName, authenticatedUserId), eq(replyLikesTable.replyId, replyId)))
             .limit(1);
 
         if (existingLike.length > 0) {
-            // Unvote
             await db.delete(replyLikesTable)
                 .where(and(eq(replyLikesTable.userName, authenticatedUserId), eq(replyLikesTable.replyId, replyId)));
-            
+
             const updated = await db.update(repliesTable)
                 .set({ upvotes: sql`${repliesTable.upvotes} - 1` })
                 .where(eq(repliesTable.id, replyId))
                 .returning();
-            
+
             return NextResponse.json({ ...updated[0], hasUpvoted: false });
         } else {
-            // Vote
-            // Insert a stable identity for the like (use Clerk `user.id`)
             await db.insert(replyLikesTable).values({
                 userName: authenticatedUserId,
                 replyId
@@ -59,11 +56,11 @@ export async function POST(req: Request) {
                 .set({ upvotes: sql`${repliesTable.upvotes} + 1` })
                 .where(eq(repliesTable.id, replyId))
                 .returning();
-            
+
             return NextResponse.json({ ...updated[0], hasUpvoted: true });
         }
     } catch (error) {
-        console.error("Error voting on reply:", error);
-        return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+        const { status, body } = buildErrorResponse(error);
+        return NextResponse.json(body, { status });
     }
 }


### PR DESCRIPTION
## Description
Added checkUserBlock so blocked users cannot cast or remove votes on replies. Removed unused userName from data destructuring, removed a redundant replyId null check that Zod already handles, and updated the catch block to use buildErrorResponse for consistency with the rest of the codebase.

## Related Issue
<!-- Link the issue this PR addresses. Use "Closes #<number>" to auto-close the issue on merge. -->
Closes #149 

## Type of Change
<!-- Check the relevant option. -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Documentation update (README, guides, comments)
- [ ] Style / UI change (no logic change)
- [x] Code refactor (no behavior change)
- [ ] Test addition or update
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Screenshots (if UI change)
<!-- Add before/after screenshots for any UI changes. Delete this section if not applicable. -->
N/A

## How Has This Been Tested?
<!-- Describe the tests you ran to verify your changes. -->
- [x] Tested locally with `npm run dev`
- [ ] Verified on mobile viewport (375px)
- [ ] Verified on desktop viewport (1440px)

## Checklist
- [x] I have tested my changes locally (`npm run dev`)
- [x] My code follows the existing code style (TypeScript, Tailwind, no `any` types)
- [x] I have not introduced unrelated changes (each PR should address one issue)
- [x] I have added comments where necessary
- [x] My branch is up to date with `main`
- [x] I have linked the related issue above
- [ ] Screenshots are included (if this is a UI change)
