### PR TITLE
fix: protect classroom member emails

### DIFF
--- a/__tests__/api/rooms-members.test.ts
+++ b/__tests__/api/rooms-members.test.ts
@@ -1,0 +1,146 @@
+import { GET } from '@/app/api/rooms/members/route';
+
+const currentUserMock = jest.fn();
+const checkUserBlockMock = jest.fn();
+const selectResultQueue: any[] = [];
+
+jest.mock('@clerk/nextjs/server', () => ({
+    currentUser: () => currentUserMock(),
+}));
+
+jest.mock('@/lib/auth-utils', () => ({
+    checkUserBlock: (...args: any[]) => checkUserBlockMock(...args),
+}));
+
+const createQueryMock = (data: any) => {
+    const chain: any = {
+        from: () => chain,
+        where: () => chain,
+        then: (resolve: any) => Promise.resolve(resolve(data)),
+    };
+
+    return chain;
+};
+
+jest.mock('@/configs/db', () => ({
+    db: {
+        select: jest.fn().mockImplementation(() => createQueryMock(selectResultQueue.shift() ?? [])),
+    },
+}));
+
+describe('Room Members API Endpoint', () => {
+    beforeEach(() => {
+        currentUserMock.mockReset();
+        checkUserBlockMock.mockReset();
+        selectResultQueue.length = 0;
+        jest.clearAllMocks();
+    });
+
+    it('returns 401 for unauthenticated requests', async () => {
+        currentUserMock.mockResolvedValue(null);
+
+        const res = (await GET(new Request('http://localhost/api/rooms/members?classroomId=1')))!;
+        const json = await res.json();
+
+        expect(res.status).toBe(401);
+        expect(json.error).toBe('Unauthorized');
+    });
+
+    it('returns 403 when the requester is not a classroom member', async () => {
+        currentUserMock.mockResolvedValue({
+            primaryEmailAddress: { emailAddress: 'outsider@example.com' },
+        });
+        checkUserBlockMock.mockResolvedValue({ isBlocked: false });
+        selectResultQueue.push([]);
+
+        const res = (await GET(new Request('http://localhost/api/rooms/members?classroomId=1')))!;
+        const json = await res.json();
+
+        expect(res.status).toBe(403);
+        expect(json.error).toBe('Access denied');
+    });
+
+    it('does not expose member emails to student requesters', async () => {
+        currentUserMock.mockResolvedValue({
+            primaryEmailAddress: { emailAddress: 'student@example.com' },
+        });
+        checkUserBlockMock.mockResolvedValue({ isBlocked: false });
+        selectResultQueue.push(
+            [{ id: 1, userEmail: 'student@example.com', role: 'student', classroomId: 1 }],
+            [
+                {
+                    id: 1,
+                    userEmail: 'student@example.com',
+                    role: 'student',
+                    joinedAt: new Date('2026-01-01T00:00:00.000Z'),
+                },
+                {
+                    id: 2,
+                    userEmail: 'classmate@example.com',
+                    role: 'student',
+                    joinedAt: new Date('2026-01-02T00:00:00.000Z'),
+                },
+            ],
+        );
+
+        const res = (await GET(new Request('http://localhost/api/rooms/members?classroomId=1')))!;
+        const json = await res.json();
+
+        expect(res.status).toBe(200);
+        expect(json).toEqual([
+            {
+                displayName: 'Student_1',
+                role: 'student',
+                joinedAt: '2026-01-01T00:00:00.000Z',
+            },
+            {
+                displayName: 'Student_2',
+                role: 'student',
+                joinedAt: '2026-01-02T00:00:00.000Z',
+            },
+        ]);
+        expect(JSON.stringify(json)).not.toContain('userEmail');
+        expect(JSON.stringify(json)).not.toContain('classmate@example.com');
+    });
+
+    it('includes member emails for teacher requesters', async () => {
+        currentUserMock.mockResolvedValue({
+            primaryEmailAddress: { emailAddress: 'teacher@example.com' },
+        });
+        checkUserBlockMock.mockResolvedValue({ isBlocked: false });
+        selectResultQueue.push(
+            [{ id: 1, userEmail: 'teacher@example.com', role: 'teacher', classroomId: 1 }],
+            [
+                {
+                    id: 1,
+                    userEmail: 'teacher@example.com',
+                    role: 'teacher',
+                    joinedAt: new Date('2026-01-01T00:00:00.000Z'),
+                },
+                {
+                    id: 2,
+                    userEmail: 'student@example.com',
+                    role: 'student',
+                    joinedAt: new Date('2026-01-02T00:00:00.000Z'),
+                },
+            ],
+        );
+
+        const res = (await GET(new Request('http://localhost/api/rooms/members?classroomId=1')))!;
+        const json = await res.json();
+
+        expect(res.status).toBe(200);
+        expect(json).toEqual([
+            {
+                userEmail: 'teacher@example.com',
+                role: 'teacher',
+                joinedAt: '2026-01-01T00:00:00.000Z',
+            },
+            {
+                userEmail: 'student@example.com',
+                role: 'student',
+                joinedAt: '2026-01-02T00:00:00.000Z',
+            },
+        ]);
+    });
+});

--- a/app/api/rooms/members/route.ts
+++ b/app/api/rooms/members/route.ts
@@ -6,6 +6,12 @@ import { currentUser } from '@clerk/nextjs/server';
 import { checkUserBlock } from '@/lib/auth-utils';
 import { buildErrorResponse } from '@/lib/error-handler';
 
+const PRIVILEGED_MEMBER_ROLES = new Set(['teacher', 'admin']);
+
+function canViewMemberEmails(role: string) {
+    return PRIVILEGED_MEMBER_ROLES.has(role.toLowerCase());
+}
+
 export async function GET(req: Request) {
     try {
         const user = await currentUser();
@@ -40,6 +46,7 @@ export async function GET(req: Request) {
         // Fetch all members of this classroom
         const members = await db
             .select({
+                id: membershipsTable.id,
                 userEmail: membershipsTable.userEmail,
                 role: membershipsTable.role,
                 joinedAt: membershipsTable.joinedAt,
@@ -47,7 +54,17 @@ export async function GET(req: Request) {
             .from(membershipsTable)
             .where(eq(membershipsTable.classroomId, classroomId));
 
-        return NextResponse.json(members);
+        if (canViewMemberEmails(membership.role)) {
+            return NextResponse.json(members.map(({ id, ...member }) => member));
+        }
+
+        const safeMembers = members.map((member) => ({
+            displayName: `${member.role === 'student' ? 'Student' : 'Member'}_${member.id}`,
+            role: member.role,
+            joinedAt: member.joinedAt,
+        }));
+
+        return NextResponse.json(safeMembers);
     } catch (error) {
         const { status, body } = buildErrorResponse(error);
         return NextResponse.json(body, { status });


### PR DESCRIPTION
## Description
Fixes the classroom members API privacy issue by making the response role-based. Teachers/admins can still view member emails, while students receive only privacy-safe member data without `userEmail`.

Also adds focused API tests for authentication, membership authorization, student redaction, and teacher/admin visibility.

## Related Issue
Closes #307

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Documentation update (README, guides, comments)
- [ ] Style / UI change (no logic change)
- [ ] Code refactor (no behavior change)
- [x] Test addition or update
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Screenshots (if UI change)
Not applicable. This PR only updates backend API behavior and API tests.

## How Has This Been Tested?
- [ ] Tested locally with `npm run dev`
- [ ] Verified on mobile viewport (375px)
- [ ] Verified on desktop viewport (1440px)

Added API tests in `__tests__/api/rooms-members.test.ts` covering:
- unauthenticated request returns `401`
- non-member request returns `403`
- student request does not include `userEmail`
- teacher request includes `userEmail`

Attempted local verification:
- `npm.cmd test -- --runTestsByPath __tests__/api/rooms-members.test.ts`
- `npm.cmd exec tsc -- --noEmit`
- `npm.cmd run lint`
- `npm.cmd run build`

Local test/build execution was blocked by an environment-level Next SWC issue:

```text
@next/swc-win32-x64-msvc ... is not a valid Win32 application