### PR TITLE
fix: gate notification polling by auth state

### DIFF
--- a/src/components/NotificationBell.tsx
+++ b/src/components/NotificationBell.tsx
@@ -5,6 +5,7 @@ import { Bell, Check, Loader2 } from "lucide-react"
 import useSWR from "swr"
 import Link from "next/link"
 import { useRouter } from "next/navigation"
+import { useAuth } from "@clerk/nextjs"
 import {
     Popover,
     PopoverContent,
@@ -20,25 +21,47 @@ interface Notification extends NotificationRecord {
     createdAt: string;
 }
 
-const fetcher = (url: string) => fetch(url).then((res) => res.json())
+const fetcher = async (url: string) => {
+    const res = await fetch(url)
+    const data = await res.json()
+
+    if (!res.ok) {
+        throw new Error(data?.error || "Failed to fetch notifications")
+    }
+
+    return data
+}
 
 export default function NotificationBell() {
     const [isOpen, setIsOpen] = useState(false)
+    const [hasPollingError, setHasPollingError] = useState(false)
     const router = useRouter()
+    const { isLoaded, isSignedIn } = useAuth()
+    const canLoadNotifications = isLoaded && isSignedIn
 
-    const { data, error, mutate } = useSWR('/api/notifications', fetcher, {
-        refreshInterval: 30000,
+    const { data, error, mutate } = useSWR(canLoadNotifications ? '/api/notifications' : null, fetcher, {
+        refreshInterval: hasPollingError ? 120000 : 30000,
+        shouldRetryOnError: false,
+        onError: () => setHasPollingError(true),
+        onSuccess: () => setHasPollingError(false),
     })
 
     const unreadCount = data?.unreadCount || 0
     const notifications: Notification[] = data?.notifications || []
-    const isLoading = !data && !error
+    const isLoading = canLoadNotifications && !data && !error
 
     useEffect(() => {
+        if (!canLoadNotifications) {
+            setHasPollingError(false)
+            return
+        }
+
         const source = new EventSource('/api/notifications/stream')
+        let streamErrorCount = 0
 
         source.addEventListener('notification', (event) => {
             const payload = JSON.parse((event as MessageEvent).data) as Notification
+            streamErrorCount = 0
 
             toast(payload.title, {
                 description: payload.message,
@@ -76,14 +99,22 @@ export default function NotificationBell() {
             }, false)
         })
 
+        source.onopen = () => {
+            streamErrorCount = 0
+        }
+
         source.onerror = () => {
-            // Keep the browser's built-in retry behavior active.
+            streamErrorCount += 1
+
+            if (streamErrorCount >= 3) {
+                source.close()
+            }
         }
 
         return () => {
             source.close()
         }
-    }, [mutate, router])
+    }, [canLoadNotifications, mutate, router])
 
     const markAsRead = async (id: number) => {
         // Optimistic update


### PR DESCRIPTION
## **User description**
## Description
Fixes the notification bell polling behavior so it only requests notifications when Clerk auth is loaded and the user is signed in. It also treats failed notification responses as SWR errors, disables aggressive retrying, slows polling after errors, and prevents the notification stream from opening for signed-out users.

## Related Issue
Closes #421

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Documentation update (README, guides, comments)
- [ ] Style / UI change (no logic change)
- [ ] Code refactor (no behavior change)
- [ ] Test addition or update
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Screenshots (if UI change)

Not applicable. This is a network/auth polling behavior fix with no UI changes.

## How Has This Been Tested?
- [x] Tested locally with `npm run dev`
- [ ] Verified on mobile viewport (375px)
- [ ] Verified on desktop viewport (1440px)

Additional verification:
- Confirmed only `src/components/NotificationBell.tsx` was changed.
- Confirmed `/api/notifications` does not repeatedly poll when Clerk is not loaded/signed in.
- Ran `npx tsc --noEmit`; `NotificationBell.tsx` has no type errors.
- `npm run build` is blocked locally by an unrelated Next webpack issue caused by the apostrophe in the local folder path.

## Checklist
- [x] I have tested my changes locally (`npm run dev`)
- [x] My code follows the existing code style (TypeScript, Tailwind, no `any` types)
- [x] I have not introduced unrelated changes (each PR should address one issue)
- [ ] I have added comments where necessary
- [ ] My branch is up to date with `main`
- [x] I have linked the related issue above
- [x] Screenshots are included (if this is a UI change)


___

## **CodeAnt-AI Description**
Stop notification polling and live updates when the user is not signed in

### What Changed
- Notification data now loads only after authentication is ready and the user is signed in
- Failed notification requests now show an error instead of silently retrying, and polling slows down after errors
- The live notification stream no longer opens for signed-out users and closes after repeated connection failures
- New notification messages still appear in the bell and increase the unread count when the user is signed in

### Impact
`✅ Fewer notification requests for signed-out users`
`✅ Reduced repeated polling after notification errors`
`✅ More reliable unread updates for signed-in users`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Notifications now only load when you're signed in, preventing unnecessary requests.
  * Improved error handling and recovery for notification polling.
  * Enhanced notification stream stability with better error detection and handling for repeated failures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/knoxiboy/DoubtDesk/pull/424?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->