### PR TITLE
fix(#466): validate history role and content before injecting into LLM context

### DIFF
--- a/src/app/api/ask-ai/route.ts
+++ b/src/app/api/ask-ai/route.ts
@@ -254,9 +254,30 @@ export async function POST(req: Request) {
             history = [],
         } = await req.json();
 
-        const conversationHistory = Array.isArray(history)
-            ? history
-            : [];
+        // Validate and sanitize history entries before injecting them into the
+        // LLM context. Accepting arbitrary objects would let an attacker inject
+        // system-role messages that override the application system prompt or
+        // bypass the moderation check applied only to the current prompt field.
+        const ALLOWED_ROLES = new Set(['user', 'assistant']);
+        const MAX_HISTORY_ENTRIES = 20;
+        const MAX_CONTENT_LENGTH = 4000;
+
+        const conversationHistory: { role: 'user' | 'assistant'; content: string }[] = [];
+        if (Array.isArray(history)) {
+            for (const entry of history.slice(-MAX_HISTORY_ENTRIES)) {
+                if (
+                    entry &&
+                    typeof entry === 'object' &&
+                    ALLOWED_ROLES.has(entry.role) &&
+                    typeof entry.content === 'string'
+                ) {
+                    conversationHistory.push({
+                        role: entry.role as 'user' | 'assistant',
+                        content: entry.content.slice(0, MAX_CONTENT_LENGTH),
+                    });
+                }
+            }
+        }
 
         // 1. AI Moderation Check for Prompts
         if (prompt) {


### PR DESCRIPTION
Closes #466

## Summary

The `history` field in the ask-ai route was spread directly into the LLM messages array with no validation of role values, content types, or array length. An attacker could inject `system`-role messages to override the application system prompt and bypass the content moderation check that only runs on the current `prompt` field.

## Fix

Added validation that filters history entries before they reach the messages array:
- Only `user` and `assistant` roles are accepted (`system` is blocked)
- Each entry must have `typeof content === 'string'`
- History is capped to the last 20 entries
- Individual content strings are truncated to 4000 characters

## Files Changed

- `src/app/api/ask-ai/route.ts`: replaced bare array spread with validated loop.