### PR TITLE
fix: secure email unsubscribe flow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,10 @@ NEXT_PUBLIC_NEON_DB_CONNECTION_STRING=postgresql://user:password@host/database?s
 
 # Public site URL for canonical, OpenGraph, and Twitter metadata
 NEXT_PUBLIC_SITE_URL=http://localhost:3000
+NEXT_PUBLIC_APP_URL=http://localhost:3000
+
+# Email unsubscribe signing secret
+UNSUBSCRIBE_SECRET=replace_with_a_long_random_secret
 
 # Authentication (Clerk)
 NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_your_key_here

--- a/__tests__/api/unsubscribe.test.ts
+++ b/__tests__/api/unsubscribe.test.ts
@@ -1,0 +1,104 @@
+import { NextRequest } from 'next/server';
+import { generateUnsubscribeToken } from '@/lib/email';
+import { GET, POST } from '@/app/api/unsubscribe/route';
+
+const mockWhere = jest.fn();
+const mockSet = jest.fn(() => ({ where: mockWhere }));
+const mockUpdate = jest.fn(() => ({ set: mockSet }));
+
+jest.mock('@/configs/db', () => ({
+    db: {
+        update: mockUpdate,
+    },
+}));
+
+jest.mock('@/configs/schema', () => ({
+    usersTable: {
+        email: 'email',
+    },
+}));
+
+jest.mock('drizzle-orm', () => ({
+    eq: jest.fn((field, value) => ({ field, value })),
+}));
+
+function makeSignedRequest(method: string, email = 'Student@College.edu') {
+    const expires = Date.now() + 60_000;
+    const token = generateUnsubscribeToken(email, expires);
+    const url = `http://localhost/api/unsubscribe?email=${encodeURIComponent(email)}&expires=${expires}&token=${token}`;
+
+    return new NextRequest(url, {
+        method,
+        headers: { 'x-forwarded-for': '127.0.0.1' },
+    });
+}
+
+function makeUnsignedRequest(method: string, ip: string) {
+    return new NextRequest('http://localhost/api/unsubscribe?email=student%40college.edu&token=bad', {
+        method,
+        headers: { 'x-forwarded-for': ip },
+    });
+}
+
+describe('Unsubscribe API Endpoint', () => {
+    beforeEach(() => {
+        process.env.UNSUBSCRIBE_SECRET = 'test-unsubscribe-secret';
+        jest.clearAllMocks();
+    });
+
+    it('does not change notification preferences on GET', async () => {
+        const res = await GET(makeSignedRequest('GET'));
+
+        expect(res.status).toBe(200);
+        expect(res.headers.get('content-type')).toContain('text/html');
+        expect(res.headers.get('cache-control')).toBe('no-store');
+        expect(mockUpdate).not.toHaveBeenCalled();
+    });
+
+    it('rejects invalid GET requests without updating the user', async () => {
+        const req = new NextRequest('http://localhost/api/unsubscribe?email=student%40college.edu', {
+            method: 'GET',
+        });
+
+        const res = await GET(req);
+
+        expect(res.status).toBe(307);
+        expect(res.headers.get('location')).toContain('Invalid%20or%20expired%20unsubscribe%20link');
+        expect(mockUpdate).not.toHaveBeenCalled();
+    });
+
+    it('rejects missing or tampered tokens without updating the user', async () => {
+        const req = makeUnsignedRequest('POST', '127.0.0.2');
+
+        const res = await POST(req);
+
+        expect(res.status).toBe(307);
+        expect(res.headers.get('location')).toContain('Invalid%20or%20expired%20unsubscribe%20link');
+        expect(mockUpdate).not.toHaveBeenCalled();
+    });
+
+    it('rate limits repeated unsubscribe attempts from the same IP', async () => {
+        let res: Response | undefined;
+
+        for (let i = 0; i < 11; i += 1) {
+            res = await POST(makeUnsignedRequest('POST', '127.0.0.3'));
+        }
+
+        expect(res?.status).toBe(307);
+        expect(res?.headers.get('location')).toContain('Too%20many%20unsubscribe%20attempts');
+        expect(mockUpdate).not.toHaveBeenCalled();
+    });
+
+    it('updates notification preferences only for a valid signed POST', async () => {
+        const res = await POST(makeSignedRequest('POST'));
+
+        expect(res.status).toBe(307);
+        expect(res.headers.get('location')).toBe('http://localhost/profile?unsubscribed=true');
+        expect(mockUpdate).toHaveBeenCalledTimes(1);
+        expect(mockSet).toHaveBeenCalledWith({
+            emailNotificationsEnabled: false,
+            notificationPreference: 'none',
+        });
+        expect(mockWhere).toHaveBeenCalledWith({ field: 'email', value: 'student@college.edu' });
+    });
+});

--- a/__tests__/lib/email.test.ts
+++ b/__tests__/lib/email.test.ts
@@ -1,15 +1,29 @@
-import { sendWarningEmail, sendBlockEmail } from '@/lib/email';
+import {
+    generateUnsubscribeLink,
+    generateUnsubscribeToken,
+    sendBlockEmail,
+    sendWarningEmail,
+    verifyUnsubscribeToken,
+} from '@/lib/email';
 import { jest } from '@jest/globals';
 
 describe('Email Helper Functions', () => {
     let consoleSpy: jest.SpiedFunction<typeof console.log>;
+    const originalClerkSecret = process.env.CLERK_SECRET_KEY;
 
     beforeEach(() => {
+        process.env.UNSUBSCRIBE_SECRET = 'test-unsubscribe-secret';
         consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
     });
 
     afterEach(() => {
         consoleSpy.mockRestore();
+        delete process.env.UNSUBSCRIBE_SECRET;
+        if (originalClerkSecret) {
+            process.env.CLERK_SECRET_KEY = originalClerkSecret;
+        } else {
+            delete process.env.CLERK_SECRET_KEY;
+        }
     });
 
     it('should log warning email simulation correctly', async () => {
@@ -36,5 +50,47 @@ describe('Email Helper Functions', () => {
         expect(consoleSpy).toHaveBeenCalledWith(
             expect.stringContaining('block #2')
         );
+    });
+
+    it('should generate and verify signed unsubscribe tokens', () => {
+        const expiresAt = Date.now() + 60_000;
+        const token = generateUnsubscribeToken('Student@College.edu', expiresAt);
+
+        expect(verifyUnsubscribeToken('student@college.edu', expiresAt.toString(), token)).toBe(true);
+        expect(verifyUnsubscribeToken('attacker@college.edu', expiresAt.toString(), token)).toBe(false);
+        expect(verifyUnsubscribeToken('student@college.edu', (Date.now() - 1).toString(), token)).toBe(false);
+    });
+
+    it('should reject missing, malformed, and non-numeric token parameters', () => {
+        const expiresAt = Date.now() + 60_000;
+        const token = generateUnsubscribeToken('student@college.edu', expiresAt);
+
+        expect(verifyUnsubscribeToken('student@college.edu', expiresAt.toString(), null)).toBe(false);
+        expect(verifyUnsubscribeToken('student@college.edu', null, token)).toBe(false);
+        expect(verifyUnsubscribeToken('student@college.edu', 'not-a-timestamp', token)).toBe(false);
+        expect(verifyUnsubscribeToken('student@college.edu', expiresAt.toString(), `${token.slice(0, -2)}ff`)).toBe(false);
+        expect(verifyUnsubscribeToken('student@college.edu', expiresAt.toString(), 'not-hex')).toBe(false);
+    });
+
+    it('should require an unsubscribe signing secret', () => {
+        delete process.env.UNSUBSCRIBE_SECRET;
+        delete process.env.CLERK_SECRET_KEY;
+
+        expect(() => generateUnsubscribeToken('student@college.edu')).toThrow('UNSUBSCRIBE_SECRET is required');
+    });
+
+    it('should include signed token parameters in unsubscribe links', () => {
+        const link = generateUnsubscribeLink('student@college.edu', 'https://doubtdesk.example');
+        const url = new URL(link);
+
+        expect(url.pathname).toBe('/api/unsubscribe');
+        expect(url.searchParams.get('email')).toBe('student@college.edu');
+        expect(url.searchParams.get('expires')).toBeTruthy();
+        expect(url.searchParams.get('token')).toBeTruthy();
+        expect(verifyUnsubscribeToken(
+            'student@college.edu',
+            url.searchParams.get('expires'),
+            url.searchParams.get('token')
+        )).toBe(true);
     });
 });

--- a/app/api/unsubscribe/route.ts
+++ b/app/api/unsubscribe/route.ts
@@ -1,28 +1,118 @@
 import { NextRequest, NextResponse } from "next/server";
+import { eq } from "drizzle-orm";
 import { db } from "@/configs/db";
 import { usersTable } from "@/configs/schema";
-import { eq } from "drizzle-orm";
+import { verifyUnsubscribeToken } from "@/lib/email";
+
+const RATE_LIMIT_WINDOW_MS = 60 * 1000;
+const RATE_LIMIT_MAX_REQUESTS = 10;
+const unsubscribeAttempts = new Map<string, { count: number; resetAt: number }>();
+
+function getClientIp(req: NextRequest) {
+    return req.headers.get("x-forwarded-for")?.split(",")[0]?.trim()
+        || req.headers.get("x-real-ip")
+        || "unknown";
+}
+
+function isRateLimited(ip: string) {
+    const now = Date.now();
+    const current = unsubscribeAttempts.get(ip);
+
+    if (!current || current.resetAt <= now) {
+        unsubscribeAttempts.set(ip, { count: 1, resetAt: now + RATE_LIMIT_WINDOW_MS });
+        return false;
+    }
+
+    current.count += 1;
+    return current.count > RATE_LIMIT_MAX_REQUESTS;
+}
+
+function getParams(req: NextRequest) {
+    const { searchParams } = new URL(req.url);
+
+    return {
+        email: searchParams.get("email"),
+        expires: searchParams.get("expires"),
+        token: searchParams.get("token"),
+    };
+}
+
+function isValidRequest(email: string | null, expires: string | null, token: string | null) {
+    return Boolean(email && verifyUnsubscribeToken(email, expires, token));
+}
+
+function redirectWithError(req: NextRequest, message: string) {
+    return NextResponse.redirect(new URL(`/profile?error=${encodeURIComponent(message)}`, req.url));
+}
+
+function escapeHtml(value: string) {
+    return value
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/"/g, "&quot;")
+        .replace(/'/g, "&#039;");
+}
 
 export async function GET(req: NextRequest) {
-    try {
-        const { searchParams } = new URL(req.url);
-        const email = searchParams.get("email");
+    const { email, expires, token } = getParams(req);
 
-        if (!email) {
-            return NextResponse.redirect(new URL("/profile?error=Email%20required", req.url));
+    if (!isValidRequest(email, expires, token)) {
+        return redirectWithError(req, "Invalid or expired unsubscribe link");
+    }
+
+    const unsubscribeAction = `/api/unsubscribe?email=${encodeURIComponent(email!)}&expires=${encodeURIComponent(expires!)}&token=${encodeURIComponent(token!)}`;
+
+    return new NextResponse(
+        `<!DOCTYPE html>
+        <html lang="en">
+            <head>
+                <meta charset="UTF-8" />
+                <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+                <title>Unsubscribe from DoubtDesk</title>
+            </head>
+            <body style="margin:0;min-height:100vh;display:grid;place-items:center;background:#0f172a;color:#e2e8f0;font-family:Arial,sans-serif;">
+                <main style="max-width:420px;padding:32px;text-align:center;">
+                    <h1 style="font-size:24px;margin:0 0 12px;">Unsubscribe from email notifications?</h1>
+                    <p style="line-height:1.5;color:#cbd5e1;">This will turn off DoubtDesk email notifications for ${escapeHtml(email!)}.</p>
+                    <form method="POST" action="${unsubscribeAction}">
+                        <button type="submit" style="border:0;border-radius:8px;background:#4f46e5;color:white;font-weight:700;padding:12px 18px;cursor:pointer;">Unsubscribe</button>
+                    </form>
+                </main>
+            </body>
+        </html>`,
+        {
+            status: 200,
+            headers: {
+                "Content-Type": "text/html; charset=utf-8",
+                "Cache-Control": "no-store",
+            },
+        }
+    );
+}
+
+export async function POST(req: NextRequest) {
+    try {
+        const ip = getClientIp(req);
+        if (isRateLimited(ip)) {
+            return redirectWithError(req, "Too many unsubscribe attempts. Please try again later.");
         }
 
-        // Update user preference in DB to 'none' and disable email notifications
+        const { email, expires, token } = getParams(req);
+        if (!email || !isValidRequest(email, expires, token)) {
+            return redirectWithError(req, "Invalid or expired unsubscribe link");
+        }
+
         await db.update(usersTable)
-            .set({ 
-                emailNotificationsEnabled: false, 
-                notificationPreference: "none" 
+            .set({
+                emailNotificationsEnabled: false,
+                notificationPreference: "none",
             })
-            .where(eq(usersTable.email, email));
+            .where(eq(usersTable.email, email.trim().toLowerCase()));
 
         return NextResponse.redirect(new URL("/profile?unsubscribed=true", req.url));
     } catch (error: any) {
         console.error("Unsubscribe API Error:", error);
-        return NextResponse.redirect(new URL("/profile?error=Internal%20Server%20Error", req.url));
+        return redirectWithError(req, "Internal Server Error");
     }
 }

--- a/lib/email.ts
+++ b/lib/email.ts
@@ -1,3 +1,62 @@
+import { createHmac, timingSafeEqual } from "crypto";
+
+const UNSUBSCRIBE_TOKEN_TTL_MS = 30 * 24 * 60 * 60 * 1000;
+
+function getUnsubscribeSecret() {
+    const secret = process.env.UNSUBSCRIBE_SECRET || process.env.CLERK_SECRET_KEY;
+
+    if (!secret) {
+        throw new Error("UNSUBSCRIBE_SECRET is required to generate unsubscribe links");
+    }
+
+    return secret;
+}
+
+function normalizeEmail(email: string) {
+    return email.trim().toLowerCase();
+}
+
+export function generateUnsubscribeToken(email: string, expiresAt = Date.now() + UNSUBSCRIBE_TOKEN_TTL_MS) {
+    const payload = `${normalizeEmail(email)}.${expiresAt}`;
+
+    return createHmac("sha256", getUnsubscribeSecret())
+        .update(payload)
+        .digest("hex");
+}
+
+export function verifyUnsubscribeToken(email: string, expiresAt: string | null, token: string | null) {
+    if (!expiresAt || !token) {
+        return false;
+    }
+
+    const expiresAtMs = Number(expiresAt);
+    if (!Number.isFinite(expiresAtMs) || expiresAtMs <= Date.now()) {
+        return false;
+    }
+
+    const expectedToken = generateUnsubscribeToken(email, expiresAtMs);
+    const expectedBuffer = Buffer.from(expectedToken, "hex");
+    const tokenBuffer = Buffer.from(token, "hex");
+
+    if (expectedBuffer.length !== tokenBuffer.length) {
+        return false;
+    }
+
+    return timingSafeEqual(expectedBuffer, tokenBuffer);
+}
+
+export function generateUnsubscribeLink(email: string, appUrl: string) {
+    const expiresAt = Date.now() + UNSUBSCRIBE_TOKEN_TTL_MS;
+    const token = generateUnsubscribeToken(email, expiresAt);
+    const url = new URL("/api/unsubscribe", appUrl);
+
+    url.searchParams.set("email", email);
+    url.searchParams.set("expires", expiresAt.toString());
+    url.searchParams.set("token", token);
+
+    return url.toString();
+}
+
 export async function sendWarningEmail(email: string, reason: string, strikes: number) {
     console.log(`[EMAIL SIMULATION] To: ${email}, Subject: Safety Warning - DoubtDesk, Message: Your post was flagged for: ${reason}. You have ${strikes}/3 strikes. Further violations will result in an automatic account block.`);
     
@@ -273,7 +332,7 @@ export async function sendDigestEmail(params: {
 }) {
     const { toEmail, subject, totalReplies, totalDoubts, doubts } = params;
     const appUrl = process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000";
-    const unsubscribeLink = `${appUrl}/api/unsubscribe?email=${encodeURIComponent(toEmail)}`;
+    const unsubscribeLink = generateUnsubscribeLink(toEmail, appUrl);
 
     let doubtsHtml = "";
     for (const d of doubts) {


### PR DESCRIPTION
Description
Secures the email unsubscribe flow by replacing raw email-based unsubscribe links with HMAC-signed, expiring tokens. GET /api/unsubscribe now only renders a confirmation page, while POST /api/unsubscribe verifies the token before disabling email notifications. Also adds basic rate limiting, env documentation, and security-focused tests.

Related Issue
Closes #313

Type of Change

- Bug fix (non-breaking change that fixes an issue)
- Documentation update (README, guides, comments)
- Test addition or update

Screenshots (if UI change)
Not applicable. This is a backend/security fix.

How Has This Been Tested?

- Added Jest tests for signed unsubscribe tokens and API route behavior
- Ran independent tsx edge-case checks for token verification and route behavior
- Ran git diff --check

Notes:

- npm.cmd test -- --runTestsByPath __tests__\lib\email.test.ts __tests__\api\unsubscribe.test.ts is blocked locally by an invalid Next SWC Windows binary/Jest transform issue before tests execute.
- npm.cmd run lint is blocked because next lint is unsupported in the current Next setup.
- npm.cmd run build compiles, then fails during the Next TypeScript worker startup with the same local SWC binary issue.

Checklist

My code follows the existing code style (TypeScript, Tailwind, no any types)

- I have not introduced unrelated changes (each PR should address one issue)
- I have added comments where necessary
- My branch is up to date with main
- I have linked the related issue above
