### PR TITLE
fix: show errors for bookmarks and recommendations

### DIFF
--- a/src/app/bookmarks/page.tsx
+++ b/src/app/bookmarks/page.tsx
@@ -7,6 +7,16 @@ import { useRouter } from "next/navigation";
 import { useAppUser } from "@/app/provider";
 import { SignedIn, SignedOut, RedirectToSignIn } from "@clerk/nextjs";
 
+const ERROR_MESSAGES = {
+  BOOKMARKS_LOAD_FAILED: "Failed to load bookmarks",
+} as const;
+
+const UI_TEXT = {
+  ERROR_HEADING: "Unable to Load Bookmarks",
+  RETRY_BUTTON: "Try Again",
+  RETRY_BOOKMARKS_LABEL: "Retry loading bookmarks",
+} as const;
+
 export default function BookmarksPage() {
   const [bookmarks, setBookmarks] = useState<any[]>([]);
   const [loading, setLoading] = useState(true);
@@ -22,13 +32,13 @@ export default function BookmarksPage() {
       const data = await res.json();
 
       if (!res.ok) {
-        throw new Error(data?.error || "Failed to load bookmarks");
+        throw new Error(data?.error || ERROR_MESSAGES.BOOKMARKS_LOAD_FAILED);
       }
 
       setBookmarks(data);
     } catch (error) {
       console.error("Failed to fetch bookmarks:", error);
-      setError(error instanceof Error ? error.message : "Failed to load bookmarks");
+      setError(error instanceof Error ? error.message : ERROR_MESSAGES.BOOKMARKS_LOAD_FAILED);
     } finally {
       setLoading(false);
     }
@@ -76,20 +86,24 @@ export default function BookmarksPage() {
                 <p className="text-slate-400 dark:text-zinc-500 font-bold uppercase tracking-wider text-xs">Loading your saved doubts...</p>
               </div>
             ) : error ? (
-              <div className="flex flex-col items-center justify-center py-20 bg-red-50/50 dark:bg-red-950/10 border border-dashed border-red-200 dark:border-red-900 rounded-2xl text-center px-6 shadow-sm">
+              <div
+                role="alert"
+                className="flex flex-col items-center justify-center py-20 bg-red-50/50 dark:bg-red-950/10 border border-dashed border-red-200 dark:border-red-900 rounded-2xl text-center px-6 shadow-sm"
+              >
                 <div className="w-16 h-16 bg-white dark:bg-zinc-900 border border-red-200 dark:border-red-900 rounded-xl flex items-center justify-center mb-6 shadow-sm">
-                  <Bookmark className="w-7 h-7 text-red-500" />
+                  <Bookmark aria-hidden="true" className="w-7 h-7 text-red-500" />
                 </div>
-                <h3 className="text-xl font-bold text-slate-900 dark:text-white tracking-tight mb-2">Unable to Load Bookmarks</h3>
+                <h3 className="text-xl font-bold text-slate-900 dark:text-white tracking-tight mb-2">{UI_TEXT.ERROR_HEADING}</h3>
                 <p className="text-slate-500 dark:text-zinc-400 max-w-sm mx-auto font-medium text-xs leading-relaxed mb-6">
                   {error}
                 </p>
                 <button
                   onClick={fetchBookmarks}
+                  aria-label={UI_TEXT.RETRY_BOOKMARKS_LABEL}
                   className="inline-flex items-center gap-2 px-6 py-3.5 bg-red-600 hover:bg-red-700 text-white rounded-xl font-bold uppercase tracking-wider text-xs transition-all duration-300 shadow-lg shadow-red-600/10 active:scale-[0.98]"
                 >
-                  <RefreshCw className="w-3.5 h-3.5" />
-                  Try Again
+                  <RefreshCw aria-hidden="true" className="w-3.5 h-3.5" />
+                  {UI_TEXT.RETRY_BUTTON}
                 </button>
               </div>
             ) : bookmarks.length > 0 ? (

--- a/src/app/bookmarks/page.tsx
+++ b/src/app/bookmarks/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { Bookmark, Loader2, ArrowLeft } from "lucide-react";
+import { Bookmark, Loader2, ArrowLeft, RefreshCw } from "lucide-react";
 import DoubtCard from "@/components/DoubtCard";
 import { useRouter } from "next/navigation";
 import { useAppUser } from "@/app/provider";
@@ -10,19 +10,25 @@ import { SignedIn, SignedOut, RedirectToSignIn } from "@clerk/nextjs";
 export default function BookmarksPage() {
   const [bookmarks, setBookmarks] = useState<any[]>([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
   const router = useRouter();
   const { appUser } = useAppUser();
 
   const fetchBookmarks = async () => {
     setLoading(true);
+    setError(null);
     try {
       const res = await fetch("/api/bookmarks");
       const data = await res.json();
-      if (res.ok) {
-        setBookmarks(data);
+
+      if (!res.ok) {
+        throw new Error(data?.error || "Failed to load bookmarks");
       }
+
+      setBookmarks(data);
     } catch (error) {
       console.error("Failed to fetch bookmarks:", error);
+      setError(error instanceof Error ? error.message : "Failed to load bookmarks");
     } finally {
       setLoading(false);
     }
@@ -68,6 +74,23 @@ export default function BookmarksPage() {
               <div className="flex flex-col items-center justify-center py-24 space-y-4">
                 <Loader2 className="w-8 h-8 text-purple-500 animate-spin" />
                 <p className="text-slate-400 dark:text-zinc-500 font-bold uppercase tracking-wider text-xs">Loading your saved doubts...</p>
+              </div>
+            ) : error ? (
+              <div className="flex flex-col items-center justify-center py-20 bg-red-50/50 dark:bg-red-950/10 border border-dashed border-red-200 dark:border-red-900 rounded-2xl text-center px-6 shadow-sm">
+                <div className="w-16 h-16 bg-white dark:bg-zinc-900 border border-red-200 dark:border-red-900 rounded-xl flex items-center justify-center mb-6 shadow-sm">
+                  <Bookmark className="w-7 h-7 text-red-500" />
+                </div>
+                <h3 className="text-xl font-bold text-slate-900 dark:text-white tracking-tight mb-2">Unable to Load Bookmarks</h3>
+                <p className="text-slate-500 dark:text-zinc-400 max-w-sm mx-auto font-medium text-xs leading-relaxed mb-6">
+                  {error}
+                </p>
+                <button
+                  onClick={fetchBookmarks}
+                  className="inline-flex items-center gap-2 px-6 py-3.5 bg-red-600 hover:bg-red-700 text-white rounded-xl font-bold uppercase tracking-wider text-xs transition-all duration-300 shadow-lg shadow-red-600/10 active:scale-[0.98]"
+                >
+                  <RefreshCw className="w-3.5 h-3.5" />
+                  Try Again
+                </button>
               </div>
             ) : bookmarks.length > 0 ? (
               <div className="flex flex-col gap-6 lg:gap-8">

--- a/src/components/RecommendedClassrooms.tsx
+++ b/src/components/RecommendedClassrooms.tsx
@@ -19,20 +19,22 @@ export default function RecommendedClassrooms() {
     const [classrooms, setClassrooms] = useState<Classroom[]>([]);
     const [loading, setLoading] = useState(true);
     const [refreshing, setRefreshing] = useState(false);
+    const [error, setError] = useState<string | null>(null);
 
     const fetchRecommendations = async () => {
+        setError(null);
         try {
             const res = await fetch("/api/recommendations");
+            const data = await res.json();
 
             if (!res.ok) {
-                throw new Error("Failed to fetch recommendations");
+                throw new Error(data?.error || "Failed to load recommendations");
             }
-
-            const data = await res.json();
 
             setClassrooms(data.recommendations || []);
         } catch (error) {
             console.error(error);
+            setError(error instanceof Error ? error.message : "Failed to load recommendations");
         } finally {
             setLoading(false);
             setRefreshing(false);
@@ -53,6 +55,27 @@ export default function RecommendedClassrooms() {
             <div className="flex items-center gap-2 text-sm text-gray-500">
                 <Loader2 className="h-4 w-4 animate-spin" />
                 Loading recommendations...
+            </div>
+        );
+    }
+
+    if (error) {
+        return (
+            <div className="rounded-xl border border-red-200 bg-red-50 p-4 text-sm text-red-700">
+                <p className="font-medium">Unable to load recommendations.</p>
+                <p className="mt-1 text-red-600">{error}</p>
+                <button
+                    onClick={refreshRecommendations}
+                    disabled={refreshing}
+                    className="mt-3 flex items-center gap-2 rounded-lg border border-red-200 bg-white px-3 py-2 text-sm font-medium text-red-700 hover:bg-red-50 disabled:opacity-60"
+                >
+                    <RefreshCw
+                        className={`h-4 w-4 ${
+                            refreshing ? "animate-spin" : ""
+                        }`}
+                    />
+                    Try again
+                </button>
             </div>
         );
     }

--- a/src/components/RecommendedClassrooms.tsx
+++ b/src/components/RecommendedClassrooms.tsx
@@ -15,6 +15,16 @@ type Classroom = {
     activityCount: number;
 };
 
+const ERROR_MESSAGES = {
+    RECOMMENDATIONS_LOAD_FAILED: "Failed to load recommendations",
+} as const;
+
+const UI_TEXT = {
+    ERROR_HEADING: "Unable to load recommendations.",
+    RETRY_BUTTON: "Try again",
+    RETRY_RECOMMENDATIONS_LABEL: "Retry loading recommendations",
+} as const;
+
 export default function RecommendedClassrooms() {
     const [classrooms, setClassrooms] = useState<Classroom[]>([]);
     const [loading, setLoading] = useState(true);
@@ -22,19 +32,19 @@ export default function RecommendedClassrooms() {
     const [error, setError] = useState<string | null>(null);
 
     const fetchRecommendations = async () => {
-        setError(null);
         try {
             const res = await fetch("/api/recommendations");
             const data = await res.json();
 
             if (!res.ok) {
-                throw new Error(data?.error || "Failed to load recommendations");
+                throw new Error(data?.error || ERROR_MESSAGES.RECOMMENDATIONS_LOAD_FAILED);
             }
 
             setClassrooms(data.recommendations || []);
+            setError(null);
         } catch (error) {
             console.error(error);
-            setError(error instanceof Error ? error.message : "Failed to load recommendations");
+            setError(error instanceof Error ? error.message : ERROR_MESSAGES.RECOMMENDATIONS_LOAD_FAILED);
         } finally {
             setLoading(false);
             setRefreshing(false);
@@ -61,20 +71,25 @@ export default function RecommendedClassrooms() {
 
     if (error) {
         return (
-            <div className="rounded-xl border border-red-200 bg-red-50 p-4 text-sm text-red-700">
-                <p className="font-medium">Unable to load recommendations.</p>
+            <div
+                role="alert"
+                className="rounded-xl border border-red-200 bg-red-50 p-4 text-sm text-red-700"
+            >
+                <p className="font-medium">{UI_TEXT.ERROR_HEADING}</p>
                 <p className="mt-1 text-red-600">{error}</p>
                 <button
                     onClick={refreshRecommendations}
                     disabled={refreshing}
+                    aria-label={UI_TEXT.RETRY_RECOMMENDATIONS_LABEL}
                     className="mt-3 flex items-center gap-2 rounded-lg border border-red-200 bg-white px-3 py-2 text-sm font-medium text-red-700 hover:bg-red-50 disabled:opacity-60"
                 >
                     <RefreshCw
+                        aria-hidden="true"
                         className={`h-4 w-4 ${
                             refreshing ? "animate-spin" : ""
                         }`}
                     />
-                    Try again
+                    {UI_TEXT.RETRY_BUTTON}
                 </button>
             </div>
         );


### PR DESCRIPTION
## **User description**
## Description
Adds proper failed-load states for bookmarks and recommended classrooms so API failures are no longer shown as valid empty results. Failed requests now store an error message and render a retry UI instead of falling through to “No Bookmarks Yet” or “No recommendations available right now.”

## Related Issue
Closes #420

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Documentation update (README, guides, comments)
- [ ] Style / UI change (no logic change)
- [ ] Code refactor (no behavior change)
- [ ] Test addition or update
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Screenshots (if UI change)
Not applicable. This is an error-state behavior fix.

## How Has This Been Tested?
- [x] Tested locally with `npm run dev`
- [ ] Verified on mobile viewport (375px)
- [ ] Verified on desktop viewport (1440px)

Additional verification:
- Confirmed only `src/app/bookmarks/page.tsx` and `src/components/RecommendedClassrooms.tsx` changed.
- Ran `git diff --check HEAD~1..HEAD`.
- Ran `npx tsc --noEmit`; remaining errors are unrelated existing issues in API tests and `AnimatedCursor.tsx`.

## Checklist
- [x] I have tested my changes locally (`npm run dev`)
- [x] My code follows the existing code style (TypeScript, Tailwind, no `any` types)
- [x] I have not introduced unrelated changes (each PR should address one issue)
- [ ] I have added comments where necessary
- [x] My branch is up to date with `main`
- [x] I have linked the related issue above
- [x] Screenshots are included (if this is a UI change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for bookmarks and recommendations loading.
  * Added user-facing error messages and distinct error states.
  * Added "Try Again" retry buttons to recover without full page reload.
  * Retry buttons are disabled while a retry is in progress.
  * Better feedback when network or server issues prevent loading content.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/knoxiboy/DoubtDesk/pull/425?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Show load errors and retry actions for bookmarks and recommendations**

### What Changed
- When bookmarks fail to load, users now see an error message and a retry button instead of an empty bookmarks view
- When recommended classrooms fail to load, users now see an error state with the server message and a retry button instead of “No recommendations available right now”
- Retry actions let users try the request again without leaving the page

### Impact
`✅ Clearer loading failures`
`✅ Fewer empty screens after API errors`
`✅ Easier recovery from failed refreshes`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
