### PR TITLE
fix: harden AI image upload handling

### DIFF
--- a/src/__tests__/api/ask-ai.test.ts
+++ b/src/__tests__/api/ask-ai.test.ts
@@ -1,5 +1,6 @@
 import { POST } from '@/app/api/ask-ai/route';
 import { aiLimiter } from '@/lib/ratelimit';
+import { AI_REQUEST_MAX_BYTES } from '@/lib/ai-image-validation';
 
 jest.mock('@/lib/ratelimit', () => ({
     aiLimiter: {
@@ -153,6 +154,25 @@ describe('Ask AI API Endpoint', () => {
         expect(json).toEqual({
             error: 'Please upload a valid PNG, JPG, or WEBP image.',
             code: 'INVALID_IMAGE_PAYLOAD',
+        });
+    });
+
+    it('POST should reject request bodies larger than the configured limit', async () => {
+        const req = new Request('http://localhost/api/ask-ai', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                prompt: 'x'.repeat(AI_REQUEST_MAX_BYTES),
+            }),
+        });
+
+        const res = await POST(req);
+        const json = await res.json();
+
+        expect(res.status).toBe(413);
+        expect(json).toEqual({
+            error: 'Requests must be 4MB or smaller.',
+            code: 'REQUEST_TOO_LARGE',
         });
     });
 });

--- a/src/__tests__/api/ask-ai.test.ts
+++ b/src/__tests__/api/ask-ai.test.ts
@@ -157,6 +157,26 @@ describe('Ask AI API Endpoint', () => {
         });
     });
 
+    it('POST should reject malformed classroom IDs without coercing them', async () => {
+        const req = new Request('http://localhost/api/ask-ai', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                prompt: 'What is the speed of light?',
+                classroomId: '12abc',
+            }),
+        });
+
+        const res = await POST(req);
+        const json = await res.json();
+
+        expect(res.status).toBe(422);
+        expect(json).toEqual({
+            error: 'Invalid classroomId.',
+            code: 'INVALID_CLASSROOM_ID',
+        });
+    });
+
     it('POST should reject request bodies larger than the configured limit', async () => {
         const req = new Request('http://localhost/api/ask-ai', {
             method: 'POST',

--- a/src/__tests__/api/ask-ai.test.ts
+++ b/src/__tests__/api/ask-ai.test.ts
@@ -1,4 +1,16 @@
 import { POST } from '@/app/api/ask-ai/route';
+import { aiLimiter } from '@/lib/ratelimit';
+
+jest.mock('@/lib/ratelimit', () => ({
+    aiLimiter: {
+        limit: jest.fn().mockResolvedValue({
+            success: true,
+            limit: 10,
+            remaining: 9,
+            reset: Date.now() + 60_000,
+        }),
+    },
+}));
 
 jest.mock('@clerk/nextjs/server', () => ({
     auth: jest.fn().mockImplementation(async () => ({ userId: 'user_123' })),
@@ -58,9 +70,17 @@ jest.mock('groq-sdk', () => {
 
 describe('Ask AI API Endpoint', () => {
     const originalFetch = global.fetch;
+    const mockAiLimit = aiLimiter.limit as jest.MockedFunction<typeof aiLimiter.limit>;
 
     afterEach(() => {
         global.fetch = originalFetch;
+        mockAiLimit.mockReset();
+        mockAiLimit.mockResolvedValue({
+            success: true,
+            limit: 10,
+            remaining: 9,
+            reset: Date.now() + 60_000,
+        });
     });
 
     it('POST should generate AI solution and extract subject', async () => {
@@ -87,5 +107,52 @@ describe('Ask AI API Endpoint', () => {
         expect(res.status).toBe(200);
         expect(json.subject).toBe('Physics');
         expect(json.reply).toContain('Light travels at approximately');
+    });
+
+    it('POST should reject rate-limited requests before processing the body', async () => {
+        mockAiLimit.mockResolvedValueOnce({
+            success: false,
+            limit: 10,
+            remaining: 0,
+            reset: Date.now() + 30_000,
+        });
+
+        const req = new Request('http://localhost/api/ask-ai', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                prompt: 'What is the speed of light?',
+            }),
+        });
+
+        const res = await POST(req);
+        const json = await res.json();
+
+        expect(res.status).toBe(429);
+        expect(res.headers.get('Retry-After')).toBeTruthy();
+        expect(json).toEqual({
+            error: 'Too many AI requests. Please try again shortly.',
+            code: 'RATE_LIMITED',
+        });
+    });
+
+    it('POST should reject unsupported image payloads before provider calls', async () => {
+        const req = new Request('http://localhost/api/ask-ai', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                prompt: '',
+                imageBase64: 'data:image/gif;base64,R0lGODlhAQABAIAAAAUEBA==',
+            }),
+        });
+
+        const res = await POST(req);
+        const json = await res.json();
+
+        expect(res.status).toBe(422);
+        expect(json).toEqual({
+            error: 'Please upload a valid PNG, JPG, or WEBP image.',
+            code: 'INVALID_IMAGE_PAYLOAD',
+        });
     });
 });

--- a/src/app/api/ask-ai/route.ts
+++ b/src/app/api/ask-ai/route.ts
@@ -6,6 +6,12 @@ import { doubtsTable, repliesTable, usersTable, classroomsTable } from '@/config
 import { eq } from 'drizzle-orm';
 import { moderateContent, handleModerationViolation } from '@/lib/moderation';
 import { checkPedagogicalDrift } from '@/lib/pedagogy';
+import { aiLimiter } from '@/lib/ratelimit';
+import {
+    AI_REQUEST_MAX_BYTES,
+    AI_REQUEST_MAX_SIZE_LABEL,
+    validateAiImageDataUrl,
+} from '@/lib/ai-image-validation';
 
 const groq = new Groq({
     apiKey: process.env.GROQ_API_KEY || 'dummy_key',
@@ -51,6 +57,96 @@ const UNCLEAR_IMAGE_PATTERNS = [
     /text\s+(is\s+)?(unclear|blurry|blurred|unreadable|not legible)/i,
     /please\s+(upload|provide).*(clearer|higher[-\s]?quality)/i,
 ];
+
+function jsonError(
+    error: string,
+    status: number,
+    code?: string,
+    headers?: HeadersInit
+) {
+    return NextResponse.json(
+        {
+            error,
+            ...(code ? { code } : {}),
+        },
+        { status, headers }
+    );
+}
+
+async function readJsonWithLimit(req: Request) {
+    const contentLength = Number(req.headers.get('content-length') || 0);
+
+    if (contentLength > AI_REQUEST_MAX_BYTES) {
+        return {
+            ok: false as const,
+            response: jsonError(
+                `Requests must be ${AI_REQUEST_MAX_SIZE_LABEL} or smaller.`,
+                413,
+                'REQUEST_TOO_LARGE'
+            ),
+        };
+    }
+
+    if (!req.body) {
+        return {
+            ok: true as const,
+            data: {},
+        };
+    }
+
+    const reader = req.body.getReader();
+    const decoder = new TextDecoder();
+    const chunks: Uint8Array[] = [];
+    let receivedBytes = 0;
+
+    while (true) {
+        const { done, value } = await reader.read();
+
+        if (done) break;
+        if (!value) continue;
+
+        receivedBytes += value.byteLength;
+
+        if (receivedBytes > AI_REQUEST_MAX_BYTES) {
+            await reader.cancel();
+
+            return {
+                ok: false as const,
+                response: jsonError(
+                    `Requests must be ${AI_REQUEST_MAX_SIZE_LABEL} or smaller.`,
+                    413,
+                    'REQUEST_TOO_LARGE'
+                ),
+            };
+        }
+
+        chunks.push(value);
+    }
+
+    let rawBody = '';
+
+    for (const chunk of chunks) {
+        rawBody += decoder.decode(chunk, { stream: true });
+    }
+
+    rawBody += decoder.decode();
+
+    try {
+        return {
+            ok: true as const,
+            data: rawBody ? JSON.parse(rawBody) : {},
+        };
+    } catch {
+        return {
+            ok: false as const,
+            response: jsonError(
+                'Invalid JSON request body.',
+                400,
+                'INVALID_JSON'
+            ),
+        };
+    }
+}
 
 function isUnclearVisionReply(reply: string) {
     const normalizedReply = reply
@@ -247,13 +343,63 @@ export async function POST(req: Request) {
             );
         }
 
+        const rateLimit = await aiLimiter.limit(email);
+
+        if (!rateLimit.success) {
+            const retryAfter = Math.max(
+                1,
+                Math.ceil((rateLimit.reset - Date.now()) / 1000)
+            );
+
+            return jsonError(
+                'Too many AI requests. Please try again shortly.',
+                429,
+                'RATE_LIMITED',
+                { 'Retry-After': String(retryAfter) }
+            );
+        }
+
+        const bodyResult = await readJsonWithLimit(req);
+
+        if (!bodyResult.ok) {
+            return bodyResult.response;
+        }
+
+        const body =
+            bodyResult.data &&
+            typeof bodyResult.data === 'object' &&
+            !Array.isArray(bodyResult.data)
+                ? (bodyResult.data as Record<string, unknown>)
+                : {};
+
         const {
-            prompt,
             type = 'standard',
             imageBase64,
             classroomId,
             history = [],
-        } = await req.json();
+        } = body;
+
+        const prompt =
+            typeof body.prompt === 'string' ? body.prompt : '';
+        const solveType =
+            typeof type === 'string' ? type : 'standard';
+        const classroomIdValue =
+            typeof classroomId === 'string' || typeof classroomId === 'number'
+                ? classroomId
+                : null;
+        const validatedImage = imageBase64
+            ? validateAiImageDataUrl(imageBase64)
+            : null;
+
+        if (validatedImage && !validatedImage.ok) {
+            return jsonError(
+                validatedImage.error,
+                validatedImage.status,
+                validatedImage.code
+            );
+        }
+
+        const safeImageBase64 = validatedImage?.dataUrl ?? null;
 
         // Validate and sanitize history entries before injecting them into the
         // LLM context. Accepting arbitrary objects would let an attacker inject
@@ -266,15 +412,21 @@ export async function POST(req: Request) {
         const conversationHistory: { role: 'user' | 'assistant'; content: string }[] = [];
         if (Array.isArray(history)) {
             for (const entry of history.slice(-MAX_HISTORY_ENTRIES)) {
+                const historyEntry = entry as {
+                    role?: unknown;
+                    content?: unknown;
+                };
+
                 if (
-                    entry &&
-                    typeof entry === 'object' &&
-                    ALLOWED_ROLES.has(entry.role) &&
-                    typeof entry.content === 'string'
+                    historyEntry &&
+                    typeof historyEntry === 'object' &&
+                    typeof historyEntry.role === 'string' &&
+                    ALLOWED_ROLES.has(historyEntry.role) &&
+                    typeof historyEntry.content === 'string'
                 ) {
                     conversationHistory.push({
-                        role: entry.role as 'user' | 'assistant',
-                        content: entry.content.slice(0, MAX_CONTENT_LENGTH),
+                        role: historyEntry.role as 'user' | 'assistant',
+                        content: historyEntry.content.slice(0, MAX_CONTENT_LENGTH),
                     });
                 }
             }
@@ -283,7 +435,7 @@ export async function POST(req: Request) {
         let targetGradeLevel = 13;
         let pedagogyLevel = "Undergraduate (Freshman)";
 
-        if (classroomId) {
+        if (classroomIdValue) {
             try {
                 const [classroom] = await db
                     .select({
@@ -291,7 +443,7 @@ export async function POST(req: Request) {
                         targetGradeLevel: classroomsTable.targetGradeLevel,
                     })
                     .from(classroomsTable)
-                    .where(eq(classroomsTable.id, parseInt(classroomId.toString())));
+                    .where(eq(classroomsTable.id, parseInt(classroomIdValue.toString(), 10)));
                 if (classroom) {
                     pedagogyLevel = classroom.pedagogyLevel;
                     targetGradeLevel = classroom.targetGradeLevel;
@@ -323,7 +475,7 @@ export async function POST(req: Request) {
 
         if (
             !prompt &&
-            !imageBase64 &&
+            !safeImageBase64 &&
             conversationHistory.length === 0
         ) {
             return NextResponse.json(
@@ -342,7 +494,7 @@ export async function POST(req: Request) {
 - Symbols: Wrap all variables and greek letters in math delimiters.
 - Cleanliness: No repeated characters or filler text.`;
 
-        const PEDAGOGY_RULES = classroomId ? `
+        const PEDAGOGY_RULES = classroomIdValue ? `
 ### PEDAGOGICAL LEVEL TARGET:
 - The target student academic level is: ${pedagogyLevel} (Flesch-Kincaid Grade Level Target: ${targetGradeLevel}).
 - Explain concepts at this specific complexity. Do NOT use terms or mathematical proofs beyond this grade level. Avoid oversimplifying unless required.` : '';
@@ -367,15 +519,15 @@ ${MATH_RULES}
 4. If they ask a new unrelated doubt, politely ask them to start a new session.
 
 Respond in clean, well-spaced markdown. Do NOT use the "SUBJECT:" header for follow-ups.`;
-        } else if (type === 'simple') {
+        } else if (solveType === 'simple') {
             systemPrompt = `You are an expert AI Doubt Solver. VERY FIRST LINE must be: SUBJECT: [Detected Subject from: ${SUBJECT_LIST}]
 Then write 3-5 short paragraphs using plain English and a real-world analogy. No LaTeX or formulas. Respond in clean, well-spaced markdown.`;
-        } else if (type === 'exam') {
+        } else if (solveType === 'exam') {
             systemPrompt = `You are a strict exam-focused AI Tutor. Respond in clean, well-spaced markdown.
 VERY FIRST LINE must be: SUBJECT: [Detected Subject from: ${SUBJECT_LIST}]
 ${MATH_RULES}
 Structure: Provide an EXAM-READY answer with Key Formula, Step-by-step, Common mistakes, and Examiner keywords. Use **Step X:** for sub-steps inside sections.`;
-        } else if (type === 'eli10') {
+        } else if (solveType === 'eli10') {
             systemPrompt = `You are a friendly AI teacher explaining to a 10-year-old. VERY FIRST LINE must be: SUBJECT: [Detected Subject from: ${SUBJECT_LIST}]
 Use fun analogies, simple words, and no complex math notation unless explained by a fun story.
 
@@ -409,7 +561,7 @@ Use bold text (e.g. **Step 1:**) for sub-steps inside the sections. Do NOT use a
         }
 
         const isVisionRequest =
-            !!imageBase64 && !isFollowUp;
+            !!safeImageBase64 && !isFollowUp;
 
         let userMessageContent: Groq.Chat.Completions.ChatCompletionMessageParam["content"];
 
@@ -429,7 +581,7 @@ ${prompt ? `Additional context from student: ${prompt}` : ''}`;
                 {
                     type: 'image_url',
                     image_url: {
-                        url: imageBase64,
+                        url: safeImageBase64,
                     },
                 },
             ];
@@ -513,10 +665,11 @@ ${prompt ? `Additional context from student: ${prompt}` : ''}`;
                         content:
                             prompt || 'Visual Inquiry',
                         imageUrl:
-                            imageBase64?.slice(0, 500),
-                        classroomId: classroomId
+                            safeImageBase64?.slice(0, 500),
+                        classroomId: classroomIdValue
                             ? parseInt(
-                                  classroomId.toString()
+                                  classroomIdValue.toString(),
+                                  10
                               )
                             : null,
                         type: 'ai',
@@ -578,9 +731,7 @@ ${prompt ? `Additional context from student: ${prompt}` : ''}`;
 
         return NextResponse.json(
             {
-                error: error instanceof Error ?
-                    error.message :
-                    'The AI service is currently overloaded or experiencing issues. Please try again in 30 seconds.',
+                error: 'The AI service is currently overloaded or experiencing issues. Please try again in 30 seconds.',
             },
             { status: 500 }
         );

--- a/src/app/api/ask-ai/route.ts
+++ b/src/app/api/ask-ai/route.ts
@@ -383,10 +383,25 @@ export async function POST(req: Request) {
             typeof body.prompt === 'string' ? body.prompt : '';
         const solveType =
             typeof type === 'string' ? type : 'standard';
-        const classroomIdValue =
-            typeof classroomId === 'string' || typeof classroomId === 'number'
-                ? classroomId
-                : null;
+        let classroomIdValue: number | null = null;
+
+        if (classroomId !== undefined && classroomId !== null) {
+            const parsedClassroomId =
+                typeof classroomId === 'string' || typeof classroomId === 'number'
+                    ? Number(classroomId)
+                    : Number.NaN;
+
+            if (!Number.isSafeInteger(parsedClassroomId) || parsedClassroomId <= 0) {
+                return jsonError(
+                    'Invalid classroomId.',
+                    422,
+                    'INVALID_CLASSROOM_ID'
+                );
+            }
+
+            classroomIdValue = parsedClassroomId;
+        }
+
         const validatedImage = imageBase64
             ? validateAiImageDataUrl(imageBase64)
             : null;
@@ -443,7 +458,7 @@ export async function POST(req: Request) {
                         targetGradeLevel: classroomsTable.targetGradeLevel,
                     })
                     .from(classroomsTable)
-                    .where(eq(classroomsTable.id, parseInt(classroomIdValue.toString(), 10)));
+                    .where(eq(classroomsTable.id, classroomIdValue));
                 if (classroom) {
                     pedagogyLevel = classroom.pedagogyLevel;
                     targetGradeLevel = classroom.targetGradeLevel;
@@ -666,12 +681,7 @@ ${prompt ? `Additional context from student: ${prompt}` : ''}`;
                             prompt || 'Visual Inquiry',
                         imageUrl:
                             safeImageBase64?.slice(0, 500),
-                        classroomId: classroomIdValue
-                            ? parseInt(
-                                  classroomIdValue.toString(),
-                                  10
-                              )
-                            : null,
+                        classroomId: classroomIdValue,
                         type: 'ai',
                         isSolved: 'solved',
                     })

--- a/src/app/ask-ai/page.tsx
+++ b/src/app/ask-ai/page.tsx
@@ -14,6 +14,12 @@ import ReactMarkdown from 'react-markdown';
 import remarkMath from 'remark-math';
 import rehypeKatex from 'rehype-katex';
 import remarkGfm from 'remark-gfm';
+import {
+    AI_IMAGE_ALLOWED_TYPES_LABEL,
+    AI_IMAGE_MAX_BYTES,
+    AI_IMAGE_MAX_SIZE_LABEL,
+    isAllowedAiImageMimeType,
+} from '@/lib/ai-image-validation';
 import 'katex/dist/katex.min.css';
 
 type InputMode = 'text' | 'image';
@@ -85,10 +91,40 @@ export default function AskAIPage() {
     };
 
     const handleImageUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
-        const file = e.target.files?.[0];
+        const input = e.currentTarget;
+        const file = input.files?.[0];
         if (!file) return;
+
+        setErrorMsg(null);
+        setErrorCode(null);
+
+        if (!isAllowedAiImageMimeType(file.type)) {
+            setErrorMsg(`Please upload a ${AI_IMAGE_ALLOWED_TYPES_LABEL} image.`);
+            input.value = '';
+            return;
+        }
+
+        if (file.size > AI_IMAGE_MAX_BYTES) {
+            setErrorMsg(`Images must be ${AI_IMAGE_MAX_SIZE_LABEL} or smaller.`);
+            setErrorCode('IMAGE_TOO_LARGE');
+            input.value = '';
+            return;
+        }
+
         const reader = new FileReader();
-        reader.onloadend = () => setImageBase64(reader.result as string);
+        reader.onerror = () => {
+            setErrorMsg('Could not read this image. Please try another file.');
+            input.value = '';
+        };
+        reader.onloadend = () => {
+            if (typeof reader.result === 'string') {
+                setImageBase64(reader.result);
+                return;
+            }
+
+            setErrorMsg('Could not read this image. Please try another file.');
+            input.value = '';
+        };
         reader.readAsDataURL(file);
     };
 
@@ -374,7 +410,7 @@ export default function AskAIPage() {
                                 </>
                             ) : (
                                 <>
-                                    <input type="file" accept="image/*" className="hidden" ref={fileInputRef} onChange={handleImageUpload} />
+                                    <input type="file" accept="image/png,image/jpeg,image/webp" className="hidden" ref={fileInputRef} onChange={handleImageUpload} />
                                     {!imageBase64 ? (
                                         <button
                                             onClick={() => fileInputRef.current?.click()}
@@ -385,7 +421,7 @@ export default function AskAIPage() {
                                             </div>
                                             <div className="text-center">
                                                 <p className="text-slate-900 dark:text-white font-bold">Click to upload image</p>
-                                                <p className="text-slate-500 dark:text-slate-500 text-sm mt-1">PNG, JPG, WEBP · Max 10MB</p>
+                                                <p className="text-slate-500 dark:text-slate-500 text-sm mt-1">{AI_IMAGE_ALLOWED_TYPES_LABEL} · Max {AI_IMAGE_MAX_SIZE_LABEL}</p>
                                             </div>
                                         </button>
                                     ) : (

--- a/src/app/ask-ai/page.tsx
+++ b/src/app/ask-ai/page.tsx
@@ -15,6 +15,7 @@ import remarkMath from 'remark-math';
 import rehypeKatex from 'rehype-katex';
 import remarkGfm from 'remark-gfm';
 import {
+    AI_IMAGE_ALLOWED_MIME_TYPES,
     AI_IMAGE_ALLOWED_TYPES_LABEL,
     AI_IMAGE_MAX_BYTES,
     AI_IMAGE_MAX_SIZE_LABEL,
@@ -410,7 +411,7 @@ export default function AskAIPage() {
                                 </>
                             ) : (
                                 <>
-                                    <input type="file" accept="image/png,image/jpeg,image/webp" className="hidden" ref={fileInputRef} onChange={handleImageUpload} />
+                                    <input type="file" accept={AI_IMAGE_ALLOWED_MIME_TYPES.join(',')} className="hidden" ref={fileInputRef} onChange={handleImageUpload} />
                                     {!imageBase64 ? (
                                         <button
                                             onClick={() => fileInputRef.current?.click()}

--- a/src/components/AskAIView.tsx
+++ b/src/components/AskAIView.tsx
@@ -12,6 +12,7 @@ import remarkGfm from 'remark-gfm';
 import { toast } from 'sonner';
 import { Doubt } from '@/types';
 import {
+    AI_IMAGE_ALLOWED_MIME_TYPES,
     AI_IMAGE_ALLOWED_TYPES_LABEL,
     AI_IMAGE_MAX_BYTES,
     AI_IMAGE_MAX_SIZE_LABEL,
@@ -262,7 +263,7 @@ const { copied, copy } = useCopyToClipboard();
                         </>
                     ) : (
                         <>
-                            <input type="file" accept="image/png,image/jpeg,image/webp" className="hidden" ref={fileInputRef} onChange={handleImageUpload} />
+                            <input type="file" accept={AI_IMAGE_ALLOWED_MIME_TYPES.join(',')} className="hidden" ref={fileInputRef} onChange={handleImageUpload} />
                             {!imageBase64 ? (
                                 <button
                                     onClick={() => fileInputRef.current?.click()}

--- a/src/components/AskAIView.tsx
+++ b/src/components/AskAIView.tsx
@@ -11,6 +11,12 @@ import rehypeKatex from 'rehype-katex';
 import remarkGfm from 'remark-gfm';
 import { toast } from 'sonner';
 import { Doubt } from '@/types';
+import {
+    AI_IMAGE_ALLOWED_TYPES_LABEL,
+    AI_IMAGE_MAX_BYTES,
+    AI_IMAGE_MAX_SIZE_LABEL,
+    isAllowedAiImageMimeType,
+} from '@/lib/ai-image-validation';
 import 'katex/dist/katex.min.css';
 
 type SolveType = 'standard' | 'simple' | 'exam' | 'eli10';
@@ -148,10 +154,48 @@ const { copied, copy } = useCopyToClipboard();
     };
 
     const handleImageUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
-        const file = e.target.files?.[0];
+        const input = e.currentTarget;
+        const file = input.files?.[0];
         if (!file) return;
+
+        setErrorMsg(null);
+        setErrorCode(null);
+
+        if (!isAllowedAiImageMimeType(file.type)) {
+            const message = `Please upload a ${AI_IMAGE_ALLOWED_TYPES_LABEL} image.`;
+            setErrorMsg(message);
+            toast.error(message);
+            input.value = '';
+            return;
+        }
+
+        if (file.size > AI_IMAGE_MAX_BYTES) {
+            const message = `Images must be ${AI_IMAGE_MAX_SIZE_LABEL} or smaller.`;
+            setErrorMsg(message);
+            setErrorCode('IMAGE_TOO_LARGE');
+            toast.error(message);
+            input.value = '';
+            return;
+        }
+
         const reader = new FileReader();
-        reader.onloadend = () => setImageBase64(reader.result as string);
+        reader.onerror = () => {
+            const message = 'Could not read this image. Please try another file.';
+            setErrorMsg(message);
+            toast.error(message);
+            input.value = '';
+        };
+        reader.onloadend = () => {
+            if (typeof reader.result === 'string') {
+                setImageBase64(reader.result);
+                return;
+            }
+
+            const message = 'Could not read this image. Please try another file.';
+            setErrorMsg(message);
+            toast.error(message);
+            input.value = '';
+        };
         reader.readAsDataURL(file);
     };
 
@@ -218,7 +262,7 @@ const { copied, copy } = useCopyToClipboard();
                         </>
                     ) : (
                         <>
-                            <input type="file" accept="image/*" className="hidden" ref={fileInputRef} onChange={handleImageUpload} />
+                            <input type="file" accept="image/png,image/jpeg,image/webp" className="hidden" ref={fileInputRef} onChange={handleImageUpload} />
                             {!imageBase64 ? (
                                 <button
                                     onClick={() => fileInputRef.current?.click()}
@@ -229,13 +273,14 @@ const { copied, copy } = useCopyToClipboard();
                                     </div>
                                     <div className="text-center">
                                         <p className="text-slate-900 dark:text-white font-bold text-xs uppercase tracking-widest">Select Image</p>
+                                        <p className="text-slate-500 dark:text-slate-500 text-[10px] mt-1">{AI_IMAGE_ALLOWED_TYPES_LABEL} · Max {AI_IMAGE_MAX_SIZE_LABEL}</p>
                                     </div>
                                 </button>
                             ) : (
                                 <div className="relative rounded-2xl overflow-hidden border border-slate-200 dark:border-white/10 bg-white dark:bg-slate-950">
                                     <img src={imageBase64} alt="Uploaded" className="w-full max-h-64 object-contain" />
                                     <button
-                                        onClick={() => setImageBase64(null)}
+                                        onClick={() => { setImageBase64(null); if (fileInputRef.current) fileInputRef.current.value = ''; }}
                                         className="absolute top-3 right-3 w-8 h-8 bg-red-500 rounded-full flex items-center justify-center shadow-lg"
                                         aria-label="Remove image"
                                     >

--- a/src/lib/ai-image-validation.ts
+++ b/src/lib/ai-image-validation.ts
@@ -1,0 +1,112 @@
+export const AI_REQUEST_MAX_BYTES = 4 * 1024 * 1024;
+export const AI_IMAGE_MAX_BYTES = 3 * 1024 * 1024;
+export const AI_REQUEST_MAX_SIZE_LABEL = '4MB';
+export const AI_IMAGE_MAX_SIZE_LABEL = '3MB';
+export const AI_IMAGE_ALLOWED_TYPES_LABEL = 'PNG, JPG, WEBP';
+export const AI_IMAGE_ALLOWED_MIME_TYPES = [
+    'image/png',
+    'image/jpeg',
+    'image/webp',
+] as const;
+
+const AI_IMAGE_DATA_URL_PATTERN =
+    /^data:(image\/(?:png|jpeg|webp));base64,([A-Za-z0-9+/]+={0,2})$/i;
+
+export type AiImageValidationResult =
+    | {
+          ok: true;
+          dataUrl: string;
+          mimeType: string;
+          decodedBytes: number;
+      }
+    | {
+          ok: false;
+          status: 413 | 422;
+          code: string;
+          error: string;
+      };
+
+export function isAllowedAiImageMimeType(mimeType: string) {
+    return (AI_IMAGE_ALLOWED_MIME_TYPES as readonly string[]).includes(
+        mimeType.toLowerCase()
+    );
+}
+
+export function getBase64DecodedByteLength(base64Data: string) {
+    const padding =
+        base64Data.endsWith("==") ? 2 : base64Data.endsWith("=") ? 1 : 0;
+
+    return Math.floor((base64Data.length * 3) / 4) - padding;
+}
+
+export function validateAiImageDataUrl(
+    imageBase64: unknown
+): AiImageValidationResult {
+    if (typeof imageBase64 !== "string") {
+        return {
+            ok: false,
+            status: 422,
+            code: 'INVALID_IMAGE_PAYLOAD',
+            error: 'Please upload a valid PNG, JPG, or WEBP image.',
+        };
+    }
+
+    const match = imageBase64.match(AI_IMAGE_DATA_URL_PATTERN);
+
+    if (!match) {
+        return {
+            ok: false,
+            status: 422,
+            code: 'INVALID_IMAGE_PAYLOAD',
+            error: 'Please upload a valid PNG, JPG, or WEBP image.',
+        };
+    }
+
+    const mimeType = match[1].toLowerCase();
+    const base64Data = match[2];
+
+    if (base64Data.length % 4 !== 0) {
+        return {
+            ok: false,
+            status: 422,
+            code: 'INVALID_IMAGE_PAYLOAD',
+            error: 'Please upload a valid PNG, JPG, or WEBP image.',
+        };
+    }
+
+    if (!isAllowedAiImageMimeType(mimeType)) {
+        return {
+            ok: false,
+            status: 422,
+            code: 'UNSUPPORTED_IMAGE_TYPE',
+            error: `Only ${AI_IMAGE_ALLOWED_TYPES_LABEL} images are supported.`,
+        };
+    }
+
+    const decodedBytes = getBase64DecodedByteLength(base64Data);
+
+    if (decodedBytes <= 0) {
+        return {
+            ok: false,
+            status: 422,
+            code: 'INVALID_IMAGE_PAYLOAD',
+            error: 'Please upload a valid PNG, JPG, or WEBP image.',
+        };
+    }
+
+    if (decodedBytes > AI_IMAGE_MAX_BYTES) {
+        return {
+            ok: false,
+            status: 413,
+            code: 'IMAGE_TOO_LARGE',
+            error: `Images must be ${AI_IMAGE_MAX_SIZE_LABEL} or smaller.`,
+        };
+    }
+
+    return {
+        ok: true,
+        dataUrl: imageBase64,
+        mimeType,
+        decodedBytes,
+    };
+}

--- a/src/lib/ai-image-validation.ts
+++ b/src/lib/ai-image-validation.ts
@@ -1,7 +1,12 @@
 export const AI_REQUEST_MAX_BYTES = 4 * 1024 * 1024;
 export const AI_IMAGE_MAX_BYTES = 3 * 1024 * 1024;
-export const AI_REQUEST_MAX_SIZE_LABEL = '4MB';
-export const AI_IMAGE_MAX_SIZE_LABEL = '3MB';
+
+function formatMegabytes(bytes: number) {
+    return `${bytes / (1024 * 1024)}MB`;
+}
+
+export const AI_REQUEST_MAX_SIZE_LABEL = formatMegabytes(AI_REQUEST_MAX_BYTES);
+export const AI_IMAGE_MAX_SIZE_LABEL = formatMegabytes(AI_IMAGE_MAX_BYTES);
 export const AI_IMAGE_ALLOWED_TYPES_LABEL = 'PNG, JPG, WEBP';
 export const AI_IMAGE_ALLOWED_MIME_TYPES = [
     'image/png',


### PR DESCRIPTION
Closes #504

## What changed
- enforce a 4MB request-body limit while streaming the `/api/ask-ai` JSON body
- validate AI image data URLs, allowed MIME types, base64 shape, and decoded size before provider calls
- apply the existing `aiLimiter` with a clear 429 response and `Retry-After` header
- add matching PNG/JPG/WEBP and 3MB checks to both image-upload interfaces
- return generic provider failure responses instead of exposing internal error details

## Verification
- focused ask-ai route tests pass, including rate-limit and invalid-image rejection paths
- scoped TypeScript check for all touched files passes
- `git diff --check` passes
- CI Build Check, TypeScript Check, ESLint, Security Scan, and Dependency Audit pass
- the remaining full-suite test failures are existing failures in doubts sorting/filtering, rooms-members, and DB configuration

This contribution is part of GSSoC 2026. The issue already has the `gssoc'26` and `level:critical` labels.