### PR TITLE
fix(a11y): add alt attributes to images (#408)

### DIFF
--- a/components/DoubtRepliesModal.tsx
+++ b/components/DoubtRepliesModal.tsx
@@ -768,7 +768,7 @@ export default function DoubtRepliesModal({ doubt, isOpen, onClose, onReplyChang
                                         </div>
                                     ) : (
                                         <div className="relative overflow-hidden rounded-2xl border-2 border-emerald-500/20 bg-white dark:bg-slate-950 shadow-2xl group/img">
-                                            <img src={solutionImage} className="w-full sm:w-64 h-36 object-cover opacity-80 group-hover/img:opacity-100 transition-all duration-500" />
+                                            <img src={solutionImage} alt="" className="w-full sm:w-64 h-36 object-cover opacity-80 group-hover/img:opacity-100 transition-all duration-500" />
 
                                             {/* Image Overlay */}
                                             <div className="absolute inset-0 bg-gradient-to-t from-slate-950/90 via-transparent to-transparent flex flex-col justify-end p-3 translate-y-2 group-hover/img:translate-y-0 transition-transform">


### PR DESCRIPTION
﻿## Summary
Added lt="" attribute to the decorative <img> tag in DoubtRepliesModal.tsx so screen readers skip it (purely decorative).

Fixes #408


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accessibility for image previews in solution attachments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/knoxiboy/DoubtDesk/pull/413?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->