### PR TITLE
fix: validate resume analyzer uploads

### DIFF
--- a/__tests__/api/resume-analyzer.test.ts
+++ b/__tests__/api/resume-analyzer.test.ts
@@ -1,0 +1,270 @@
+import axios from "axios";
+import { POST } from "@/app/api/resume-analyzer/route";
+
+const mockPdf = jest.fn();
+
+jest.mock("pdf-parse-fork", () => mockPdf);
+
+jest.mock("axios", () => ({
+    __esModule: true,
+    default: {
+        post: jest.fn()
+    }
+}));
+
+jest.mock("@clerk/nextjs/server", () => ({
+    currentUser: jest.fn().mockResolvedValue({
+        primaryEmailAddress: { emailAddress: "student@example.com" }
+    })
+}));
+
+jest.mock("@/lib/auth-utils", () => ({
+    checkUserBlock: jest.fn().mockResolvedValue({ isBlocked: false })
+}));
+
+const mockDbValues = jest.fn().mockResolvedValue(undefined);
+
+jest.mock("@/configs/db", () => ({
+    db: {
+        insert: jest.fn().mockReturnValue({
+            values: mockDbValues
+        })
+    }
+}));
+
+function createMultipartRequest(file?: Blob, filename = "resume.pdf") {
+    const formData = new FormData();
+
+    if (file) {
+        formData.append("resume", file, filename);
+    }
+
+    return new Request("http://localhost/api/resume-analyzer", {
+        method: "POST",
+        body: formData
+    }) as any;
+}
+
+describe("Resume Analyzer API Endpoint", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it("rejects requests without a resume file", async () => {
+        const res = (await POST(createMultipartRequest()))!;
+        const json = await res.json();
+
+        expect(res.status).toBe(400);
+        expect(json.error).toBe("Resume file is required");
+        expect(mockPdf).not.toHaveBeenCalled();
+    });
+
+    it("rejects non-file resume form fields", async () => {
+        const formData = new FormData();
+        formData.append("resume", "not a file");
+
+        const req = new Request("http://localhost/api/resume-analyzer", {
+            method: "POST",
+            body: formData
+        }) as any;
+
+        const res = (await POST(req))!;
+        const json = await res.json();
+
+        expect(res.status).toBe(400);
+        expect(json.error).toBe("Resume file is required");
+        expect(mockPdf).not.toHaveBeenCalled();
+    });
+
+    it("rejects unsupported resume file types before parsing", async () => {
+        const req = createMultipartRequest(
+            new Blob(["not a pdf"], { type: "text/plain" }),
+            "resume.txt"
+        );
+
+        const res = (await POST(req))!;
+        const json = await res.json();
+
+        expect(res.status).toBe(400);
+        expect(json.error).toBe("Only PDF resume files are supported");
+        expect(mockPdf).not.toHaveBeenCalled();
+    });
+
+    it("rejects PDF MIME uploads without a PDF filename", async () => {
+        const req = createMultipartRequest(
+            new Blob(["%PDF with bad filename"], { type: "application/pdf" }),
+            "resume.docx"
+        );
+
+        const res = (await POST(req))!;
+        const json = await res.json();
+
+        expect(res.status).toBe(400);
+        expect(json.error).toBe("Only PDF resume files are supported");
+        expect(mockPdf).not.toHaveBeenCalled();
+    });
+
+    it("rejects oversized resumes before reading the upload", async () => {
+        const oversizedPdf = new Blob(
+            [new Uint8Array(5 * 1024 * 1024 + 1)],
+            { type: "application/pdf" }
+        );
+
+        const res = (await POST(createMultipartRequest(oversizedPdf)))!;
+        const json = await res.json();
+
+        expect(res.status).toBe(400);
+        expect(json.error).toBe("Resume file must be 5MB or smaller");
+        expect(mockPdf).not.toHaveBeenCalled();
+    });
+
+    it("accepts resumes exactly at the 5MB limit", async () => {
+        mockPdf.mockResolvedValueOnce({ text: "Experienced TypeScript developer" });
+        (axios.post as jest.Mock).mockResolvedValueOnce({
+            data: {
+                choices: [{
+                    message: {
+                        content: JSON.stringify({
+                            score: 88,
+                            summary: "Strong backend resume",
+                            scoreBreakdown: {
+                                skills: 90,
+                                projects: 85,
+                                experience: 88,
+                                ats: 86,
+                                impact: 87,
+                                industryFit: 90
+                            },
+                            strengths: ["TypeScript"],
+                            weaknesses: ["Testing"],
+                            improvementPoints: ["Add metrics"],
+                            missingKeywords: [],
+                            sectionwiseAnalysis: {
+                                education: "Good",
+                                experience: "Strong",
+                                projects: "Relevant",
+                                skills: "Clear"
+                            }
+                        })
+                    }
+                }]
+            }
+        });
+
+        const maxSizePdf = new Blob(
+            [new Uint8Array(5 * 1024 * 1024)],
+            { type: "application/pdf" }
+        );
+
+        const res = (await POST(createMultipartRequest(maxSizePdf)))!;
+        const json = await res.json();
+
+        expect(res.status).toBe(200);
+        expect(json.score).toBe(88);
+        expect(mockPdf).toHaveBeenCalledTimes(1);
+    });
+
+    it("returns a safe error when PDF parsing fails", async () => {
+        mockPdf.mockRejectedValueOnce(new Error("pdf parser stack details"));
+
+        const res = (await POST(createMultipartRequest(
+            new Blob(["%PDF invalid"], { type: "application/pdf" })
+        )))!;
+        const json = await res.json();
+
+        expect(res.status).toBe(400);
+        expect(json).toEqual({
+            error: "Unable to read the uploaded PDF. Please upload a valid text-based PDF resume."
+        });
+        expect(json.detail).toBeUndefined();
+        expect(json.stack).toBeUndefined();
+    });
+
+    it("returns a safe error when no text can be extracted from the PDF", async () => {
+        mockPdf.mockResolvedValueOnce({ text: "   " });
+
+        const res = (await POST(createMultipartRequest(
+            new Blob(["%PDF image only"], { type: "application/pdf" })
+        )))!;
+        const json = await res.json();
+
+        expect(res.status).toBe(400);
+        expect(json).toEqual({
+            error: "Failed to extract text from the PDF"
+        });
+        expect(json.detail).toBeUndefined();
+        expect(json.stack).toBeUndefined();
+        expect(axios.post).not.toHaveBeenCalled();
+    });
+
+    it("does not expose provider error details to the client", async () => {
+        mockPdf.mockResolvedValueOnce({ text: "Experienced TypeScript developer" });
+        (axios.post as jest.Mock).mockRejectedValueOnce({
+            message: "provider failed",
+            response: {
+                data: {
+                    error: "internal provider response"
+                }
+            }
+        });
+
+        const res = (await POST(createMultipartRequest(
+            new Blob(["%PDF valid"], { type: "application/pdf" })
+        )))!;
+        const json = await res.json();
+
+        expect(res.status).toBe(500);
+        expect(json).toEqual({
+            error: "Failed to analyze resume. Please try again later."
+        });
+        expect(JSON.stringify(json)).not.toContain("internal provider response");
+        expect(JSON.stringify(json)).not.toContain("provider failed");
+    });
+
+    it("analyzes valid PDF resumes successfully", async () => {
+        mockPdf.mockResolvedValueOnce({ text: "Experienced TypeScript developer" });
+        (axios.post as jest.Mock).mockResolvedValueOnce({
+            data: {
+                choices: [{
+                    message: {
+                        content: JSON.stringify({
+                            score: 88,
+                            summary: "Strong backend resume",
+                            scoreBreakdown: {
+                                skills: 90,
+                                projects: 85,
+                                experience: 88,
+                                ats: 86,
+                                impact: 87,
+                                industryFit: 90
+                            },
+                            strengths: ["TypeScript"],
+                            weaknesses: ["Testing"],
+                            improvementPoints: ["Add metrics"],
+                            missingKeywords: [],
+                            sectionwiseAnalysis: {
+                                education: "Good",
+                                experience: "Strong",
+                                projects: "Relevant",
+                                skills: "Clear"
+                            }
+                        })
+                    }
+                }]
+            }
+        });
+
+        const res = (await POST(createMultipartRequest(
+            new Blob(["%PDF valid"], { type: "application/pdf" })
+        )))!;
+        const json = await res.json();
+
+        expect(res.status).toBe(200);
+        expect(json.score).toBe(88);
+        expect(axios.post).toHaveBeenCalledTimes(1);
+        expect(mockDbValues).toHaveBeenCalledWith(expect.objectContaining({
+            resumeName: "resume.pdf",
+            resumeText: "Experienced TypeScript developer"
+        }));
+    });
+});

--- a/app/api/resume-analyzer/route.ts
+++ b/app/api/resume-analyzer/route.ts
@@ -9,17 +9,52 @@ import { checkUserBlock } from "@/lib/auth-utils";
 const require = createRequire(import.meta.url);
 const pdf = require("pdf-parse-fork");
 
+const MAX_RESUME_SIZE_BYTES = 5 * 1024 * 1024;
+const SUPPORTED_RESUME_MIME_TYPES = new Set(["application/pdf"]);
+
+function isUploadedFile(value: FormDataEntryValue | null): value is File {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        "arrayBuffer" in value &&
+        "size" in value &&
+        "type" in value &&
+        "name" in value
+    );
+}
+
+function validateResumeFile(file: File) {
+    if (!SUPPORTED_RESUME_MIME_TYPES.has(file.type)) {
+        return "Only PDF resume files are supported";
+    }
+
+    if (!file.name.toLowerCase().endsWith(".pdf")) {
+        return "Only PDF resume files are supported";
+    }
+
+    if (file.size > MAX_RESUME_SIZE_BYTES) {
+        return "Resume file must be 5MB or smaller";
+    }
+
+    return null;
+}
+
 // Forced Refresh: 2026-02-09T06:05:00Z
 export async function POST(req: NextRequest) {
     try {
         const formData = await req.formData();
-        const file = formData.get("resume") as File;
+        const file = formData.get("resume");
         const jobDescription = formData.get("jobDescription") as string || "";
         const fieldOfInterest = formData.get("fieldOfInterest") as string || "";
         const targetRole = formData.get("targetRole") as string || "";
 
-        if (!file) {
+        if (!isUploadedFile(file)) {
             return NextResponse.json({ error: "Resume file is required" }, { status: 400 });
+        }
+
+        const validationError = validateResumeFile(file);
+        if (validationError) {
+            return NextResponse.json({ error: validationError }, { status: 400 });
         }
 
         const user = await currentUser();
@@ -39,7 +74,9 @@ export async function POST(req: NextRequest) {
             resumeText = data.text;
         } catch (parseError: any) {
             console.error("PDF Parsing Error:", parseError);
-            throw new Error(`PDF Extraction failed: ${parseError.message}`);
+            return NextResponse.json({
+                error: "Unable to read the uploaded PDF. Please upload a valid text-based PDF resume."
+            }, { status: 400 });
         }
 
         if (!resumeText || resumeText.trim().length === 0) {
@@ -158,8 +195,7 @@ ${resumeText}
             response: error.response?.data
         });
         return NextResponse.json({
-            error: error.message || "Failed to analyze resume",
-            detail: error.response?.data || error.stack
+            error: "Failed to analyze resume. Please try again later."
         }, { status: 500 });
     }
 }


### PR DESCRIPTION
## Description
Adds strict upload validation and safer error handling for the resume analyzer API. The endpoint now accepts only PDF resumes, rejects files larger than 5MB before parsing, returns user-safe error messages, and logs internal details server-side only. Added API tests for validation and error-handling edge cases.

## Related Issue
Closes #308

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Documentation update (README, guides, comments)
- [ ] Style / UI change (no logic change)
- [ ] Code refactor (no behavior change)
- [x] Test addition or update
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Screenshots (if UI change)
Not applicable. This is a backend API change.

## How Has This Been Tested?
- [ ] Tested locally with `npm run dev`
- [ ] Verified on mobile viewport (375px)
- [ ] Verified on desktop viewport (1440px)
- Added API test coverage for:
  - Missing resume file
  - Non-file resume field
  - Unsupported MIME type
  - PDF MIME with non-PDF filename
  - Oversized files above 5MB
  - File exactly at the 5MB limit
  - PDF parsing failures
  - Empty extracted PDF text
  - Provider error sanitization
  - Valid PDF analysis flow
- `git diff --check` passed
- `npm test -- --runTestsByPath __tests__/api/resume-analyzer.test.ts` could not complete locally because Next SWC fails to load in my environment:
  `next-swc.win32-x64-msvc.node is not a valid Win32 application`
- `tsc --noEmit` is currently blocked by unrelated existing repository errors in `doubts.test.ts`, `replies-auto-transition.test.ts`, and missing `jspdf` declarations

## Checklist
- [ ] I have tested my changes locally (`npm run dev`)
- [x] My code follows the existing code style (TypeScript, Tailwind, no `any` types)
- [x] I have not introduced unrelated changes (each PR should address one issue)
- [x] I have added comments where necessary
- [x] My branch is up to date with `main`
- [x] I have linked the related issue above
- [ ] Screenshots are included (if this is a UI change)