### PR TITLE
fix: use server-only database url

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 # Database (Neon PostgreSQL)
-NEXT_PUBLIC_NEON_DB_CONNECTION_STRING=postgresql://user:password@host/database?sslmode=require
+DATABASE_URL=postgresql://user:password@host/database?sslmode=require
 
 # Public site URL for canonical, OpenGraph, and Twitter metadata
 NEXT_PUBLIC_SITE_URL=http://localhost:3000

--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ Create a `.env` file in the project root with the following keys:
 
 ```env
 # Database (Neon PostgreSQL)
-NEXT_PUBLIC_NEON_DB_CONNECTION_STRING=your_neon_connection_string
+DATABASE_URL=your_neon_connection_string
 
 # Authentication (Clerk)
 NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_...

--- a/__tests__/configs/db.test.ts
+++ b/__tests__/configs/db.test.ts
@@ -1,0 +1,71 @@
+const missingDatabaseUrlError = 'DATABASE_URL is required. Please check your .env file.';
+
+describe('getDatabaseUrl', () => {
+    const originalDatabaseUrl = process.env.DATABASE_URL;
+    const originalPublicDatabaseUrl = process.env.NEXT_PUBLIC_NEON_DB_CONNECTION_STRING;
+
+    afterEach(() => {
+        if (originalDatabaseUrl) {
+            process.env.DATABASE_URL = originalDatabaseUrl;
+        } else {
+            delete process.env.DATABASE_URL;
+        }
+
+        if (originalPublicDatabaseUrl) {
+            process.env.NEXT_PUBLIC_NEON_DB_CONNECTION_STRING = originalPublicDatabaseUrl;
+        } else {
+            delete process.env.NEXT_PUBLIC_NEON_DB_CONNECTION_STRING;
+        }
+    });
+
+    it.each([undefined, '', '   '])('throws when DATABASE_URL is %p', (databaseUrl) => {
+        if (databaseUrl === undefined) {
+            delete process.env.DATABASE_URL;
+        } else {
+            process.env.DATABASE_URL = databaseUrl;
+        }
+
+        const { getDatabaseUrl } = require('@/configs/database-url');
+
+        expect(() => getDatabaseUrl()).toThrow(missingDatabaseUrlError);
+    });
+
+    it('returns a trimmed DATABASE_URL when configured', () => {
+        process.env.DATABASE_URL = '  postgresql://user:password@host/database?sslmode=require  ';
+
+        const { getDatabaseUrl } = require('@/configs/database-url');
+
+        expect(getDatabaseUrl()).toBe('postgresql://user:password@host/database?sslmode=require');
+    });
+
+    it('does not fall back to the old public database variable', () => {
+        delete process.env.DATABASE_URL;
+        process.env.NEXT_PUBLIC_NEON_DB_CONNECTION_STRING = 'postgresql://public-prefix/database';
+
+        const { getDatabaseUrl } = require('@/configs/database-url');
+
+        expect(() => getDatabaseUrl()).toThrow(missingDatabaseUrlError);
+    });
+});
+
+describe('database configuration', () => {
+    const originalDatabaseUrl = process.env.DATABASE_URL;
+
+    beforeEach(() => {
+        jest.resetModules();
+        jest.clearAllMocks();
+        delete process.env.DATABASE_URL;
+    });
+
+    afterEach(() => {
+        if (originalDatabaseUrl) {
+            process.env.DATABASE_URL = originalDatabaseUrl;
+        } else {
+            delete process.env.DATABASE_URL;
+        }
+    });
+
+    it('throws a clear error when DATABASE_URL is missing', () => {
+        expect(() => require('@/configs/db')).toThrow(missingDatabaseUrlError);
+    });
+});

--- a/configs/database-url.ts
+++ b/configs/database-url.ts
@@ -1,0 +1,9 @@
+export function getDatabaseUrl() {
+    const databaseUrl = process.env.DATABASE_URL?.trim();
+
+    if (!databaseUrl) {
+        throw new Error('DATABASE_URL is required. Please check your .env file.');
+    }
+
+    return databaseUrl;
+}

--- a/configs/db.tsx
+++ b/configs/db.tsx
@@ -1,7 +1,8 @@
 import { drizzle } from 'drizzle-orm/neon-http';
 import { neon } from '@neondatabase/serverless';
+import { getDatabaseUrl } from './database-url';
 
-const sql = neon(process.env.NEXT_PUBLIC_NEON_DB_CONNECTION_STRING || "postgres://dummy:dummy@dummy/dummy");
+const sql = neon(getDatabaseUrl());
 export const db = drizzle(sql);
 
 /** Re-export the transaction helper so callers import from one place. */

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -1,11 +1,12 @@
 import 'dotenv/config';
 import { defineConfig } from 'drizzle-kit';
+import { getDatabaseUrl } from './configs/database-url';
 
 export default defineConfig({
 
     schema: './configs/schema.ts',
     dialect: 'postgresql',
     dbCredentials: {
-        url: process.env.NEXT_PUBLIC_NEON_DB_CONNECTION_STRING!,
+        url: getDatabaseUrl(),
     },
 });

--- a/scripts/fix-db.ts
+++ b/scripts/fix-db.ts
@@ -1,7 +1,8 @@
 import 'dotenv/config';
 import { neon } from '@neondatabase/serverless';
+import { getDatabaseUrl } from '../configs/database-url';
 
-const sql = neon(process.env.NEXT_PUBLIC_NEON_DB_CONNECTION_STRING!);
+const sql = neon(getDatabaseUrl());
 
 async function main() {
     try {

--- a/scripts/inspect-db.ts
+++ b/scripts/inspect-db.ts
@@ -1,7 +1,8 @@
 import 'dotenv/config';
 import { neon } from '@neondatabase/serverless';
+import { getDatabaseUrl } from '../configs/database-url';
 
-const sql = neon(process.env.NEXT_PUBLIC_NEON_DB_CONNECTION_STRING!);
+const sql = neon(getDatabaseUrl());
 
 async function main() {
     try {

--- a/scripts/test-db.ts
+++ b/scripts/test-db.ts
@@ -2,9 +2,10 @@ import { drizzle } from "drizzle-orm/neon-http";
 import { chatHistoryTable } from "../configs/schema";
 import { eq, desc, sql } from "drizzle-orm";
 import * as dotenv from "dotenv";
+import { getDatabaseUrl } from "../configs/database-url";
 dotenv.config();
 
-const db = drizzle(process.env.NEXT_PUBLIC_NEON_DB_CONNECTION_STRING!);
+const db = drizzle(getDatabaseUrl());
 
 async function testQuery() {
   try {


### PR DESCRIPTION
## Description
This PR fixes the database environment variable mismatch by switching the project from the public-prefixed `NEXT_PUBLIC_NEON_DB_CONNECTION_STRING` to the server-only `DATABASE_URL`. It also adds a shared database URL guard with a clear missing-env error and updates the docs, example env file, Drizzle config, and DB scripts for consistency.

## Related Issue
Closes #309

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Documentation update (README, guides, comments)
- [ ] Style / UI change (no logic change)
- [ ] Code refactor (no behavior change)
- [x] Test addition or update
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Screenshots (if UI change)
Not applicable. This PR does not include UI changes.

## How Has This Been Tested?
- [x] Verified database URL helper handles missing, empty, whitespace-only, and trimmed `DATABASE_URL` values
- [x] Verified the old `NEXT_PUBLIC_NEON_DB_CONNECTION_STRING` is not used as a fallback
- [x] Verified `configs/db.tsx` imports successfully with a valid `DATABASE_URL`
- [x] Verified `drizzle.config.ts` reads `DATABASE_URL`
- [x] Ran targeted TypeScript validation for all changed files
- [x] Ran `git diff --check`

Note: Full Jest, lint, and build checks could not complete locally due to existing repo/toolchain issues:
- Jest fails before tests run due to a Next SWC binary / setup parsing issue
- `npm run lint` uses `next lint`, which is invalid with the installed Next 16 CLI
- Build compiles successfully, then fails in Next’s TypeScript worker due to the same SWC issue

## Checklist
- [ ] I have tested my changes locally (`npm run dev`)
- [x] My code follows the existing code style (TypeScript, Tailwind, no `any` types)
- [x] I have not introduced unrelated changes (each PR should address one issue)
- [x] I have added comments where necessary
- [x] My branch is up to date with `main`
- [x] I have linked the related issue above
- [x] Screenshots are included (if this is a UI change)