### PR TITLE
fix(#470): reject oversized payloads before parsing in ask-ai route

### DIFF
--- a/src/app/api/ask-ai/route.ts
+++ b/src/app/api/ask-ai/route.ts
@@ -197,8 +197,24 @@ async function callGroqWithFallback(
 /**
  * Main AI Solver API Route.
  */
+// Maximum allowed Content-Length for this route in bytes.
+// imageBase64 payloads are read entirely into memory before the slice, so a
+// large body allocates the full payload on the server heap before any truncation
+// occurs. Enforcing this limit early keeps memory usage predictable under load.
+const MAX_BODY_BYTES = 512 * 1024; // 512 KB
+
 export async function POST(req: Request) {
     try {
+        // Reject oversized payloads before parsing JSON to avoid loading
+        // a multi-megabyte body into memory only to discard most of it.
+        const contentLength = parseInt(req.headers.get('content-length') ?? '0', 10);
+        if (contentLength > MAX_BODY_BYTES) {
+            return NextResponse.json(
+                { error: 'Request payload too large. Maximum size is 512 KB.' },
+                { status: 413 }
+            );
+        }
+
         const user = await currentUser();
 
         if (!user) {


### PR DESCRIPTION
## **User description**
Closes #470

## Summary

`req.json()` in the ask-ai route reads the full request body into memory before any processing occurs. The `imageBase64?.slice(0, 500)` truncation only happens after the entire payload is already in the heap. A malicious caller sending a multi-megabyte body (up to the default Next.js 4 MB limit) would cause the server to allocate memory for the full payload only to discard most of it. Under concurrent load this amplifies memory pressure significantly.

## Fix

Added an early `Content-Length` check against `MAX_BODY_BYTES = 512 KB` before `req.json()` is called. Requests exceeding the limit receive a `413` response without the payload ever being parsed or loaded.

## Files Changed

- `src/app/api/ask-ai/route.ts`: added `MAX_BODY_BYTES` constant and Content-Length guard at the top of the `POST` handler.


___

## **CodeAnt-AI Description**
**Reject oversized ask-ai requests before they are parsed**

### What Changed
- Requests larger than 512 KB are now blocked before the ask-ai body is parsed.
- Oversized requests receive a 413 response with a clear size limit message.
- This prevents large payloads from being loaded into memory only to be mostly discarded.

### Impact
`✅ Lower memory use on ask-ai requests`
`✅ Fewer server slowdowns from large uploads`
`✅ Clearer errors for oversized requests`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
