### PR TITLE
fix: normalize infinite doubt feed pages

### DIFF
--- a/src/components/InfiniteDoubtFeed.tsx
+++ b/src/components/InfiniteDoubtFeed.tsx
@@ -29,7 +29,18 @@ interface InfiniteDoubtFeedProps {
 }
 
 const PAGE_SIZE = 10;
+const FAILED_LOAD_TEXT = "Failed to load doubts.";
+const RETRY_TEXT = "Retry";
+const SYNCING_TEXT = "Syncing Data...";
+const LOAD_MORE_TEXT = "Load More Doubts";
+const LOADING_MORE_ARIA_LABEL = "Loading more doubts";
+const LOAD_MORE_ARIA_LABEL = "Load more doubts";
+const VAULT_SYNCED_TEXT = "Vault Fully Synchronized";
 
+/**
+ * Normalizes either the current raw array response from /api/doubts or a
+ * paginated { doubts, pagination, error } response into one page shape.
+ */
 const normalizePage = (page: any) => {
     if (Array.isArray(page)) {
         return {
@@ -79,15 +90,32 @@ export default function InfiniteDoubtFeed({
         return `/api/doubts?${params.toString()}`;
     };
 
-    const { data, size, setSize, isLoading, isValidating, mutate } = useSWRInfinite(getKey, fetcher, {
+    const { data, error, size, setSize, isLoading, isValidating, mutate } = useSWRInfinite(getKey, fetcher, {
         revalidateFirstPage: false
     });
 
     const pages = data?.map(normalizePage);
     const doubts = pages ? pages.flatMap((page) => page.doubts) : [];
-    const isEmpty = pages?.[0]?.doubts.length === 0 || pages?.[0]?.error !== undefined;
+    const isPageError = pages?.[0]?.error !== undefined;
+    const isEmpty = !error && !isPageError && pages?.[0]?.doubts.length === 0;
     const isReachingEnd = isEmpty || (pages && !pages[pages.length - 1]?.hasMore);
     const isLoadingMore = isLoading || (size > 0 && data && typeof data[size - 1] === "undefined");
+    const hasLoadError = Boolean(error || isPageError);
+
+    if (hasLoadError) {
+        return (
+            <div className="py-24 text-center space-y-4 bg-red-50 dark:bg-red-900/10 border border-dashed border-red-200 dark:border-red-800/30 rounded-[2.5rem]">
+                <MessageSquare className="w-12 h-12 text-red-600 dark:text-red-400 mx-auto" />
+                <p className="text-red-600 dark:text-red-400 font-bold uppercase tracking-widest text-xs">{FAILED_LOAD_TEXT}</p>
+                <button
+                    onClick={() => mutate()}
+                    className="text-red-600 dark:text-red-400 font-black uppercase tracking-widest text-[10px] hover:underline underline-offset-4"
+                >
+                    {RETRY_TEXT}
+                </button>
+            </div>
+        );
+    }
 
     if (isLoading && doubts.length === 0) {
         return (
@@ -135,17 +163,18 @@ export default function InfiniteDoubtFeed({
                     <button
                         onClick={() => setSize(size + 1)}
                         disabled={isLoadingMore || isValidating}
+                        aria-label={isLoadingMore || isValidating ? LOADING_MORE_ARIA_LABEL : LOAD_MORE_ARIA_LABEL}
                         className="group flex items-center gap-3 px-8 py-3.5 bg-slate-100 dark:bg-white/5 border border-slate-200 dark:border-white/10 hover:bg-slate-200 dark:hover:bg-white/10 hover:border-blue-500/30 rounded-2xl font-black uppercase tracking-[0.2em] text-[10px] transition-all active:scale-[0.98] disabled:opacity-50 disabled:cursor-not-allowed"
                     >
                         {isLoadingMore || isValidating ? (
                             <>
                                 <Loader2 className="w-4 h-4 text-blue-500 animate-spin" />
-                                <span>Syncing Data...</span>
+                                <span>{SYNCING_TEXT}</span>
                             </>
                         ) : (
                             <>
                                 <ChevronDown className="w-4 h-4 text-blue-500 group-hover:translate-y-0.5 transition-transform" />
-                                <span>Load More Doubts</span>
+                                <span>{LOAD_MORE_TEXT}</span>
                             </>
                         )}
                     </button>
@@ -153,7 +182,7 @@ export default function InfiniteDoubtFeed({
                     doubts.length > 0 && (
                         <div className="flex flex-col items-center gap-2">
                             <div className="w-8 h-[1px] bg-gradient-to-r from-transparent via-slate-700 to-transparent mb-2"></div>
-                            <p className="text-slate-600 text-[9px] font-black uppercase tracking-[0.4em]">Vault Fully Synchronized</p>
+                            <p className="text-slate-600 text-[9px] font-black uppercase tracking-[0.4em]">{VAULT_SYNCED_TEXT}</p>
                         </div>
                     )
                 )}

--- a/src/components/InfiniteDoubtFeed.tsx
+++ b/src/components/InfiniteDoubtFeed.tsx
@@ -5,7 +5,15 @@ import DoubtCard from "@/components/DoubtCard";
 import useSWRInfinite from "swr/infinite";
 import ScrollToTopButton from "./ScrollToTopButton";
 
-const fetcher = (url: string) => fetch(url).then((res) => res.json());
+const fetcher = async (url: string) => {
+    const res = await fetch(url);
+
+    if (!res.ok) {
+        throw new Error(`Failed to load doubts: ${res.status}`);
+    }
+
+    return res.json();
+};
 
 interface InfiniteDoubtFeedProps {
     classroomId?: number;
@@ -22,6 +30,22 @@ interface InfiniteDoubtFeedProps {
 
 const PAGE_SIZE = 10;
 
+const normalizePage = (page: any) => {
+    if (Array.isArray(page)) {
+        return {
+            doubts: page,
+            hasMore: page.length === PAGE_SIZE,
+            error: undefined,
+        };
+    }
+
+    return {
+        doubts: page?.doubts ?? [],
+        hasMore: Boolean(page?.pagination?.hasMore),
+        error: page?.error,
+    };
+};
+
 export default function InfiniteDoubtFeed({
     classroomId,
     subject,
@@ -35,7 +59,7 @@ export default function InfiniteDoubtFeed({
     emptyActionLabel
 }: InfiniteDoubtFeedProps) {
     const getKey = (pageIndex: number, previousPageData: any) => {
-        if (previousPageData && !previousPageData.pagination?.hasMore) return null;
+        if (previousPageData && !normalizePage(previousPageData).hasMore) return null;
 
 
         const params = new URLSearchParams();
@@ -59,9 +83,10 @@ export default function InfiniteDoubtFeed({
         revalidateFirstPage: false
     });
 
-    const doubts = data ? data.flatMap((page) => page?.doubts ?? []) : [];
-    const isEmpty = data?.[0]?.doubts?.length === 0 || data?.[0]?.error !== undefined;
-    const isReachingEnd = isEmpty || (data && !data[data.length - 1]?.pagination?.hasMore);
+    const pages = data?.map(normalizePage);
+    const doubts = pages ? pages.flatMap((page) => page.doubts) : [];
+    const isEmpty = pages?.[0]?.doubts.length === 0 || pages?.[0]?.error !== undefined;
+    const isReachingEnd = isEmpty || (pages && !pages[pages.length - 1]?.hasMore);
     const isLoadingMore = isLoading || (size > 0 && data && typeof data[size - 1] === "undefined");
 
     if (isLoading && doubts.length === 0) {


### PR DESCRIPTION
## **User description**
Closes #419

Raised as part of GSSoC 2026.

I hit this while checking `InfiniteDoubtFeed`: the component assumes each SWR page looks like `{ doubts, pagination }`, but `/api/doubts` currently returns a plain array. That means the feed flattens to an empty list and the pagination check never reads the actual page data correctly.

This keeps the existing API behavior intact and makes the component handle both response shapes:
- raw array pages from the current `/api/doubts` route
- object pages with `{ doubts, pagination }` if the API is changed later

I also made the local fetcher throw on non-2xx responses so failed loads do not get treated as valid page data.

Testing:
- `npm test -- --passWithNoTests` passes: 19 suites, 82 tests
- focused TypeScript check for `src/components/InfiniteDoubtFeed.tsx` passes
- full build is still blocked by the existing unrelated `framer-motion` dependency issue in `src/components/AnimatedCursor.tsx`


___

## **CodeAnt-AI Description**
**Fix infinite doubt feed loading and pagination for current API responses**

### What Changed
- The doubt feed now works when the API returns a plain list of doubts, instead of showing an empty feed.
- Pagination now stops at the right time for both plain list responses and responses that include pagination details.
- Failed requests are treated as errors instead of being shown as valid feed data.

### Impact
`✅ Fewer empty doubt feeds`
`✅ Correct "load more" behavior`
`✅ Clearer failed-load handling`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling in infinite feed data loading with better HTTP status reporting
  * Enhanced consistency in paginated data processing across different data formats

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/knoxiboy/DoubtDesk/pull/443?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->