### PR TITLE
real-time notifications for new doubts and replies

### DIFF
--- a/app/api/doubts/route.ts
+++ b/app/api/doubts/route.ts
@@ -9,6 +9,7 @@ import { buildErrorResponse } from "@/lib/error-handler";
 import { checkUserBlock } from "@/lib/auth-utils";
 import { parseAndValidateRequest } from "@/lib/validations/validate";
 import { createDoubtSchema } from "@/lib/validations/doubt";
+import { createClassroomDoubtNotifications } from "@/lib/notifications/service";
 
 export async function GET(req: Request) {
     const { searchParams } = new URL(req.url);
@@ -253,6 +254,19 @@ export async function POST(req: Request) {
             classroomId: parsedClassroomId,
             type
         }).returning();
+
+        if (parsedClassroomId) {
+            createClassroomDoubtNotifications({
+                classroomId: parsedClassroomId,
+                doubtId: newDoubt.id,
+                subject,
+                authorEmail: email,
+                authorName: userName,
+                doubtType: type,
+            }).catch((notificationErr) => {
+                console.error("Failed to create classroom doubt notifications:", notificationErr);
+            });
+        }
 
         const normalizedTags: string[] = Array.from(new Set(
             (Array.isArray(tags) ? tags : [])

--- a/app/api/notifications/stream/route.ts
+++ b/app/api/notifications/stream/route.ts
@@ -1,0 +1,57 @@
+import { currentUser } from "@clerk/nextjs/server";
+import { NextResponse } from "next/server";
+import { subscribeToNotifications } from "@/lib/notifications/realtime";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET(req: Request) {
+    const user = await currentUser();
+    if (!user || !user.primaryEmailAddress?.emailAddress) {
+        return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const userEmail = user.primaryEmailAddress.emailAddress;
+    const encoder = new TextEncoder();
+    let cleanup = () => {};
+    let heartbeat: ReturnType<typeof setInterval> | null = null;
+
+    const stream = new ReadableStream<Uint8Array>({
+        start(controller) {
+            cleanup = subscribeToNotifications(userEmail, controller);
+            controller.enqueue(encoder.encode(`: connected\n\n`));
+            heartbeat = setInterval(() => {
+                try {
+                    controller.enqueue(encoder.encode(`: ping\n\n`));
+                } catch {
+                    cleanup();
+                    if (heartbeat) {
+                        clearInterval(heartbeat);
+                    }
+                }
+            }, 25000);
+
+            req.signal.addEventListener("abort", () => {
+                cleanup();
+                if (heartbeat) {
+                    clearInterval(heartbeat);
+                }
+            });
+        },
+        cancel() {
+            cleanup();
+            if (heartbeat) {
+                clearInterval(heartbeat);
+            }
+        },
+    });
+
+    return new Response(stream, {
+        headers: {
+            "Content-Type": "text/event-stream",
+            "Cache-Control": "no-cache, no-transform",
+            Connection: "keep-alive",
+            "X-Accel-Buffering": "no",
+        },
+    });
+}

--- a/app/api/replies/route.ts
+++ b/app/api/replies/route.ts
@@ -9,6 +9,7 @@ import { inngest } from "@/inngest/client";
 import { parseAndValidateRequest } from "@/lib/validations/validate";
 import { createReplySchema } from "@/lib/validations/reply";
 import { DOUBT_STATUS } from "@/lib/doubtStatus";
+import { createReplyNotification } from "@/lib/notifications/service";
 
 export async function GET(req: Request) {
     try {
@@ -146,6 +147,20 @@ export async function POST(req: Request) {
             content: content || null,
             imageUrl: imageUrl || null,
         }).returning();
+
+        createReplyNotification({
+            doubtId,
+            replyId: newReply[0].id,
+            doubtOwnerEmail: doubt.userEmail || null,
+            replierEmail: email,
+            doubtTitle: doubt.subject || doubt.content || "your doubt",
+            replierName: userName,
+            replyContent: content || "",
+            classroomId: doubt.classroomId || null,
+            doubtType: doubt.type,
+        }).catch((notificationErr) => {
+            console.error("Failed to create reply notification:", notificationErr);
+        });
 
         // Auto-transition: unsolved -> in-progress on first reply.
         // Design notes:

--- a/app/rooms/[id]/page.tsx
+++ b/app/rooms/[id]/page.tsx
@@ -71,6 +71,7 @@ export default function ClassroomPage() {
     const [subjectFilter, setSubjectFilter] = useState("All");
     const [tagFilter, setTagFilter] = useState("");
     const sort = (searchParams.get("sort") as DoubtSortValue) || "newest";
+    const notificationTab = searchParams.get("tab");
 
     useEffect(() => {
         const timer = setTimeout(() => {
@@ -78,6 +79,12 @@ export default function ClassroomPage() {
         }, 500);
         return () => clearTimeout(timer);
     }, [searchVal]);
+
+    useEffect(() => {
+        if (notificationTab === "community" || notificationTab === "teacher-doubts" || notificationTab === "ask-ai" || notificationTab === "insights") {
+            setActiveTab(notificationTab);
+        }
+    }, [notificationTab]);
 
     const type = activeTab === 'teacher-doubts' ? 'teacher' : activeTab === 'community' ? 'community' : 'ai';
     const userName = typeof window !== 'undefined' ? localStorage.getItem("anonymous_user") : "";

--- a/components/DoubtCard.tsx
+++ b/components/DoubtCard.tsx
@@ -1,20 +1,22 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { MessageSquare, ThumbsUp, CheckCircle, Edit2, Trash2, X, ZoomIn, AlertTriangle, Pin, Bookmark, Clock } from "lucide-react";
 import AskDoubt from "./AskDoubt";
 import DoubtRepliesModal from "./DoubtRepliesModal";
 import { toast } from "sonner";
 import { DeleteConfirmationDialog } from "./DeleteConfirmationDialog";
+import { useSearchParams } from "next/navigation";
 
 interface DoubtCardProps {
     doubt: any;
     onUpdate?: () => void;
     onViewAISolution?: (doubt: any) => void;
     role?: string;
+    openRepliesOnMount?: boolean;
 }
 
-export default function DoubtCard({ doubt, onUpdate, onViewAISolution, role }: DoubtCardProps) {
+export default function DoubtCard({ doubt, onUpdate, onViewAISolution, role, openRepliesOnMount = false }: DoubtCardProps) {
     const [isOwner, setIsOwner] = useState(false);
     const [isLiking, setIsLiking] = useState(false);
     const [isSolving, setIsSolving] = useState(false);
@@ -26,6 +28,8 @@ export default function DoubtCard({ doubt, onUpdate, onViewAISolution, role }: D
     const [isPinning, setIsPinning] = useState(false);
     const [isBookmarking, setIsBookmarking] = useState(false);
     const [likes, setLikes] = useState<number>(doubt.likes || 0);
+    const searchParams = useSearchParams();
+    const lastAutoOpenedThread = useRef<string | null>(null);
 
     const isTeacher = role === 'teacher';
 
@@ -35,6 +39,17 @@ export default function DoubtCard({ doubt, onUpdate, onViewAISolution, role }: D
             setIsOwner(true);
         }
     }, [doubt.userName]);
+
+    useEffect(() => {
+        const deepLinkedDoubtId = Number(searchParams.get("doubtId") || "") || null;
+        const shouldAutoOpen = openRepliesOnMount || deepLinkedDoubtId === doubt.id;
+        const autoOpenKey = shouldAutoOpen ? `${doubt.id}:${searchParams.get("doubtId") || ""}` : null;
+
+        if (shouldAutoOpen && autoOpenKey !== lastAutoOpenedThread.current) {
+            setIsRepliesOpen(true);
+            lastAutoOpenedThread.current = autoOpenKey;
+        }
+    }, [doubt.id, openRepliesOnMount, searchParams]);
 
     const handleAction = async (action: string) => {
         if (action === "like") {

--- a/components/NotificationBell.tsx
+++ b/components/NotificationBell.tsx
@@ -1,9 +1,10 @@
 "use client"
 
-import { useState } from "react"
+import { useEffect, useState } from "react"
 import { Bell, Check, Loader2 } from "lucide-react"
 import useSWR from "swr"
 import Link from "next/link"
+import { useRouter } from "next/navigation"
 import {
     Popover,
     PopoverContent,
@@ -12,14 +13,10 @@ import {
 import { Button } from "@/components/ui/button"
 import { ScrollArea } from "@/components/ui/scroll-area"
 import { formatDistanceToNow } from "date-fns"
+import { toast } from "sonner"
+import type { NotificationRecord } from "@/lib/notifications/realtime"
 
-interface Notification {
-    id: number;
-    title: string;
-    message: string;
-    link: string | null;
-    type: string;
-    isRead: boolean;
+interface Notification extends NotificationRecord {
     createdAt: string;
 }
 
@@ -27,15 +24,66 @@ const fetcher = (url: string) => fetch(url).then((res) => res.json())
 
 export default function NotificationBell() {
     const [isOpen, setIsOpen] = useState(false)
+    const router = useRouter()
 
-    // Polling every 10 seconds for new notifications
     const { data, error, mutate } = useSWR('/api/notifications', fetcher, {
-        refreshInterval: 10000, 
+        refreshInterval: 30000,
     })
 
     const unreadCount = data?.unreadCount || 0
     const notifications: Notification[] = data?.notifications || []
     const isLoading = !data && !error
+
+    useEffect(() => {
+        const source = new EventSource('/api/notifications/stream')
+
+        source.addEventListener('notification', (event) => {
+            const payload = JSON.parse((event as MessageEvent).data) as Notification
+
+            toast(payload.title, {
+                description: payload.message,
+                action: payload.link
+                    ? {
+                        label: "View",
+                        onClick: () => router.push(payload.link as string),
+                    }
+                    : undefined,
+            })
+
+            mutate((currentData: any) => {
+                if (!currentData) return currentData
+
+                const alreadyExists = currentData.notifications.some((notification: Notification) => notification.id === payload.id)
+                if (alreadyExists) {
+                    return currentData
+                }
+
+                toast(payload.title, {
+                    description: payload.message,
+                    action: payload.link
+                        ? {
+                            label: "View",
+                            onClick: () => router.push(payload.link as string),
+                        }
+                        : undefined,
+                })
+
+                return {
+                    ...currentData,
+                    unreadCount: (currentData.unreadCount || 0) + 1,
+                    notifications: [payload, ...currentData.notifications],
+                }
+            }, false)
+        })
+
+        source.onerror = () => {
+            // Keep the browser's built-in retry behavior active.
+        }
+
+        return () => {
+            source.close()
+        }
+    }, [mutate, router])
 
     const markAsRead = async (id: number) => {
         // Optimistic update
@@ -97,8 +145,8 @@ export default function NotificationBell() {
                 >
                     <Bell className="h-5 w-5 text-muted-foreground" />
                     {unreadCount > 0 && (
-                        <span className="absolute top-1.5 right-1.5 flex h-2.5 w-2.5 rounded-full bg-red-500 ring-2 ring-background">
-                            <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-red-400 opacity-75"></span>
+                        <span className="absolute -top-1 -right-1 flex min-w-5 h-5 items-center justify-center rounded-full bg-red-500 px-1 text-[10px] font-black text-white ring-2 ring-background">
+                            {unreadCount > 99 ? "99+" : unreadCount}
                         </span>
                     )}
                 </Button>

--- a/lib/notifications/realtime.ts
+++ b/lib/notifications/realtime.ts
@@ -1,0 +1,67 @@
+export type NotificationRecord = {
+    id: number;
+    userEmail: string;
+    title: string;
+    message: string;
+    link: string | null;
+    type: string;
+    isRead: boolean;
+    createdAt: Date | string;
+};
+
+type NotificationSubscriber = {
+    controller: ReadableStreamDefaultController<Uint8Array>;
+    encoder: TextEncoder;
+};
+
+type SubscriberBucket = Set<NotificationSubscriber>;
+
+const notificationSubscribers = new Map<string, SubscriberBucket>();
+
+function formatEvent(eventName: string, data: unknown) {
+    return `event: ${eventName}\ndata: ${JSON.stringify(data)}\n\n`;
+}
+
+function removeSubscriber(userEmail: string, subscriber: NotificationSubscriber) {
+    const bucket = notificationSubscribers.get(userEmail);
+    if (!bucket) return;
+
+    bucket.delete(subscriber);
+    if (bucket.size === 0) {
+        notificationSubscribers.delete(userEmail);
+    }
+}
+
+export function subscribeToNotifications(
+    userEmail: string,
+    controller: ReadableStreamDefaultController<Uint8Array>
+) {
+    const subscriber: NotificationSubscriber = {
+        controller,
+        encoder: new TextEncoder(),
+    };
+
+    const bucket = notificationSubscribers.get(userEmail) ?? new Set<NotificationSubscriber>();
+    bucket.add(subscriber);
+    notificationSubscribers.set(userEmail, bucket);
+
+    controller.enqueue(subscriber.encoder.encode(formatEvent("connected", { userEmail })));
+
+    return () => removeSubscriber(userEmail, subscriber);
+}
+
+export function publishNotification(notification: NotificationRecord) {
+    const bucket = notificationSubscribers.get(notification.userEmail);
+    if (!bucket || bucket.size === 0) return;
+
+    const encoder = new TextEncoder();
+    const payload = encoder.encode(formatEvent("notification", notification));
+
+    for (const subscriber of Array.from(bucket)) {
+        try {
+            subscriber.controller.enqueue(payload);
+        } catch {
+            removeSubscriber(notification.userEmail, subscriber);
+        }
+    }
+}

--- a/lib/notifications/service.ts
+++ b/lib/notifications/service.ts
@@ -1,0 +1,103 @@
+import { eq } from "drizzle-orm";
+import { db } from "@/configs/db";
+import { classroomsTable, membershipsTable, notificationsTable } from "@/configs/schema";
+import { publishNotification, type NotificationRecord } from "@/lib/notifications/realtime";
+
+export type NotificationInput = {
+    userEmail: string;
+    title: string;
+    message: string;
+    link: string | null;
+    type: string;
+};
+
+export async function createNotifications(inputs: NotificationInput[]) {
+    if (inputs.length === 0) {
+        return [] as NotificationRecord[];
+    }
+
+    const created = await db.insert(notificationsTable).values(inputs).returning();
+
+    for (const notification of created) {
+        publishNotification(notification);
+    }
+
+    return created;
+}
+
+export async function createClassroomDoubtNotifications(params: {
+    classroomId: number;
+    doubtId: number;
+    subject: string;
+    authorEmail: string;
+    authorName: string;
+    doubtType: string;
+}) {
+    const { classroomId, doubtId, subject, authorEmail, authorName, doubtType } = params;
+
+    const [room] = await db.select().from(classroomsTable).where(eq(classroomsTable.id, classroomId)).limit(1);
+    if (!room) {
+        return [] as NotificationRecord[];
+    }
+
+    const memberRows = await db
+        .select({ userEmail: membershipsTable.userEmail })
+        .from(membershipsTable)
+        .where(eq(membershipsTable.classroomId, classroomId));
+
+    const recipients = new Set<string>(memberRows.map((row) => row.userEmail));
+    if (room.teacherEmail) {
+        recipients.add(room.teacherEmail);
+    }
+    recipients.delete(authorEmail);
+
+    const notifications = Array.from(recipients)
+        .filter(Boolean)
+        .map((userEmail) => ({
+            userEmail,
+            title: `New doubt in ${room.name}`,
+            message: `${authorName} posted ${subject ? `a ${subject} doubt` : "a new doubt"} in ${room.name}.`,
+            link: `/rooms/${classroomId}?tab=${doubtType === "teacher" ? "teacher-doubts" : "community"}&doubtId=${doubtId}`,
+            type: "classroom_doubt",
+        }));
+
+    return createNotifications(notifications);
+}
+
+export async function createReplyNotification(params: {
+    doubtId: number;
+    replyId: number;
+    doubtOwnerEmail: string | null;
+    replierEmail: string;
+    doubtTitle: string;
+    replierName: string;
+    replyContent: string;
+    classroomId: number | null;
+    doubtType: string;
+}) {
+    const { doubtId, replyId, doubtOwnerEmail, replierEmail, doubtTitle, replierName, replyContent, classroomId, doubtType } = params;
+
+    if (!doubtOwnerEmail) {
+        return [] as NotificationRecord[];
+    }
+
+    if (replierEmail === doubtOwnerEmail) {
+        return [] as NotificationRecord[];
+    }
+
+    const preview = replyContent?.trim() || "Open the thread to read the reply.";
+
+    const link = classroomId
+        ? `/rooms/${classroomId}?tab=${doubtType === "teacher" ? "teacher-doubts" : "community"}&doubtId=${doubtId}&replyId=${replyId}`
+        : `/public-rooms?doubtId=${doubtId}&replyId=${replyId}`;
+
+    return createNotifications([
+        {
+            userEmail: doubtOwnerEmail,
+            title: `New reply on ${doubtTitle}`,
+            message: `${replierName} replied: ${preview.slice(0, 120)}`,
+            link,
+            type: "doubt_reply",
+        },
+    ]);
+}


### PR DESCRIPTION
Real-time notifications are now wired end-to-end. New classroom doubts and replies create notification rows and publish them immediately from route.ts and route.ts, the SSE stream lives in route.ts, and the shared broadcast helpers are in realtime.ts and service.ts. The navbar bell now listens live, shows a numeric unread badge, and raises a toast when a new notification arrives in NotificationBell.tsx and NotificationBell.tsx. Click-through opening is handled by DoubtCard.tsx and the classroom tab sync in [app/rooms/[id]/page.tsx#L74](app/rooms/[id]/page.tsx#L74), so notification links land on the relevant thread.



Validation-wise, the touched files are clean in `get_errors`, and `git diff --check` passed. I couldn’t complete a full TypeScript compile in this workspace because the local compiler/node_modules aren’t installed here. This implementation uses an in-memory SSE bus, so it’s solid for local development and a single Node process; for multi-instance production, you’d swap that bus for Ably, Pusher, or another shared broker.

closes #30