### PR TITLE
fix: wrap doubt like toggle in transaction with floor guard to prevent race conditions (#472)

### DIFF
--- a/src/app/api/doubts/action/[id]/route.ts
+++ b/src/app/api/doubts/action/[id]/route.ts
@@ -52,38 +52,53 @@ export async function PATCH(req: Request, { params }: { params: Promise<{ id: st
             if (!email) {
                 return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
             }
-            
+
             const secureUserIdentifier = email;
 
-            // Check if already liked
-            const existingLike = await db.select()
-                .from(likesTable)
-                .where(and(eq(likesTable.userName, secureUserIdentifier), eq(likesTable.doubtId, doubtId)))
-                .limit(1);
+            const result = await db.transaction(async (tx) => {
+                const locked = await tx.execute(
+                    sql`SELECT ${doubtsTable.id} FROM ${doubtsTable} WHERE ${doubtsTable.id} = ${doubtId} FOR UPDATE`
+                );
 
-            if (existingLike.length > 0) {
-                await db.delete(likesTable)
-                    .where(and(eq(likesTable.userName, secureUserIdentifier), eq(likesTable.doubtId, doubtId)));
-                
-                const updated = await db.update(doubtsTable)
-                    .set({ likes: sql`${doubtsTable.likes} - 1` })
-                    .where(eq(doubtsTable.id, doubtId))
-                    .returning();
-                
-                return NextResponse.json({ ...updated[0], hasLiked: false });
-            } else {
-                await db.insert(likesTable).values({
-                    userName: secureUserIdentifier,
-                    doubtId
-                });
+                if (!locked.rows.length) {
+                    return null;
+                }
 
-                const updated = await db.update(doubtsTable)
-                    .set({ likes: sql`${doubtsTable.likes} + 1` })
-                    .where(eq(doubtsTable.id, doubtId))
-                    .returning();
-                
-                return NextResponse.json({ ...updated[0], hasLiked: true });
+                const existingLike = await tx.select()
+                    .from(likesTable)
+                    .where(and(eq(likesTable.userName, secureUserIdentifier), eq(likesTable.doubtId, doubtId)))
+                    .limit(1);
+
+                if (existingLike.length > 0) {
+                    await tx.delete(likesTable)
+                        .where(and(eq(likesTable.userName, secureUserIdentifier), eq(likesTable.doubtId, doubtId)));
+
+                    const updated = await tx.update(doubtsTable)
+                        .set({ likes: sql`GREATEST(${doubtsTable.likes} - 1, 0)` })
+                        .where(eq(doubtsTable.id, doubtId))
+                        .returning();
+
+                    return { ...updated[0], hasLiked: false };
+                } else {
+                    await tx.insert(likesTable).values({
+                        userName: secureUserIdentifier,
+                        doubtId
+                    });
+
+                    const updated = await tx.update(doubtsTable)
+                        .set({ likes: sql`${doubtsTable.likes} + 1` })
+                        .where(eq(doubtsTable.id, doubtId))
+                        .returning();
+
+                    return { ...updated[0], hasLiked: true };
+                }
+            });
+
+            if (!result) {
+                return NextResponse.json({ error: "Doubt not found" }, { status: 404 });
             }
+
+            return NextResponse.json(result);
         }
 
         if (action === "solve") {


### PR DESCRIPTION
## **User description**
## Summary
- Wrapped the doubt like toggle (check → insert/delete → update count) in `db.transaction()` to prevent race conditions from concurrent requests
- Added `GREATEST(likes - 1, 0)` floor guard to prevent negative like counts on unlike
- Matches the transaction pattern already used in the fixed reply vote endpoint (`replies/vote/route.ts`)

## Changes
- `src/app/api/doubts/action/[id]/route.ts` — like action block now uses atomic transaction with `tx` instead of `db`

## Test plan
- [ ] Like a doubt — count increments by 1, `hasLiked: true` in response
- [ ] Unlike the same doubt — count decrements by 1 (never below 0), `hasLiked: false`
- [ ] Rapid double-click like — no duplicate likes, count stays correct
- [ ] Verify response shape unchanged for frontend compatibility

Closes #472

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Made the like/unlike action atomic to prevent inconsistent counts and race conditions, ensuring more reliable toggling and accurate like totals with immediate, consistent feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Prevent duplicate likes and negative like counts on doubts**

### What Changed
- Like and unlike actions now happen as one locked operation, so rapid repeated clicks do not create duplicate likes or mismatched counts
- Unliking a doubt can no longer reduce the like count below zero
- If the doubt no longer exists, the API now returns a clear not found response

### Impact
`✅ Fewer duplicate likes`
`✅ No negative like counts`
`✅ Clearer error response for missing doubts`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
