### PR TITLE
feat: implement bookmark doubt action and filter board (#418)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54,6 +54,7 @@
         "drizzle-orm": "^0.45.2",
         "embla-carousel-react": "8.6.0",
         "file-saver": "2.0.5",
+        "framer-motion": "^12.40.0",
         "google-tts-api": "^0.0.6",
         "groq-sdk": "1.1.1",
         "inngest": "^4.4.0",
@@ -13211,6 +13212,33 @@
         "url": "https://github.com/sponsors/rawify"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "12.40.0",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.40.0.tgz",
+      "integrity": "sha512-uaBd3qC1v3KQqBEjwTUd183K6PbS+j0yR9w9VmEOLWA/tnUcSn8Xa3uck7t4dgpDoUss8xQTcj8W2L07lrnLFg==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.40.0",
+        "motion-utils": "^12.39.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fresh": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
@@ -17254,6 +17282,21 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
       "integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==",
+      "license": "MIT"
+    },
+    "node_modules/motion-dom": {
+      "version": "12.40.0",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.40.0.tgz",
+      "integrity": "sha512-HxU3ZaBwNPVQUBQf1xxgq+7JrPNZvjLVxgbpEZL7RrWJnsxOf0/OM+yrHG9ogLQ31Do/r57Oz2gQWPK+6q62mg==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.39.0"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.39.0",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.39.0.tgz",
+      "integrity": "sha512-8nadJAJjTtqRkmRF36FoJTrywK9nnFmnPwnSMyxaOCU7GDjN9RTMJIxx9De8ErM+vpPhMccr/6fo5WciyQLnMQ==",
       "license": "MIT"
     },
     "node_modules/ms": {

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "drizzle-orm": "^0.45.2",
     "embla-carousel-react": "8.6.0",
     "file-saver": "2.0.5",
+    "framer-motion": "^12.40.0",
     "google-tts-api": "^0.0.6",
     "groq-sdk": "1.1.1",
     "inngest": "^4.4.0",

--- a/src/__tests__/components/DoubtCard.test.tsx
+++ b/src/__tests__/components/DoubtCard.test.tsx
@@ -1,5 +1,16 @@
 import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+jest.mock('@clerk/nextjs', () => ({
+    useUser: () => ({ isSignedIn: true, user: { id: '1' } }),
+}));
+
+jest.mock('next/navigation', () => ({
+    useSearchParams: () => ({
+        get: jest.fn(() => null),
+    }),
+}));
+
 import DoubtCard from '@/components/DoubtCard';
 
 global.fetch = jest.fn(() =>

--- a/src/app/api/doubts/route.ts
+++ b/src/app/api/doubts/route.ts
@@ -21,6 +21,7 @@ export async function GET(req: Request) {
     const type = searchParams.get("type") || 'community';
     const tag = searchParams.get("tag");
     const sort = searchParams.get("sort") || "newest";
+    const bookmarked = searchParams.get("bookmarked") === "true";
 
     try {
         const user = await currentUser();
@@ -83,6 +84,18 @@ export async function GET(req: Request) {
             // Security/Privacy: AI history is personal
             if (type === 'ai' && email) {
                 conditions.push(eq(doubtsTable.userEmail, email));
+            }
+        }
+
+        if (bookmarked && email) {
+            const userBookmarks = await db.select({ doubtId: bookmarksTable.doubtId })
+                .from(bookmarksTable)
+                .where(eq(bookmarksTable.userEmail, email));
+            const bookmarkedIds = userBookmarks.map(b => b.doubtId);
+            if (bookmarkedIds.length > 0) {
+                conditions.push(inArray(doubtsTable.id, bookmarkedIds));
+            } else {
+                conditions.push(eq(doubtsTable.id, -1));
             }
         }
 

--- a/src/app/api/doubts/route.ts
+++ b/src/app/api/doubts/route.ts
@@ -28,6 +28,15 @@ export async function GET(req: Request) {
         if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
         const email = user.primaryEmailAddress?.emailAddress;
 
+        // Fetch user bookmarks once if email is available to avoid redundant queries
+        let bookmarkedIds = new Set<number>();
+        if (email) {
+            const userBookmarks = await db.select({ doubtId: bookmarksTable.doubtId })
+                .from(bookmarksTable)
+                .where(eq(bookmarksTable.userEmail, email));
+            bookmarkedIds = new Set(userBookmarks.map(b => b.doubtId));
+        }
+
         if (classroomId && email) {
             const [membership] = await db.select().from(membershipsTable).where(
                 and(eq(membershipsTable.userEmail, email), eq(membershipsTable.classroomId, classroomId))
@@ -87,13 +96,11 @@ export async function GET(req: Request) {
             }
         }
 
-        if (bookmarked && email) {
-            const userBookmarks = await db.select({ doubtId: bookmarksTable.doubtId })
-                .from(bookmarksTable)
-                .where(eq(bookmarksTable.userEmail, email));
-            const bookmarkedIds = userBookmarks.map(b => b.doubtId);
-            if (bookmarkedIds.length > 0) {
-                conditions.push(inArray(doubtsTable.id, bookmarkedIds));
+        if (bookmarked) {
+            if (!email) {
+                conditions.push(eq(doubtsTable.id, -1));
+            } else if (bookmarkedIds.size > 0) {
+                conditions.push(inArray(doubtsTable.id, Array.from(bookmarkedIds)));
             } else {
                 conditions.push(eq(doubtsTable.id, -1));
             }
@@ -177,12 +184,6 @@ export async function GET(req: Request) {
         }
 
         if (email && doubts.length > 0) {
-            const userBookmarks = await db.select({ doubtId: bookmarksTable.doubtId })
-                .from(bookmarksTable)
-                .where(eq(bookmarksTable.userEmail, email));
-
-            const bookmarkedIds = new Set(userBookmarks.map(b => b.doubtId));
-
             doubts = doubts.map(doubt => ({
                 ...doubt,
                 hasBookmarked: bookmarkedIds.has(doubt.id)

--- a/src/app/public-rooms/page.tsx
+++ b/src/app/public-rooms/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { MessageSquare, Plus, SlidersHorizontal, Loader2 } from "lucide-react";
+import { MessageSquare, Plus, SlidersHorizontal, Loader2, Bookmark } from "lucide-react";
 import AskDoubt from "@/components/AskDoubt";
 import DoubtCard from "@/components/DoubtCard";
 import DoubtSortSelect, { DoubtSortValue } from "@/components/DoubtSortSelect";
@@ -9,8 +9,10 @@ import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import useSWRInfinite from "swr/infinite";
 import { useInView } from "react-intersection-observer";
 import ScrollToTopButton from "@/components/ScrollToTopButton";
+import { useUser } from "@clerk/nextjs";
 
 export default function PublicRoomsPage() {
+    const { isSignedIn } = useUser();
     const pathname = usePathname();
     const router = useRouter();
     const searchParams = useSearchParams();
@@ -57,8 +59,12 @@ export default function PublicRoomsPage() {
         const params = new URLSearchParams();
         
         if (filter !== "All") {
-            const subjectFilter = filter === "Others" ? appliedCustomFilter : filter;
-            if (subjectFilter) params.append("subject", subjectFilter);
+            if (filter === "Bookmarked") {
+                params.append("bookmarked", "true");
+            } else {
+                const subjectFilter = filter === "Others" ? appliedCustomFilter : filter;
+                if (subjectFilter) params.append("subject", subjectFilter);
+            }
         }
 
         if (searchQuery) {
@@ -174,7 +180,13 @@ export default function PublicRoomsPage() {
                         <SlidersHorizontal className="w-4 h-4" />
                         <span className="text-[11px] font-bold uppercase tracking-wider">Filter:</span>
                     </div>
-                    {["All", "Math", "Science", "Physics", "Chemistry", "Programming", "Others"].map((f) => (
+                    {(() => {
+                        const filtersList = ["All", "Math", "Science", "Physics", "Chemistry", "Programming", "Others"];
+                        if (isSignedIn) {
+                            filtersList.push("Bookmarked");
+                        }
+                        return filtersList;
+                    })().map((f) => (
                         <button
                             key={f}
                             onClick={() => {
@@ -187,12 +199,17 @@ export default function PublicRoomsPage() {
                                     setIsOthersActive(true);
                                 }
                             }}
-                            className={`px-5 py-2 rounded-xl text-[11px] font-bold uppercase tracking-wider transition-all duration-300 border shrink-0 ${
+                            className={`px-5 py-2 rounded-xl text-[11px] font-bold uppercase tracking-wider transition-all duration-300 border shrink-0 flex items-center gap-1.5 ${
                                 filter === f 
-                                ? "bg-blue-600 border-blue-500 text-white shadow-lg shadow-blue-600/10" 
+                                ? f === "Bookmarked"
+                                    ? "bg-blue-500/20 border-blue-500/30 text-blue-500 dark:text-blue-400 shadow-lg shadow-blue-500/5"
+                                    : "bg-blue-600 border-blue-500 text-white shadow-lg shadow-blue-600/10" 
                                 : "bg-white dark:bg-zinc-950/20 border-slate-200 dark:border-zinc-900 text-slate-500 dark:text-zinc-400 hover:bg-slate-50 dark:hover:bg-zinc-900/40"
                             }`}
                         >
+                            {f === "Bookmarked" && (
+                                <Bookmark className={`w-3.5 h-3.5 ${filter === "Bookmarked" ? "fill-blue-500 text-blue-500 dark:fill-blue-400 dark:text-blue-400" : "text-slate-400 dark:text-zinc-500"}`} />
+                            )}
                             {f}
                         </button>
                     ))}
@@ -325,15 +342,23 @@ export default function PublicRoomsPage() {
 
                     <div className="relative space-y-2 mb-6">
                         <h2 className="text-2xl font-black text-slate-900 dark:text-white tracking-tight">
-                            {searchQuery ? "No matching doubts" : randomMessage.headline}{" "}
-                            <span className="text-blue-600 dark:text-blue-400">{searchQuery ? "" : randomMessage.accent}</span>
+                            {searchQuery 
+                                ? "No matching doubts" 
+                                : filter === "Bookmarked"
+                                    ? "No bookmarked doubts yet"
+                                    : randomMessage.headline}{" "}
+                            <span className="text-blue-600 dark:text-blue-400">
+                                {searchQuery ? "" : filter === "Bookmarked" ? "" : randomMessage.accent}
+                            </span>
                         </h2>
                         <p className="text-slate-500 dark:text-zinc-400 max-w-sm mx-auto text-xs font-medium leading-relaxed">
                             {searchQuery 
                                 ? `We couldn't find any doubts matching "${searchQuery}". Try a different keyword or subject.`
-                                : filter === "All"
-                                    ? randomMessage.sub
-                                    : `${filter} is wide open. Drop a doubt, and watch your classmates rally around it.`}
+                                : filter === "Bookmarked"
+                                    ? "Save important doubts by clicking the bookmark icon on any doubt card to view them here later."
+                                    : filter === "All"
+                                        ? randomMessage.sub
+                                        : `${filter} is wide open. Drop a doubt, and watch your classmates rally around it.`}
                         </p>
                     </div>
 
@@ -344,6 +369,13 @@ export default function PublicRoomsPage() {
                                 className="flex items-center gap-3 px-6 py-3.5 bg-blue-600 hover:bg-blue-700 text-white rounded-xl font-bold uppercase tracking-wider text-xs transition-all duration-300 shadow-md shadow-blue-600/10 active:scale-[0.98]"
                             >
                                 Clear Search
+                            </button>
+                        ) : filter === "Bookmarked" ? (
+                            <button
+                                onClick={() => setFilter("All")}
+                                className="group flex items-center gap-3 px-6 py-3.5 bg-blue-600 hover:bg-blue-700 text-white rounded-xl font-bold uppercase tracking-wider text-xs transition-all duration-300 shadow-md shadow-blue-600/10 active:scale-[0.98]"
+                            >
+                                Explore public doubts
                             </button>
                         ) : (
                             <button

--- a/src/app/public-rooms/page.tsx
+++ b/src/app/public-rooms/page.tsx
@@ -35,6 +35,12 @@ export default function PublicRoomsPage() {
         return () => clearTimeout(timer);
     }, [searchVal]);
 
+    useEffect(() => {
+        if (!isSignedIn && filter === "Bookmarked") {
+            setFilter("All");
+        }
+    }, [isSignedIn, filter]);
+
     const sort = (searchParams.get("sort") as DoubtSortValue) || "newest";
 
     const fetcher = (url: string) => fetch(url).then(res => res.json());

--- a/src/components/DoubtCard.tsx
+++ b/src/components/DoubtCard.tsx
@@ -7,6 +7,7 @@ import DoubtRepliesModal from "./DoubtRepliesModal";
 import { toast } from "sonner";
 import { DeleteConfirmationDialog } from "./DeleteConfirmationDialog";
 import { useSearchParams } from "next/navigation";
+import { useUser } from "@clerk/nextjs";
 
 interface DoubtCardProps {
     doubt: any;
@@ -17,6 +18,7 @@ interface DoubtCardProps {
 }
 
 export default function DoubtCard({ doubt, onUpdate, onViewAISolution, role, openRepliesOnMount = false }: DoubtCardProps) {
+    const { isSignedIn } = useUser();
     const [isOwner, setIsOwner] = useState(false);
     const [isLiking, setIsLiking] = useState(false);
     const [isSolving, setIsSolving] = useState(false);
@@ -263,14 +265,16 @@ export default function DoubtCard({ doubt, onUpdate, onViewAISolution, role, ope
                             <span className="text-xs font-black">{likes}</span>
                         </button>
 
-                        <button
-                            onClick={handleBookmark}
-                            disabled={isBookmarking}
-                            className={`flex items-center justify-center p-3 rounded-2xl transition-all ${ doubt.hasBookmarked ? "bg-purple-600/20 text-purple-400 border border-purple-500/30 shadow-lg shadow-purple-500/10" : "bg-white/5 hover:bg-white/10 text-slate-400 hover:text-white border border-white/5" }`}
-                            title={doubt.hasBookmarked ? "Remove bookmark" : "Add to bookmarks"}
-                        >
-                            <Bookmark className={`w-4 h-4 ${isBookmarking ? 'animate-pulse' : ''} ${doubt.hasBookmarked ? 'fill-purple-400' : ''}`} />
-                        </button>
+                        {isSignedIn && (
+                            <button
+                                onClick={handleBookmark}
+                                disabled={isBookmarking}
+                                className={`flex items-center justify-center p-3 rounded-2xl transition-all ${ doubt.hasBookmarked ? "bg-purple-600/20 text-purple-400 border border-purple-500/30 shadow-lg shadow-purple-500/10" : "bg-white/5 hover:bg-white/10 text-slate-400 hover:text-white border border-white/5" }`}
+                                title={doubt.hasBookmarked ? "Remove bookmark" : "Add to bookmarks"}
+                            >
+                                <Bookmark className={`w-4 h-4 ${isBookmarking ? 'animate-pulse' : ''} ${doubt.hasBookmarked ? 'fill-purple-400' : ''}`} />
+                            </button>
+                        )}
 
                         {((isOwner && doubt.type !== 'ai') || isTeacher) && doubt.isSolved !== "solved" && (
                             <button

--- a/src/components/DoubtCard.tsx
+++ b/src/components/DoubtCard.tsx
@@ -271,6 +271,7 @@ export default function DoubtCard({ doubt, onUpdate, onViewAISolution, role, ope
                                 disabled={isBookmarking}
                                 className={`flex items-center justify-center p-3 rounded-2xl transition-all ${ doubt.hasBookmarked ? "bg-purple-600/20 text-purple-400 border border-purple-500/30 shadow-lg shadow-purple-500/10" : "bg-white/5 hover:bg-white/10 text-slate-400 hover:text-white border border-white/5" }`}
                                 title={doubt.hasBookmarked ? "Remove bookmark" : "Add to bookmarks"}
+                                aria-label={doubt.hasBookmarked ? "Remove bookmark" : "Add to bookmarks"}
                             >
                                 <Bookmark className={`w-4 h-4 ${isBookmarking ? 'animate-pulse' : ''} ${doubt.hasBookmarked ? 'fill-purple-400' : ''}`} />
                             </button>


### PR DESCRIPTION
## **User description**
## Description
This PR implements GSSoC Issue #418: "Bookmark Doubt Action and Filter Board".
- **DoubtCard**: Added a bookmark button/icon to doubt cards, rendered conditionally only for authenticated users (`isSignedIn`).
- **GET /api/doubts**: Added support for parsing the `bookmarked` search parameter and filtering the fetched doubts to only return bookmarked doubts for the signed-in user.
- **Public Doubts Board**: Added a `'Bookmarked'` filter option to the main feed filter bar (visible to signed-in users), updating the SWR fetch URL to query only bookmarked doubts when selected. Added a polished empty state when no bookmarks are present.

## Related Issue
Closes #418 

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Documentation update (README, guides, comments)
- [ ] Style / UI change (no logic change)
- [ ] Code refactor (no behavior change)
- [x] Test addition or update
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## How Has This Been Tested?
- [x] Tested locally with `npm run dev`
- [x] Verified on mobile viewport (375px)
- [x] Verified on desktop viewport (1440px)

## Checklist
- [x] I have tested my changes locally (`npm run dev`)
- [x] My code follows the existing code style (TypeScript, Tailwind, no `any` types)
- [x] I have not introduced unrelated changes (each PR should address one issue)
- [x] I have added comments where necessary
- [x] My branch is up to date with `main`
- [x] I have linked the related issue above
- [ ] Screenshots are included (if this is a UI change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Bookmarked" filter (signed-in users) and bookmark controls visible only when authenticated.
  * Server-side support for fetching only bookmarked doubts when the Bookmarked filter is used.

* **Improvements**
  * Contextual empty-state messaging and primary CTA now adapt for the Bookmarked filter.
  * Filter UI updates to show Bookmarked only to signed-in users and preserve other filter behaviors.

* **Tests**
  * Tests updated to provide deterministic authentication/navigation context.

* **Chore**
  * Added framer-motion dependency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/knoxiboy/DoubtDesk/pull/429?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Let signed-in users bookmark doubts and review them in a dedicated filter

### What Changed
- The bookmark button now appears only for signed-in users on doubt cards, with a clear label for adding or removing bookmarks
- Signed-in users can open a new “Bookmarked” filter on the public doubts board to see only their saved doubts
- The bookmarked view shows a dedicated empty state and a shortcut back to all public doubts
- The doubts API now returns only the signed-in user’s bookmarked doubts when that filter is selected
- Added test coverage for the doubt card behavior in a signed-in session

### Impact
`✅ Saved doubts are easier to find`
`✅ Fewer bookmark controls for signed-out users`
`✅ Clearer empty-state guidance for bookmarked doubts`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
