### PR TITLE
fix: enforce content moderation on doubt and reply edits (#474)

### DIFF
--- a/src/app/api/doubts/action/[id]/route.ts
+++ b/src/app/api/doubts/action/[id]/route.ts
@@ -3,6 +3,7 @@ import { doubtTagsTable, doubtsTable, likesTable, classroomsTable, repliesTable,
 import { and, eq, isNull, sql } from "drizzle-orm";
 import { NextResponse } from "next/server";
 import { currentUser } from "@clerk/nextjs/server";
+import { moderateContent, handleModerationViolation } from "@/lib/moderation";
 import { parseAndValidateRequest } from "@/lib/validations/validate";
 import { updateDoubtActionSchema } from "@/lib/validations/doubt";
 import { DOUBT_STATUS, DoubtStatus, isValidDoubtStatus } from "@/lib/doubtStatus";
@@ -164,6 +165,14 @@ export async function PATCH(req: Request, { params }: { params: Promise<{ id: st
             // Only owner can edit
             if (!isOwner) {
                 return NextResponse.json({ error: "Only the owner can edit their doubt" }, { status: 403 });
+            }
+
+            if (content) {
+                const moderation = await moderateContent(content);
+                const violationError = await handleModerationViolation(email!, content, moderation);
+                if (violationError) {
+                    return NextResponse.json({ error: violationError }, { status: 400 });
+                }
             }
 
             const [updated] = await db.update(doubtsTable)

--- a/src/app/api/replies/action/[id]/route.ts
+++ b/src/app/api/replies/action/[id]/route.ts
@@ -4,6 +4,7 @@ import { eq } from "drizzle-orm";
 import { NextRequest, NextResponse } from "next/server";
 import { currentUser } from "@clerk/nextjs/server";
 import { checkUserBlock } from "@/lib/auth-utils";
+import { moderateContent, handleModerationViolation } from "@/lib/moderation";
 import { parseAndValidateRequest } from "@/lib/validations/validate";
 import { updateReplyActionSchema } from "@/lib/validations/reply";
 
@@ -44,6 +45,14 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
         const isOwner = email && reply.userEmail === email;
         if (!isOwner && !isTeacher) {
             return NextResponse.json({ error: "Forbidden: not allowed to edit this reply" }, { status: 403 });
+        }
+
+        if (content) {
+            const moderation = await moderateContent(content);
+            const violationError = await handleModerationViolation(email, content, moderation);
+            if (violationError) {
+                return NextResponse.json({ error: violationError }, { status: 400 });
+            }
         }
 
         const updateData: { content?: string | null; imageUrl?: string | null } = {};


### PR DESCRIPTION
## **User description**
Closes #474

doubt and reply creation ran moderateContent() + handleModerationViolation() before persisting, but the edit paths skipped moderation entirely. users could post clean content then edit in abusive material bypassing the 3-strike system.

what i fixed:
- doubts/action/[id]/route.ts: added moderateContent check in the edit action before db.update(), matching the POST handler pattern
- replies/action/[id]/route.ts: same moderation check in PATCH handler before building updateData

edge cases: subject-only or imageUrl-only edits skip moderation (no text to check). null/empty content skips moderation but edit still proceeds. strikes increment correctly through existing handleModerationViolation flow.

for labels i think gssoc:approved + level:advanced + type:security + quality:clean fits here. happy to make changes if needed!


___

## **CodeAnt-AI Description**
**Block moderated content from being saved in doubt and reply edits**

### What Changed
- Editing a doubt or reply now checks the new text before saving it
- If the edited text violates moderation rules, the edit is rejected with an error instead of being applied
- Empty text and non-text-only edits still proceed without a moderation check

### Impact
`✅ Fewer abusive edits slipping through`
`✅ Stronger moderation on post updates`
`✅ Safer community replies and doubts`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
