### PR TITLE
fix: guard notification test seed route

### DIFF
--- a/src/__tests__/api/notifications-test-seed.test.ts
+++ b/src/__tests__/api/notifications-test-seed.test.ts
@@ -29,11 +29,17 @@ const { GET, POST } = require('@/app/api/notifications/test-seed/route');
 const { mockInsert, mockValues } = require('@/configs/db')._mocks;
 
 describe('Notification test seed API endpoint', () => {
+    const originalNodeEnv = process.env.NODE_ENV;
+
     beforeEach(() => {
         currentUserMock.mockReset();
         mockValues.mockReset();
         mockInsert.mockClear();
         mockValues.mockResolvedValue({});
+    });
+
+    afterEach(() => {
+        process.env.NODE_ENV = originalNodeEnv;
     });
 
     it('does not seed notifications from GET requests', async () => {
@@ -45,6 +51,32 @@ describe('Notification test seed API endpoint', () => {
         expect(json.error).toBe('Method Not Allowed');
         expect(currentUserMock).not.toHaveBeenCalled();
         expect(mockInsert).not.toHaveBeenCalled();
+    });
+
+    it('hides the seed route from GET requests in production', async () => {
+        process.env.NODE_ENV = 'production';
+
+        const res = await GET();
+        const json = await res.json();
+
+        expect(res.status).toBe(404);
+        expect(json).toEqual({ error: 'Not found' });
+        expect(currentUserMock).not.toHaveBeenCalled();
+        expect(mockInsert).not.toHaveBeenCalled();
+        expect(mockValues).not.toHaveBeenCalled();
+    });
+
+    it('hides the seed route from POST requests in production', async () => {
+        process.env.NODE_ENV = 'production';
+
+        const res = await POST();
+        const json = await res.json();
+
+        expect(res.status).toBe(404);
+        expect(json).toEqual({ error: 'Not found' });
+        expect(currentUserMock).not.toHaveBeenCalled();
+        expect(mockInsert).not.toHaveBeenCalled();
+        expect(mockValues).not.toHaveBeenCalled();
     });
 
     it('seeds notifications for the signed-in user only through POST', async () => {
@@ -73,14 +105,16 @@ describe('Notification test seed API endpoint', () => {
 
         const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
 
-        const res = await POST();
-        const json = await res.json();
+        try {
+            const res = await POST();
+            const json = await res.json();
 
-        expect(res.status).toBe(500);
-        expect(json).toEqual({ error: 'Failed to seed notifications' });
-        expect(json.details).toBeUndefined();
-        expect(json.stack).toBeUndefined();
-
-        consoleErrorSpy.mockRestore();
+            expect(res.status).toBe(500);
+            expect(json).toEqual({ error: 'Failed to seed notifications' });
+            expect(json.details).toBeUndefined();
+            expect(json.stack).toBeUndefined();
+        } finally {
+            consoleErrorSpy.mockRestore();
+        }
     });
 });

--- a/src/__tests__/api/notifications-test-seed.test.ts
+++ b/src/__tests__/api/notifications-test-seed.test.ts
@@ -1,0 +1,86 @@
+const currentUserMock = jest.fn();
+
+jest.mock('@clerk/nextjs/server', () => ({
+    currentUser: () => currentUserMock(),
+}));
+
+jest.mock('@/configs/db', () => {
+    const mockValues = jest.fn();
+    const mockInsert = jest.fn(() => ({ values: mockValues }));
+
+    return {
+        db: {
+            insert: mockInsert,
+        },
+        _mocks: {
+            mockInsert,
+            mockValues,
+        },
+    };
+});
+
+jest.mock('@/configs/schema', () => ({
+    notificationsTable: {
+        id: 'id',
+    },
+}));
+
+const { GET, POST } = require('@/app/api/notifications/test-seed/route');
+const { mockInsert, mockValues } = require('@/configs/db')._mocks;
+
+describe('Notification test seed API endpoint', () => {
+    beforeEach(() => {
+        currentUserMock.mockReset();
+        mockValues.mockReset();
+        mockInsert.mockClear();
+        mockValues.mockResolvedValue({});
+    });
+
+    it('does not seed notifications from GET requests', async () => {
+        const res = await GET();
+        const json = await res.json();
+
+        expect(res.status).toBe(405);
+        expect(res.headers.get('allow')).toBe('POST');
+        expect(json.error).toBe('Method Not Allowed');
+        expect(currentUserMock).not.toHaveBeenCalled();
+        expect(mockInsert).not.toHaveBeenCalled();
+    });
+
+    it('seeds notifications for the signed-in user only through POST', async () => {
+        currentUserMock.mockResolvedValue({
+            primaryEmailAddress: { emailAddress: 'student@example.com' },
+        });
+
+        const res = await POST();
+        const json = await res.json();
+
+        expect(res.status).toBe(200);
+        expect(json.success).toBe(true);
+        expect(mockInsert).toHaveBeenCalledWith({ id: 'id' });
+        expect(mockValues).toHaveBeenCalledWith(
+            expect.arrayContaining([
+                expect.objectContaining({ userEmail: 'student@example.com' }),
+            ])
+        );
+    });
+
+    it('returns a generic error when seeding fails', async () => {
+        currentUserMock.mockResolvedValue({
+            primaryEmailAddress: { emailAddress: 'student@example.com' },
+        });
+        mockValues.mockRejectedValue(new Error('sensitive stack trace'));
+
+        const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+        const res = await POST();
+        const json = await res.json();
+
+        expect(res.status).toBe(500);
+        expect(json).toEqual({ error: 'Failed to seed notifications' });
+        expect(json.details).toBeUndefined();
+        expect(json.stack).toBeUndefined();
+
+        consoleErrorSpy.mockRestore();
+    });
+});

--- a/src/app/api/notifications/test-seed/route.ts
+++ b/src/app/api/notifications/test-seed/route.ts
@@ -3,7 +3,24 @@ import { db } from "@/configs/db";
 import { notificationsTable } from "@/configs/schema";
 import { currentUser } from "@clerk/nextjs/server";
 
-export async function GET(req: Request) {
+const canSeedNotifications = () => process.env.NODE_ENV !== "production";
+
+export async function GET() {
+    if (!canSeedNotifications()) {
+        return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+
+    return NextResponse.json(
+        { error: "Method Not Allowed" },
+        { status: 405, headers: { Allow: "POST" } }
+    );
+}
+
+export async function POST() {
+    if (!canSeedNotifications()) {
+        return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+
     try {
         const user = await currentUser();
         if (!user || !user.primaryEmailAddress?.emailAddress) {
@@ -43,17 +60,13 @@ export async function GET(req: Request) {
         // Insert dummy notifications
         await db.insert(notificationsTable).values(dummyNotifications);
 
-        return NextResponse.json({ 
-            success: true, 
-            message: "Successfully seeded dummy notifications for the current user." 
+        return NextResponse.json({
+            success: true,
+            message: "Successfully seeded dummy notifications for the current user."
         });
 
-    } catch (error: any) {
+    } catch (error) {
         console.error("Error seeding notifications:", error);
-        return NextResponse.json({ 
-            error: "Failed to seed notifications", 
-            details: error?.message || String(error),
-            stack: error?.stack
-        }, { status: 500 });
+        return NextResponse.json({ error: "Failed to seed notifications" }, { status: 500 });
     }
 }


### PR DESCRIPTION
## **User description**
## Description
This locks down the notification test seed route from issue #450.

The route was doing a DB insert from `GET /api/notifications/test-seed`, which is risky for a test/helper endpoint because a browser visit, crawler, or accidental fetch can create data. I changed it so production gets a 404, `GET` no longer mutates anything, and local/test seeding has to go through `POST`.

The error response also no longer returns `details` or `stack` to the client.

Raised as part of GSSoC 2026.

## Related Issue
Closes #450

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Documentation update (README, guides, comments)
- [ ] Style / UI change (no logic change)
- [ ] Code refactor (no behavior change)
- [x] Test addition or update
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Screenshots (if UI change)
Not applicable. This is an API route fix.

## How Has This Been Tested?
- [x] Added Jest coverage for the seed route
- [x] `npm test -- --runTestsByPath src/__tests__/api/notifications-test-seed.test.ts`
- [x] `npm test -- --runInBand`

Notes from local checks:
- `npx tsc --noEmit` still reports existing unrelated type errors in older API tests.
- `npm run build` compiles and finishes TypeScript, then exits during static page generation without a page-level error in local output.

## Checklist
- [ ] I have tested my changes locally (`npm run dev`)
- [x] My code follows the existing code style (TypeScript, Tailwind, no `any` types)
- [x] I have not introduced unrelated changes (each PR should address one issue)
- [x] I have added comments where necessary
- [x] My branch is up to date with `main`
- [x] I have linked the related issue above
- [ ] Screenshots are included (if this is a UI change)


___

## **CodeAnt-AI Description**
**Lock down notification test seeding to POST and hide internal error details**

### What Changed
- GET requests to the notification test-seed route now return a method-not-allowed response instead of creating data
- Seeding is only available through POST in local or test environments; production now returns not found
- Failed seeding requests now return a simple error message without exposing stack traces or other internal details
- Added coverage for blocked GET requests, successful POST seeding, and generic failure responses

### Impact
`✅ Fewer accidental notification inserts`
`✅ Safer test seeding in production`
`✅ Clearer API responses without internal error details`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added/extended tests covering notification seeding API behavior, including env gating, success/failure flows, response codes, and DB/auth interactions.

* **Bug Fixes**
  * Disabled notification seeding in production environments.
  * Standardized API responses: concise success on seed, generic 500 on failure, and clear method-not-allowed information when applicable.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/knoxiboy/DoubtDesk/pull/451?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->