### PR TITLE
fix: enforce X-Frame-Options to prevent clickjacking

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -28,6 +28,19 @@ const nextConfig = {
       },
     ],
   },
+  async headers() {
+    return [
+      {
+        source: "/(.*)",
+        headers: [
+          {
+            key: "X-Frame-Options",
+            value: "DENY",
+          },
+        ],
+      },
+    ];
+  },
 };
 
 export default withPWA(nextConfig);


### PR DESCRIPTION
Resolves #363. Enforces the \X-Frame-Options: DENY\ header in \
ext.config.mjs\ across all routes to prevent the application from being embedded in iframes, effectively mitigating Clickjacking vulnerabilities.