### PR TITLE
fix: remove client-supplied createdAt from doubt and reply schemas to prevent timestamp manipulation (#476)

### DIFF
--- a/src/app/api/doubts/route.ts
+++ b/src/app/api/doubts/route.ts
@@ -241,15 +241,6 @@ const doubtType = type ?? 'community';
         // 2. Auto-detect sub-topic using AI
         const subTopic = await categorizeDoubt(content || "", subject, imageUrl);
 
-        let parsedCreatedAt: Date | undefined = undefined;
-        if (data.createdAt) {
-            const d = new Date(data.createdAt);
-            if (isNaN(d.getTime())) {
-                return NextResponse.json({ error: "Invalid createdAt date format" }, { status: 400 });
-            }
-            parsedCreatedAt = d;
-        }
-
         const [newDoubt] = await db.insert(doubtsTable).values({
             userName,
             userEmail: email,
@@ -259,7 +250,6 @@ const doubtType = type ?? 'community';
             imageUrl,
             classroomId: parsedClassroomId,
             type,
-            createdAt: parsedCreatedAt
         }).returning();
 
         if (parsedClassroomId) {

--- a/src/app/api/replies/route.ts
+++ b/src/app/api/replies/route.ts
@@ -139,15 +139,6 @@ export async function POST(req: Request) {
             }
         }
 
-        let parsedCreatedAt: Date | undefined = undefined;
-        if (data.createdAt) {
-            const d = new Date(data.createdAt);
-            if (isNaN(d.getTime())) {
-                return NextResponse.json({ error: "Invalid createdAt date format" }, { status: 400 });
-            }
-            parsedCreatedAt = d;
-        }
-
         const newReply = await db.insert(repliesTable).values({
             doubtId: doubtId,
             userName,
@@ -155,7 +146,6 @@ export async function POST(req: Request) {
             type,
             content: content || null,
             imageUrl: imageUrl || null,
-            createdAt: parsedCreatedAt
         }).returning();
 
         createReplyNotification({

--- a/src/lib/validations/doubt.ts
+++ b/src/lib/validations/doubt.ts
@@ -9,7 +9,6 @@ export const createDoubtSchema = z.object({
   classroomId: positiveInt.optional().nullable(),
   type: z.enum(["community", "teacher", "ai"]).default("community"),
   tags: z.array(trimmedString.min(1).max(80)).max(8).default([]),
-  createdAt: z.string().datetime().optional().nullable(),
 }).refine((data) => data.content || data.imageUrl, {
   message: "Either content or imageUrl is required",
   path: ["content"]

--- a/src/lib/validations/reply.ts
+++ b/src/lib/validations/reply.ts
@@ -7,7 +7,6 @@ export const createReplySchema = z.object({
   type: trimmedString.min(1),
   content: trimmedString.max(5000).optional().nullable(),
   imageUrl: safeUrl.optional().nullable(),
-  createdAt: z.string().datetime().optional().nullable(),
 }).refine((data) => data.content || data.imageUrl, {
   message: "Either content or imageUrl is required",
   path: ["content"]


### PR DESCRIPTION
## **User description**
## Summary
- Removed `createdAt` from doubt and reply Zod validation schemas — server now always uses `defaultNow()`
- Removed `parsedCreatedAt` parsing logic from both route handlers
- Prevents users from backdating/future-dating posts to manipulate sort order and analytics

## Changes
- `src/lib/validations/doubt.ts` — removed `createdAt` field from `createDoubtSchema`
- `src/lib/validations/reply.ts` — removed `createdAt` field from `createReplySchema`
- `src/app/api/doubts/route.ts` — removed `parsedCreatedAt` parsing and usage in insert
- `src/app/api/replies/route.ts` — same removal

## Test plan
- [ ] Create a doubt — gets server-generated timestamp (not client-supplied)
- [ ] Create a reply — gets server-generated timestamp
- [ ] Sending `createdAt` in request body is silently ignored by Zod (stripped)
- [ ] Sort order (newest first) works correctly with server timestamps
- [ ] Analytics peak-time and response-time calculations unaffected

Closes #476


___

## **CodeAnt-AI Description**
**Stop users from setting post timestamps on doubts and replies**

### What Changed
- Doubts and replies now always use the server’s timestamp when they are created
- Requests that include a `createdAt` value no longer affect when a post appears in the feed
- Removed date parsing and validation for client-provided timestamps from both create flows

### Impact
`✅ No timestamp manipulation`
`✅ Reliable newest-first sorting`
`✅ More accurate activity and response tracking`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced timestamp consistency for doubts and replies with automatic server-side timestamp management. The system now reliably assigns creation timestamps for all records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->