### PR TITLE
fix(#468): add IP-based rate limiting to public-chat endpoint

### DIFF
--- a/src/app/api/ai-career-chat-agent/public-chat/route.ts
+++ b/src/app/api/ai-career-chat-agent/public-chat/route.ts
@@ -4,9 +4,36 @@ import { NextRequest, NextResponse } from "next/server";
 import { eq } from "drizzle-orm";
 import { db } from "@/configs/db";
 import { chatHistoryTable, sharedChatsTable } from "@/configs/schema";
+import { generalLimiter } from "@/lib/ratelimit";
 
 export async function GET(req: NextRequest) {
     try {
+        // Rate-limit by IP to prevent automated enumeration of chatId values.
+        // Shared chats may contain sensitive academic or personal content, so
+        // unrestricted enumeration is a meaningful privacy risk even though the
+        // endpoint is intentionally public.
+        const forwardedFor = req.headers.get("x-forwarded-for");
+        const ip = req.headers.get("x-real-ip")
+            ?? forwardedFor?.split(",")[0]?.trim()
+            ?? "127.0.0.1";
+
+        try {
+            const { success } = await generalLimiter.limit(ip);
+            if (!success) {
+                return NextResponse.json(
+                    { error: "Too many requests. Please try again later." },
+                    { status: 429 }
+                );
+            }
+        } catch {
+            // Rate limiter failure: fail closed to prevent enumeration when
+            // the limiter service is unavailable.
+            return NextResponse.json(
+                { error: "Service temporarily unavailable. Please try again in a moment." },
+                { status: 503 }
+            );
+        }
+
         const { searchParams } = new URL(req.url);
         const chatId = searchParams.get("chatId");
 


### PR DESCRIPTION
Closes #468

## Summary

The `/api/ai-career-chat-agent/public-chat` endpoint had no rate limiting. An attacker could enumerate `chatId` values automatically to read conversation histories that may contain sensitive academic or personal content.

## Fix

Added IP-based rate limiting using the existing `generalLimiter` so bulk enumeration triggers 429 responses. The limiter failure path is fail-closed (503) to prevent enumeration during Redis outages.

## Files Changed

- `src/app/api/ai-career-chat-agent/public-chat/route.ts`: added IP extraction and `generalLimiter.limit()` call with fail-closed error handling.