### PR TITLE
fix: wrap doubt like toggle in transaction with floor guard (#472)

### DIFF
--- a/src/app/api/doubts/action/[id]/route.ts
+++ b/src/app/api/doubts/action/[id]/route.ts
@@ -52,38 +52,53 @@ export async function PATCH(req: Request, { params }: { params: Promise<{ id: st
             if (!email) {
                 return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
             }
-            
+
             const secureUserIdentifier = email;
 
-            // Check if already liked
-            const existingLike = await db.select()
-                .from(likesTable)
-                .where(and(eq(likesTable.userName, secureUserIdentifier), eq(likesTable.doubtId, doubtId)))
-                .limit(1);
+            const result = await db.transaction(async (tx) => {
+                const locked = await tx.execute(
+                    sql`SELECT ${doubtsTable.id} FROM ${doubtsTable} WHERE ${doubtsTable.id} = ${doubtId} FOR UPDATE`
+                );
 
-            if (existingLike.length > 0) {
-                await db.delete(likesTable)
-                    .where(and(eq(likesTable.userName, secureUserIdentifier), eq(likesTable.doubtId, doubtId)));
-                
-                const updated = await db.update(doubtsTable)
-                    .set({ likes: sql`${doubtsTable.likes} - 1` })
-                    .where(eq(doubtsTable.id, doubtId))
-                    .returning();
-                
-                return NextResponse.json({ ...updated[0], hasLiked: false });
-            } else {
-                await db.insert(likesTable).values({
-                    userName: secureUserIdentifier,
-                    doubtId
-                });
+                if (!locked.rows.length) {
+                    return null;
+                }
 
-                const updated = await db.update(doubtsTable)
-                    .set({ likes: sql`${doubtsTable.likes} + 1` })
-                    .where(eq(doubtsTable.id, doubtId))
-                    .returning();
-                
-                return NextResponse.json({ ...updated[0], hasLiked: true });
+                const existingLike = await tx.select()
+                    .from(likesTable)
+                    .where(and(eq(likesTable.userName, secureUserIdentifier), eq(likesTable.doubtId, doubtId)))
+                    .limit(1);
+
+                if (existingLike.length > 0) {
+                    await tx.delete(likesTable)
+                        .where(and(eq(likesTable.userName, secureUserIdentifier), eq(likesTable.doubtId, doubtId)));
+
+                    const updated = await tx.update(doubtsTable)
+                        .set({ likes: sql`GREATEST(${doubtsTable.likes} - 1, 0)` })
+                        .where(eq(doubtsTable.id, doubtId))
+                        .returning();
+
+                    return { ...updated[0], hasLiked: false };
+                } else {
+                    await tx.insert(likesTable).values({
+                        userName: secureUserIdentifier,
+                        doubtId
+                    });
+
+                    const updated = await tx.update(doubtsTable)
+                        .set({ likes: sql`${doubtsTable.likes} + 1` })
+                        .where(eq(doubtsTable.id, doubtId))
+                        .returning();
+
+                    return { ...updated[0], hasLiked: true };
+                }
+            });
+
+            if (!result) {
+                return NextResponse.json({ error: "Doubt not found" }, { status: 404 });
             }
+
+            return NextResponse.json(result);
         }
 
         if (action === "solve") {


### PR DESCRIPTION
Closes #472

the doubt like toggle used a non-atomic check-then-act pattern while the reply vote endpoint was already fixed for the same bug in PR #335. concurrent likes could cause duplicate entries and negative counts.

what i fixed:
- wrapped entire like toggle in db.transaction() matching the reply vote pattern
- added GREATEST(likes - 1, 0) floor guard preventing negative counts
- all operations atomic now

response shape unchanged. typecheck clean, build passes.

for labels i think gssoc:approved + level:intermediate + type:bug + quality:clean fits here. happy to make changes if needed!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability and data consistency of the like feature with enhanced concurrency safety
  * Added better error handling for invalid or missing doubt entries
  * Strengthened the like toggle mechanism to prevent edge cases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->