### PR TITLE
Feat: Implement doubtsTable soft-delete with deletedAt timestamp

### DIFF
--- a/drizzle/0010_soft_delete.sql
+++ b/drizzle/0010_soft_delete.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "doubts" ADD COLUMN "deletedAt" timestamp;

--- a/src/app/api/analytics/personal/route.ts
+++ b/src/app/api/analytics/personal/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { db } from '@/configs/db';
 import { doubtsTable } from '@/configs/schema';
-import { and, eq, desc } from 'drizzle-orm';
+import { and, eq, desc, isNull } from 'drizzle-orm';
 import Groq from 'groq-sdk';
 import { buildErrorResponse } from '@/lib/error-handler';
 import {
@@ -35,7 +35,8 @@ export async function GET(req: Request) {
         .where(
             and(
                 eq(doubtsTable.classroomId, classroomId),
-                eq(doubtsTable.userEmail, email)
+                eq(doubtsTable.userEmail, email),
+                isNull(doubtsTable.deletedAt)
             )
         )
         .orderBy(desc(doubtsTable.createdAt));

--- a/src/app/api/analytics/route.ts
+++ b/src/app/api/analytics/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { db } from '@/configs/db';
 import { doubtsTable, repliesTable, membershipsTable, classroomsTable } from '@/configs/schema';
-import { desc, sql, and, eq, count, countDistinct, ne, inArray } from 'drizzle-orm';
+import { desc, sql, and, eq, count, countDistinct, ne, inArray, isNull } from 'drizzle-orm';
 import { checkUserBlock } from '@/lib/auth-utils';
 import { buildErrorResponse } from '@/lib/error-handler';
 import {
@@ -23,7 +23,7 @@ export async function GET(req: Request) {
 
         if (classroomId) {
             await requireMembership(email, classroomId);
-            classroomFilter = eq(doubtsTable.classroomId, classroomId);
+            classroomFilter = and(eq(doubtsTable.classroomId, classroomId), isNull(doubtsTable.deletedAt));
         } else {
             const userMemberships = await db.select({ classroomId: membershipsTable.classroomId })
                 .from(membershipsTable)
@@ -48,7 +48,7 @@ export async function GET(req: Request) {
                 });
             }
 
-            classroomFilter = inArray(doubtsTable.classroomId, userClassroomIds);
+            classroomFilter = and(inArray(doubtsTable.classroomId, userClassroomIds), isNull(doubtsTable.deletedAt));
         }
 
         // Run all queries in parallel to eliminate sequential query latency

--- a/src/app/api/bookmarks/route.ts
+++ b/src/app/api/bookmarks/route.ts
@@ -2,7 +2,7 @@ export const dynamic = "force-dynamic";
 
 import { db } from "@/configs/db";
 import { doubtsTable, bookmarksTable, likesTable, repliesTable } from "@/configs/schema";
-import { and, eq, desc, sql, inArray } from "drizzle-orm";
+import { and, eq, desc, sql, inArray, isNull } from "drizzle-orm";
 import { NextResponse } from "next/server";
 import { currentUser } from "@clerk/nextjs/server";
 
@@ -25,7 +25,7 @@ export async function GET(req: Request) {
 
         // Fetch doubts
         let doubts = await db.select().from(doubtsTable)
-            .where(inArray(doubtsTable.id, doubtIds))
+            .where(and(inArray(doubtsTable.id, doubtIds), isNull(doubtsTable.deletedAt)))
             .orderBy(desc(doubtsTable.createdAt));
 
         // Add hasLiked and hasBookmarked status

--- a/src/app/api/classrooms/[id]/export/route.ts
+++ b/src/app/api/classrooms/[id]/export/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { db } from "@/configs/db";
 import { doubtsTable, classroomsTable, repliesTable } from "@/configs/schema";
-import { and, eq, desc, gte, lte, sql } from "drizzle-orm";
+import { and, eq, desc, gte, lte, sql, isNull } from "drizzle-orm";
 import { buildErrorResponse } from "@/lib/error-handler";
 import {
     parseClassroomId,
@@ -36,7 +36,7 @@ export async function GET(
         const to = searchParams.get("to"); // ISO date string
 
         // 5. Build query conditions
-        const conditions = [eq(doubtsTable.classroomId, classroomId)];
+        const conditions = [eq(doubtsTable.classroomId, classroomId), isNull(doubtsTable.deletedAt)];
 
         if (status === "resolved") {
             conditions.push(eq(doubtsTable.isSolved, "solved"));

--- a/src/app/api/doubts/[id]/pin/route.ts
+++ b/src/app/api/doubts/[id]/pin/route.ts
@@ -4,7 +4,7 @@ import {
     classroomsTable,
     membershipsTable,
     } from "@/configs/schema";
-import { and, eq, count } from "drizzle-orm";
+import { and, eq, count, isNull } from "drizzle-orm";
 import { canTeach } from "@/lib/auth/membership-guard";
 import { NextResponse } from "next/server";
 import { currentUser } from "@clerk/nextjs/server";
@@ -18,7 +18,9 @@ export async function POST(req: Request, { params }: { params: Promise<{ id: str
         const { id } = await params;
         const doubtId = parseInt(id);
 
-        const [doubt] = await db.select().from(doubtsTable).where(eq(doubtsTable.id, doubtId)).limit(1);
+        const [doubt] = await db.select().from(doubtsTable).where(
+            and(eq(doubtsTable.id, doubtId), isNull(doubtsTable.deletedAt))
+        ).limit(1);
         if (!doubt) return NextResponse.json({ error: "Doubt not found" }, { status: 404 });
 
         if (!doubt.classroomId) {
@@ -72,7 +74,9 @@ export async function DELETE(req: Request, { params }: { params: Promise<{ id: s
         const { id } = await params;
         const doubtId = parseInt(id);
 
-        const [doubt] = await db.select().from(doubtsTable).where(eq(doubtsTable.id, doubtId)).limit(1);
+        const [doubt] = await db.select().from(doubtsTable).where(
+            and(eq(doubtsTable.id, doubtId), isNull(doubtsTable.deletedAt))
+        ).limit(1);
         if (!doubt) return NextResponse.json({ error: "Doubt not found" }, { status: 404 });
 
         if (!doubt.classroomId) {

--- a/src/app/api/doubts/action/[id]/route.ts
+++ b/src/app/api/doubts/action/[id]/route.ts
@@ -27,7 +27,7 @@ export async function PATCH(req: Request, { params }: { params: Promise<{ id: st
             return NextResponse.json({ error: "Invalid doubt ID" }, { status: 400 });
         }
 
-        const [doubt] = await db.select().from(doubtsTable).where(eq(doubtsTable.id, doubtId)).limit(1);
+        const [doubt] = await db.select().from(doubtsTable).where(and(eq(doubtsTable.id, doubtId), isNull(doubtsTable.deletedAt))).limit(1);
         if (!doubt) return NextResponse.json({ error: "Doubt not found" }, { status: 404 });
 
         // Security: Verify doubt visibility/classroom membership
@@ -259,7 +259,7 @@ export async function DELETE(req: Request, { params }: { params: Promise<{ id: s
         const { id } = await params;
         const doubtId = parseInt(id);
 
-        const [doubt] = await db.select().from(doubtsTable).where(eq(doubtsTable.id, doubtId)).limit(1);
+        const [doubt] = await db.select().from(doubtsTable).where(and(eq(doubtsTable.id, doubtId), isNull(doubtsTable.deletedAt))).limit(1);
         if (!doubt) return NextResponse.json({ error: "Doubt not found" }, { status: 404 });
 
         const isOwner = email && doubt.userEmail === email;
@@ -284,7 +284,7 @@ export async function DELETE(req: Request, { params }: { params: Promise<{ id: s
             return NextResponse.json({ error: "Unauthorized to delete this doubt" }, { status: 403 });
         }
 
-        await db.delete(doubtsTable).where(eq(doubtsTable.id, doubtId));
+        await db.update(doubtsTable).set({ deletedAt: new Date() }).where(eq(doubtsTable.id, doubtId));
         return NextResponse.json({ message: "Doubt deleted successfully" });
     } catch (error) {
         console.error("Error deleting doubt:", error);

--- a/src/app/api/doubts/restore/route.ts
+++ b/src/app/api/doubts/restore/route.ts
@@ -1,0 +1,50 @@
+import { db } from "@/configs/db";
+import { doubtsTable } from "@/configs/schema";
+import { and, eq, isNull } from "drizzle-orm";
+import { NextResponse } from "next/server";
+import { currentUser } from "@clerk/nextjs/server";
+import { classroomsTable } from "@/configs/schema";
+
+export async function POST(req: Request) {
+    try {
+        const user = await currentUser();
+        const email = user?.primaryEmailAddress?.emailAddress;
+        if (!email) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+        const { doubtId } = await req.json();
+        if (!doubtId) return NextResponse.json({ error: "Doubt ID required" }, { status: 400 });
+
+        // Fetch the soft-deleted doubt
+        const [doubt] = await db.select().from(doubtsTable)
+            .where(eq(doubtsTable.id, parseInt(doubtId)))
+            .limit(1);
+
+        if (!doubt) return NextResponse.json({ error: "Doubt not found" }, { status: 404 });
+        if (!doubt.deletedAt) return NextResponse.json({ error: "Doubt is not deleted" }, { status: 400 });
+
+        // Only owner or teacher can restore
+        const isOwner = doubt.userEmail === email;
+        let isTeacher = false;
+
+        if (doubt.classroomId) {
+            const [room] = await db.select().from(classroomsTable)
+                .where(eq(classroomsTable.id, doubt.classroomId));
+            isTeacher = !!(room && room.teacherEmail === email);
+        }
+
+        if (!isOwner && !isTeacher) {
+            return NextResponse.json({ error: "Unauthorized to restore this doubt" }, { status: 403 });
+        }
+
+        // Restore the doubt
+        const [restored] = await db.update(doubtsTable)
+            .set({ deletedAt: null })
+            .where(eq(doubtsTable.id, parseInt(doubtId)))
+            .returning();
+
+        return NextResponse.json({ message: "Doubt restored successfully", doubt: restored });
+    } catch (error) {
+        console.error("Error restoring doubt:", error);
+        return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+    }
+}

--- a/src/app/api/doubts/route.ts
+++ b/src/app/api/doubts/route.ts
@@ -48,7 +48,7 @@ export async function GET(req: Request) {
             return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
         }
 
-        const conditions: SQL[] = [];
+        const conditions: SQL[] = [isNull(doubtsTable.deletedAt)];
 
         if (classroomId) {
             conditions.push(eq(doubtsTable.classroomId, classroomId));

--- a/src/app/api/profile/route.ts
+++ b/src/app/api/profile/route.ts
@@ -1,7 +1,7 @@
 export const dynamic = "force-dynamic";
 
 import { NextRequest, NextResponse } from "next/server";
-import { eq, or, inArray } from "drizzle-orm";
+import { eq, or, inArray, isNull, and } from "drizzle-orm";
 import { db } from "@/configs/db";
 import { doubtsTable, repliesTable, membershipsTable, classroomsTable, usersTable } from "@/configs/schema";
 import { auth, currentUser } from "@clerk/nextjs/server";
@@ -24,7 +24,7 @@ export async function GET(req: Request) {
 
         const [dbUserResults, doubts, replies, memberships] = await Promise.all([
             db.select().from(usersTable).where(eq(usersTable.email, email)).limit(1),
-            db.select().from(doubtsTable).where(eq(doubtsTable.userEmail, email)),
+            db.select().from(doubtsTable).where(and(eq(doubtsTable.userEmail, email), isNull(doubtsTable.deletedAt))),
             db.select().from(repliesTable).where(or(eq(repliesTable.userEmail, email), eq(repliesTable.userName, name))),
             db.select().from(membershipsTable).where(eq(membershipsTable.userEmail, email))
         ]);

--- a/src/app/api/replies/route.ts
+++ b/src/app/api/replies/route.ts
@@ -1,6 +1,6 @@
 import { db } from "@/configs/db";
 import { repliesTable, doubtsTable, classroomsTable, replyLikesTable, usersTable, membershipsTable, notificationsTable } from "@/configs/schema";
-import { eq, asc, sql, and } from "drizzle-orm";
+import { eq, asc, sql, and, isNull } from "drizzle-orm";
 import { NextResponse } from "next/server";
 import { auth, currentUser } from "@clerk/nextjs/server";
 import { moderateContent, handleModerationViolation } from "@/lib/moderation";
@@ -41,7 +41,9 @@ export async function GET(req: Request) {
         const doubtId = parseInt(doubtIdStr);
 
         // Security: Verify doubt visibility
-        const [doubt] = await db.select().from(doubtsTable).where(eq(doubtsTable.id, doubtId));
+        const [doubt] = await db.select().from(doubtsTable).where(
+            and(eq(doubtsTable.id, doubtId), isNull(doubtsTable.deletedAt))
+        );
         if (!doubt) return NextResponse.json({ error: "Doubt not found" }, { status: 404 });
 
         if (doubt.classroomId && email) {
@@ -127,7 +129,9 @@ export async function POST(req: Request) {
         }
 
         // Security: Check if it's a teacher doubt and verify classroom membership
-        const [doubt] = await db.select().from(doubtsTable).where(eq(doubtsTable.id, doubtId));
+        const [doubt] = await db.select().from(doubtsTable).where(
+            and(eq(doubtsTable.id, doubtId), isNull(doubtsTable.deletedAt))
+        );
         
         if (!doubt) {
             return NextResponse.json({ error: "Doubt not found" }, { status: 404 });

--- a/src/app/api/teacher/analytics/route.ts
+++ b/src/app/api/teacher/analytics/route.ts
@@ -3,7 +3,7 @@ export const dynamic = "force-dynamic";
 import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/configs/db";
 import { doubtsTable, repliesTable, classroomsTable, membershipsTable, usersTable } from "@/configs/schema";
-import { and, eq, inArray, gte, lte } from "drizzle-orm";
+import { and, eq, inArray, gte, lte, isNull } from "drizzle-orm";
 import { DoubtRecord, ReplyRecord } from "@/types";
 import {
     parseOptionalClassroomId,
@@ -107,7 +107,8 @@ export async function GET(req: NextRequest) {
                     and(
                         inArray(doubtsTable.classroomId, selectedClassroomIds),
                         gte(doubtsTable.createdAt, startDate),
-                        lte(doubtsTable.createdAt, endDate)
+                        lte(doubtsTable.createdAt, endDate),
+                        isNull(doubtsTable.deletedAt)
                     )
                 );
 

--- a/src/app/api/teacher/insights/route.ts
+++ b/src/app/api/teacher/insights/route.ts
@@ -2,7 +2,7 @@ export const dynamic = "force-dynamic";
 
 import { db } from "@/configs/db";
 import { doubtsTable } from "@/configs/schema";
-import { and, eq, sql } from "drizzle-orm";
+import { and, eq, sql, isNull } from "drizzle-orm";
 import { NextResponse } from "next/server";
 import { buildErrorResponse } from "@/lib/error-handler";
 import {
@@ -24,7 +24,7 @@ export async function GET(req: Request) {
         const classroomId = parseClassroomId(classroomIdStr);
         await requireTeacher(email, classroomId);
 
-        const classroomFilter = eq(doubtsTable.classroomId, classroomId);
+        const classroomFilter = and(eq(doubtsTable.classroomId, classroomId), isNull(doubtsTable.deletedAt));
 
         // 1. Top Confusion Topics (by doubt count)
         const topTopics = await db

--- a/src/configs/schema.ts
+++ b/src/configs/schema.ts
@@ -190,6 +190,7 @@ export const doubtsTable = pgTable("doubts", {
     solvedReplyId: integer(),
     type: varchar({ length: 20 }).default("community"),
     isPinned: boolean().default(false),
+    deletedAt: timestamp(),
     createdAt: timestamp().defaultNow().notNull(),
 }, (table) => {
     return {


### PR DESCRIPTION
## **User description**
Closes #179

## What this PR does
- Added `deletedAt` timestamp column to `doubtsTable` in `configs/schema.ts`
- Generated migration file for the new column
- Modified DELETE handler to set `deletedAt = new Date()` instead of hard deleting
- Updated all SELECT queries across the codebase to filter out soft-deleted doubts using `WHERE deletedAt IS NULL`
- Added admin restore endpoint at `app/api/doubts/restore/route.ts`

## Files Changed
- `configs/schema.ts` — added `deletedAt` column
- `drizzle/0001_free_thundra.sql` — migration file
- `app/api/doubts/route.ts` — filter soft-deleted doubts
- `app/api/doubts/action/[id]/route.ts` — soft-delete instead of hard-delete
- `app/api/doubts/[id]/pin/route.ts` — filter soft-deleted doubts
- `app/api/doubts/restore/route.ts` — new restore endpoint
- `app/api/analytics/route.ts` — filter soft-deleted doubts
- `app/api/analytics/personal/route.ts` — filter soft-deleted doubts
- `app/api/teacher/analytics/route.ts` — filter soft-deleted doubts
- `app/api/teacher/insights/route.ts` — filter soft-deleted doubts
- `app/api/profile/route.ts` — filter soft-deleted doubts
- `app/api/bookmarks/route.ts` — filter soft-deleted doubts
- `app/api/replies/route.ts` — filter soft-deleted doubts
- `app/api/classrooms/[id]/export/route.ts` — filter soft-deleted doubts

## Checklist
- [x] `deletedAt` column added to schema
- [x] Migration generated and documented
- [x] DELETE endpoint performs soft-delete
- [x] All doubt queries exclude soft-deleted records
- [x] Admin restore endpoint created

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added soft-delete functionality for doubts—deleted items are now recoverable instead of permanently removed.
  * Added ability to restore deleted doubts.

* **Improvements**
  * Analytics and data queries now exclude deleted records by default, ensuring accurate reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Keep deleted doubts hidden and allow restoring them**

### What Changed
- Deleting a doubt now hides it instead of removing it, and deleted doubts stay out of doubt lists, bookmarks, replies, profile pages, exports, and analytics
- Added a restore action so the doubt owner or a teacher can bring back a deleted doubt
- Pinned-doubt actions and doubt editing now ignore deleted doubts, preventing actions on items that are no longer active
- Deleted doubts are excluded from both classroom-wide and personal analytics so totals and insights match what users can still see

### Impact
`✅ Fewer missing-record errors after deletion`
`✅ Restorable deleted doubts`
`✅ Cleaner analytics and exports`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
