### PR TITLE
fix(#469): cap admin block duration at 365 days to prevent integer overflow

### DIFF
--- a/src/app/api/admin/moderation/action/route.ts
+++ b/src/app/api/admin/moderation/action/route.ts
@@ -49,9 +49,14 @@ export async function POST(request: Request) {
 
         if (action === "block") {
             const newBlockCount = user.blockCount + 1;
+            // Maximum block duration: 365 days (1 year). Without a cap the formula
+            // 14 * 2^(blockCount - 3) overflows JavaScript's safe integer range at
+            // blockCount >= 53, producing Infinity or an Invalid Date that may
+            // clear the block entirely depending on the database driver behaviour.
+            const MAX_BLOCK_DAYS = 365;
             let durationDays = 3;
             if (newBlockCount === 2) durationDays = 7;
-            else if (newBlockCount >= 3) durationDays = 14 * Math.pow(2, newBlockCount - 3);
+            else if (newBlockCount >= 3) durationDays = Math.min(14 * Math.pow(2, newBlockCount - 3), MAX_BLOCK_DAYS);
 
             const blockedUntil = new Date();
             blockedUntil.setDate(blockedUntil.getDate() + durationDays);


### PR DESCRIPTION
Closes #469

## Summary

The block duration formula `14 * Math.pow(2, newBlockCount - 3)` grows unboundedly. At `blockCount = 53` it produces approximately 40 trillion days, exceeding `Number.MAX_SAFE_INTEGER`. `setDate(Infinity)` creates an `Invalid Date` that may be stored as `null`, effectively clearing the block on the 53rd admin action.

## Fix

Added `MAX_BLOCK_DAYS = 365` and wrapped the formula with `Math.min` so the duration is capped at one year regardless of block count.

## Files Changed

- `src/app/api/admin/moderation/action/route.ts`: wrapped formula with `Math.min(..., MAX_BLOCK_DAYS)`.