### PR TITLE
remove hardcoded fallback email in testQuery [ GSSOC'26 ]

### DIFF
--- a/scripts/test-db.ts
+++ b/scripts/test-db.ts
@@ -1,40 +1,43 @@
-
-import { drizzle } from 'drizzle-orm/neon-http';
-import { chatHistoryTable } from '../configs/schema';
-import { eq, desc, sql } from 'drizzle-orm';
-import * as dotenv from 'dotenv';
+import { drizzle } from "drizzle-orm/neon-http";
+import { chatHistoryTable } from "../configs/schema";
+import { eq, desc, sql } from "drizzle-orm";
+import * as dotenv from "dotenv";
 dotenv.config();
 
 const db = drizzle(process.env.NEXT_PUBLIC_NEON_DB_CONNECTION_STRING!);
 
 async function testQuery() {
-    try {
-        console.log("Testing Chat History Query...");
+  try {
+    console.log("Testing Chat History Query...");
 
-        // First, check if there are ANY records
-        const allRecords = await db.select().from(chatHistoryTable).limit(5);
-        console.log("Sample records:", allRecords);
+    // First, check if there are ANY records
+    const allRecords = await db.select().from(chatHistoryTable).limit(5);
+    console.log("Sample records:", allRecords);
 
-        const email = allRecords[0]?.userEmail || "test@example.com";
-        console.log("Testing with email:", email);
-
-        const sessions = await db
-            .select({
-                chatId: chatHistoryTable.chatId,
-                chatTitle: sql<string>`MAX(${chatHistoryTable.chatTitle})`,
-                createdAt: sql<string>`MAX(${chatHistoryTable.createdAt})`,
-            })
-            .from(chatHistoryTable)
-            .where(eq(chatHistoryTable.userEmail, email))
-            .groupBy(chatHistoryTable.chatId)
-            .orderBy(desc(sql`MAX(${chatHistoryTable.createdAt})`));
-
-        console.log("Query Successful!");
-        console.log("Results count:", sessions.length);
-    } catch (error) {
-        console.error("Query Failed!");
-        console.error(error);
+    if (!allRecords[0]?.userEmail) {
+      console.warn("No records found in DB. Exiting.");
+      return;
     }
+    const email = allRecords[0].userEmail;
+    console.log("Testing with email:", email);
+
+    const sessions = await db
+      .select({
+        chatId: chatHistoryTable.chatId,
+        chatTitle: sql<string>`MAX(${chatHistoryTable.chatTitle})`,
+        createdAt: sql<string>`MAX(${chatHistoryTable.createdAt})`,
+      })
+      .from(chatHistoryTable)
+      .where(eq(chatHistoryTable.userEmail, email))
+      .groupBy(chatHistoryTable.chatId)
+      .orderBy(desc(sql`MAX(${chatHistoryTable.createdAt})`));
+
+    console.log("Query Successful!");
+    console.log("Results count:", sessions.length);
+  } catch (error) {
+    console.error("Query Failed!");
+    console.error(error);
+  }
 }
 
 testQuery();


### PR DESCRIPTION
## Description
Removed the hardcoded fallback email `"test@example.com"` in the 
`testQuery` function. Added an early return with a `console.warn` 
when no records are found in the database to prevent silent 
misleading query results.

## Related Issue
Closes #353 

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Documentation update (README, guides, comments)
- [ ] Style / UI change (no logic change)
- [x] Code refactor (no behavior change)
- [ ] Test addition or update
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Screenshots (if UI change)
N/A — no UI change involved.

## How Has This Been Tested?
- [x] Tested locally with `npm run dev`
- [ ] Verified on mobile viewport (375px)
- [ ] Verified on desktop viewport (1440px)

Manually verified that when the database is empty, the function 
now logs a warning and exits instead of querying with a fake email.

## Checklist
- [x] I have tested my changes locally (`npm run dev`)
- [x] My code follows the existing code style (TypeScript, Tailwind, no `any` types)
- [x] I have not introduced unrelated changes (each PR should address one issue)
- [x] I have added comments where necessary
- [x] My branch is up to date with `main`
- [x] I have linked the related issue above
- [ ] Screenshots are included (if this is a UI change)