### PR TITLE
fix(#467): fail closed on rate limiter errors for AI and video routes

### DIFF
--- a/src/middleware.tsx
+++ b/src/middleware.tsx
@@ -50,8 +50,24 @@ export default clerkMiddleware(async (auth, req) => {
                 );
             }
         } catch (error) {
+            // Rate limiter failure: fail closed for AI and video routes (high
+            // abuse risk) and fail open for general routes. Silently allowing
+            // all requests when the limiter is down eliminates the primary
+            // abuse-prevention control on the most expensive endpoints.
             console.error("Rate limiting error:", error);
-            // Fallback: allow request if rate limiter fails
+            if (isAiRoute || isVideoRoute) {
+                return new NextResponse(
+                    JSON.stringify({
+                        error: "Rate limiting service is temporarily unavailable. Please try again in a moment.",
+                    }),
+                    {
+                        status: 503,
+                        headers: { 'Content-Type': 'application/json' },
+                    }
+                );
+            }
+            // For general routes a transient limiter failure is lower risk;
+            // allow the request through rather than blocking non-AI traffic.
         }
     }
 


### PR DESCRIPTION
Closes #467

## Summary

The rate limiter `catch` block in `src/middleware.tsx` silently allowed all requests through when the Upstash/Redis service became unavailable. An attacker could exhaust the rate limiting service before hammering AI endpoints with no throttling in effect.

## Fix

The catch block now returns `503` for AI and video routes (high abuse surface, expensive per-request) so requests are rejected rather than passed through when the limiter fails. General API routes still fail open since a transient outage there is lower risk.

## Files Changed

- `src/middleware.tsx`: changed catch block to fail closed for `isAiRoute` and `isVideoRoute`.