### PR TITLE
feat: centralize classroom authorization guards

### DIFF
--- a/src/__tests__/api/ask-ai.test.ts
+++ b/src/__tests__/api/ask-ai.test.ts
@@ -194,7 +194,7 @@ describe('Ask AI API Endpoint', () => {
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({
                 prompt: 'What is the speed of light?',
-                classroomId: '12abc',
+                classroomId: '1e2',
             }),
         });
 

--- a/src/__tests__/api/ask-ai.test.ts
+++ b/src/__tests__/api/ask-ai.test.ts
@@ -8,15 +8,23 @@ jest.mock('@clerk/nextjs/server', () => ({
     }))
 }));
 
+const selectResultsQueue: any[] = [];
+
+const createQueryMock = (data: any[]) => {
+    const query: any = {
+        from: () => query,
+        where: () => query,
+        limit: () => Promise.resolve(data),
+        then: (resolve: any) => Promise.resolve(resolve(data)),
+    };
+    return query;
+};
+
 jest.mock('@/configs/db', () => ({
     db: {
-        select: jest.fn().mockImplementation(() => ({
-            from: jest.fn().mockImplementation(() => ({
-                where: jest.fn().mockImplementation(async () => ([{
-                    blockedUntil: null
-                }]))
-            }))
-        })),
+        select: jest.fn().mockImplementation(() =>
+            createQueryMock(selectResultsQueue.shift() ?? [{ blockedUntil: null }])
+        ),
         insert: jest.fn().mockImplementation(() => ({
             values: jest.fn().mockImplementation(() => ({
                 returning: jest.fn().mockImplementation(async () => ([{
@@ -59,6 +67,10 @@ jest.mock('groq-sdk', () => {
 describe('Ask AI API Endpoint', () => {
     const originalFetch = global.fetch;
 
+    beforeEach(() => {
+        selectResultsQueue.length = 0;
+    });
+
     afterEach(() => {
         global.fetch = originalFetch;
     });
@@ -87,5 +99,24 @@ describe('Ask AI API Endpoint', () => {
         expect(res.status).toBe(200);
         expect(json.subject).toBe('Physics');
         expect(json.reply).toContain('Light travels at approximately');
+    });
+
+    it('rejects classroom-scoped requests from non-members', async () => {
+        selectResultsQueue.push([{ blockedUntil: null }], []);
+
+        const req = new Request('http://localhost/api/ask-ai', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                prompt: 'What is the speed of light?',
+                classroomId: 7,
+            })
+        });
+
+        const res = await POST(req);
+        const json = await res.json();
+
+        expect(res.status).toBe(403);
+        expect(json.error).toBe('Access denied to this classroom');
     });
 });

--- a/src/__tests__/api/ask-ai.test.ts
+++ b/src/__tests__/api/ask-ai.test.ts
@@ -102,7 +102,7 @@ describe('Ask AI API Endpoint', () => {
     });
 
     it('rejects classroom-scoped requests from non-members', async () => {
-        selectResultsQueue.push([{ blockedUntil: null }], []);
+        selectResultsQueue.push([{ blockedUntil: null }], [], []);
 
         const req = new Request('http://localhost/api/ask-ai', {
             method: 'POST',

--- a/src/__tests__/api/doubts-similarity.test.ts
+++ b/src/__tests__/api/doubts-similarity.test.ts
@@ -1,0 +1,76 @@
+import { currentUser } from "@clerk/nextjs/server";
+
+import { POST } from "@/app/api/doubts/check-similarity/route";
+
+jest.mock("@clerk/nextjs/server", () => ({
+  currentUser: jest.fn(),
+}));
+
+const createQueryMock = () => {
+  const query: any = {
+    from: () => query,
+    where: () => query,
+    orderBy: () => query,
+    limit: () => query,
+    then: (resolve: any) => Promise.resolve(resolve([])),
+  };
+  return query;
+};
+
+jest.mock("@/configs/db", () => ({
+  db: {
+    select: jest.fn(() => createQueryMock()),
+  },
+}));
+
+jest.mock("groq-sdk", () => ({
+  __esModule: true,
+  default: jest.fn(() => ({
+    chat: {
+      completions: {
+        create: jest.fn(),
+      },
+    },
+  })),
+}));
+
+describe("Doubt similarity API endpoint", () => {
+  const currentUserMock = currentUser as jest.MockedFunction<typeof currentUser>;
+
+  beforeEach(() => {
+    currentUserMock.mockReset();
+    currentUserMock.mockResolvedValue(null);
+  });
+
+  it("allows anonymous community similarity checks", async () => {
+    const req = new Request("http://localhost/api/doubts/check-similarity", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        content: "How does photosynthesis convert light into energy?",
+      }),
+    });
+
+    const res = await POST(req);
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ similarDoubts: [] });
+    expect(currentUserMock).not.toHaveBeenCalled();
+  });
+
+  it("requires authentication for classroom similarity checks", async () => {
+    const req = new Request("http://localhost/api/doubts/check-similarity", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        content: "How does photosynthesis convert light into energy?",
+        classroomId: 7,
+      }),
+    });
+
+    const res = await POST(req);
+
+    expect(res.status).toBe(401);
+    await expect(res.json()).resolves.toMatchObject({ error: "Unauthorized" });
+  });
+});

--- a/src/__tests__/api/doubts.test.ts
+++ b/src/__tests__/api/doubts.test.ts
@@ -1,10 +1,8 @@
 import { GET, POST } from '@/app/api/doubts/route';
+import { currentUser } from '@clerk/nextjs/server';
 
 jest.mock('@clerk/nextjs/server', () => ({
-    currentUser: jest.fn().mockImplementation(async () => ({
-        primaryEmailAddress: { emailAddress: 'student@example.com' },
-        fullName: 'Test Student'
-    }))
+    currentUser: jest.fn()
 }));
 
 jest.mock('@/lib/moderation', () => ({
@@ -72,6 +70,7 @@ const mockDoubts = [
         userEmail: 'other@example.com'
     }
 ];
+let mockQueryDoubts = mockDoubts;
 
 const createEmptyChain = () => {
     const chain: any = {
@@ -118,7 +117,7 @@ jest.mock('@/configs/db', () => ({
                 return createEmptyChain();
             }
             // Default: return doubts
-            return createChainWithData(mockDoubts);
+            return createChainWithData(mockQueryDoubts);
         }),
 
         insert: jest.fn().mockImplementation(() => ({
@@ -140,6 +139,25 @@ jest.mock('@/configs/db', () => ({
 }));
 
 describe('Doubts API Endpoints', () => {
+    beforeEach(() => {
+        mockQueryDoubts = mockDoubts;
+        (currentUser as jest.Mock).mockResolvedValue({
+            primaryEmailAddress: { emailAddress: 'student@example.com' },
+            fullName: 'Test Student'
+        });
+    });
+
+    it('GET allows anonymous community doubt reads', async () => {
+        (currentUser as jest.Mock).mockResolvedValue(null);
+
+        const req = new Request('http://localhost/api/doubts?subject=Physics');
+        const res = await GET(req);
+        const json = await res.json();
+
+        expect(res.status).toBe(200);
+        expect(json[0].subject).toBe('Physics');
+    });
+
     it('GET should return list of doubts with pagination', async () => {
         const req = new Request('http://localhost/api/doubts?subject=Physics');
         const res = await GET(req);
@@ -151,6 +169,7 @@ describe('Doubts API Endpoints', () => {
     });
 
     it('GET should support popular sorting', async () => {
+        mockQueryDoubts = [...mockDoubts].sort((a, b) => b.likes - a.likes);
         const req = new Request('http://localhost/api/doubts?subject=Physics&sort=popular');
         const res = await GET(req);
         const json = await res.json();
@@ -171,6 +190,7 @@ describe('Doubts API Endpoints', () => {
     });
 
     it('GET should support unsolved filtering', async () => {
+        mockQueryDoubts = mockDoubts.filter((doubt) => doubt.isSolved === 'unsolved');
         const req = new Request('http://localhost/api/doubts?subject=Physics&sort=unsolved');
         const res = await GET(req);
         const json = await res.json();

--- a/src/__tests__/api/rooms-members.test.ts
+++ b/src/__tests__/api/rooms-members.test.ts
@@ -57,7 +57,7 @@ describe('Room Members API Endpoint', () => {
         const json = await res.json();
 
         expect(res.status).toBe(403);
-        expect(json.error).toBe('Access denied');
+        expect(json.error).toBe('Access denied to this classroom');
     });
 
     it('does not expose member emails to student requesters', async () => {

--- a/src/__tests__/api/rooms-members.test.ts
+++ b/src/__tests__/api/rooms-members.test.ts
@@ -16,6 +16,8 @@ const createQueryMock = (data: any) => {
     const chain: any = {
         from: () => chain,
         where: () => chain,
+        limit: () => chain,
+        offset: () => chain,
         then: (resolve: any) => Promise.resolve(resolve(data)),
     };
 
@@ -51,7 +53,7 @@ describe('Room Members API Endpoint', () => {
             primaryEmailAddress: { emailAddress: 'outsider@example.com' },
         });
         checkUserBlockMock.mockResolvedValue({ isBlocked: false });
-        selectResultQueue.push([]);
+        selectResultQueue.push([], []);
 
         const res = (await GET(new Request('http://localhost/api/rooms/members?classroomId=1')))!;
         const json = await res.json();
@@ -67,6 +69,7 @@ describe('Room Members API Endpoint', () => {
         checkUserBlockMock.mockResolvedValue({ isBlocked: false });
         selectResultQueue.push(
             [{ id: 1, userEmail: 'student@example.com', role: 'student', classroomId: 1 }],
+            [{ count: 2 }],
             [
                 {
                     id: 1,
@@ -87,18 +90,21 @@ describe('Room Members API Endpoint', () => {
         const json = await res.json();
 
         expect(res.status).toBe(200);
-        expect(json).toEqual([
-            {
-                displayName: 'Student_1',
-                role: 'student',
-                joinedAt: '2026-01-01T00:00:00.000Z',
-            },
-            {
-                displayName: 'Student_2',
-                role: 'student',
-                joinedAt: '2026-01-02T00:00:00.000Z',
-            },
-        ]);
+        expect(json).toEqual({
+            members: [
+                {
+                    displayName: 'Student_1',
+                    role: 'student',
+                    joinedAt: '2026-01-01T00:00:00.000Z',
+                },
+                {
+                    displayName: 'Student_2',
+                    role: 'student',
+                    joinedAt: '2026-01-02T00:00:00.000Z',
+                },
+            ],
+            pagination: { total: 2, page: 1, limit: 20, totalPages: 1 },
+        });
         expect(JSON.stringify(json)).not.toContain('userEmail');
         expect(JSON.stringify(json)).not.toContain('classmate@example.com');
     });
@@ -110,6 +116,7 @@ describe('Room Members API Endpoint', () => {
         checkUserBlockMock.mockResolvedValue({ isBlocked: false });
         selectResultQueue.push(
             [{ id: 1, userEmail: 'teacher@example.com', role: 'teacher', classroomId: 1 }],
+            [{ count: 2 }],
             [
                 {
                     id: 1,
@@ -130,17 +137,20 @@ describe('Room Members API Endpoint', () => {
         const json = await res.json();
 
         expect(res.status).toBe(200);
-        expect(json).toEqual([
-            {
-                userEmail: 'teacher@example.com',
-                role: 'teacher',
-                joinedAt: '2026-01-01T00:00:00.000Z',
-            },
-            {
-                userEmail: 'student@example.com',
-                role: 'student',
-                joinedAt: '2026-01-02T00:00:00.000Z',
-            },
-        ]);
+        expect(json).toEqual({
+            members: [
+                {
+                    userEmail: 'teacher@example.com',
+                    role: 'teacher',
+                    joinedAt: '2026-01-01T00:00:00.000Z',
+                },
+                {
+                    userEmail: 'student@example.com',
+                    role: 'student',
+                    joinedAt: '2026-01-02T00:00:00.000Z',
+                },
+            ],
+            pagination: { total: 2, page: 1, limit: 20, totalPages: 1 },
+        });
     });
 });

--- a/src/__tests__/api/teacher-insights.test.ts
+++ b/src/__tests__/api/teacher-insights.test.ts
@@ -79,7 +79,7 @@ describe('Teacher Insights API Endpoint', () => {
         const json = await res.json();
 
         expect(res.status).toBe(403);
-        expect(json.error).toBe('Forbidden: not the teacher of this classroom');
+        expect(json.error).toBe('Access denied to this classroom');
     });
 
     it('returns classroom-scoped insights for the teacher', async () => {
@@ -88,7 +88,7 @@ describe('Teacher Insights API Endpoint', () => {
         });
 
         selectResultsQueue.push(
-            [{ id: 7 }],
+            [{ role: 'teacher' }],
             [
                 { topic: 'Loops', subject: 'Programming', count: 4 },
                 { topic: 'Fractions', subject: 'Math', count: 2 },

--- a/src/__tests__/api/teacher-insights.test.ts
+++ b/src/__tests__/api/teacher-insights.test.ts
@@ -64,7 +64,7 @@ describe('Teacher Insights API Endpoint', () => {
         const json = await res.json();
 
         expect(res.status).toBe(400);
-        expect(json.error).toBe('classroomId is required');
+        expect(json.error).toBe('Invalid classroom ID');
     });
 
     it('returns 403 when the user is not the teacher of the classroom', async () => {
@@ -72,7 +72,7 @@ describe('Teacher Insights API Endpoint', () => {
             primaryEmailAddress: { emailAddress: 'teacher@example.com' },
         });
 
-        selectResultsQueue.push([]);
+        selectResultsQueue.push([], []);
 
         const req = new NextRequest('http://localhost/api/teacher/insights?classroomId=7');
         const res = await GET(req);

--- a/src/__tests__/lib/membership-guard.test.ts
+++ b/src/__tests__/lib/membership-guard.test.ts
@@ -1,0 +1,104 @@
+import { currentUser } from "@clerk/nextjs/server";
+
+import { db } from "@/configs/db";
+import { ApiError } from "@/lib/error-handler";
+import {
+    parseClassroomId,
+    parseOptionalClassroomId,
+    requireAuth,
+    requireMembership,
+    requireTeacher,
+} from "@/lib/auth/membership-guard";
+
+jest.mock("@clerk/nextjs/server", () => ({
+    currentUser: jest.fn(),
+}));
+
+const membershipResults: Array<{ role: string }[]> = [];
+
+const createMembershipQuery = () => {
+    const query = {
+        from: jest.fn(() => query),
+        where: jest.fn(() => query),
+        then: (resolve: (value: { role: string }[]) => unknown) =>
+            Promise.resolve(resolve(membershipResults.shift() ?? [])),
+    };
+    return query;
+};
+
+jest.mock("@/configs/db", () => ({
+    db: {
+        select: jest.fn(),
+    },
+}));
+
+const currentUserMock = currentUser as jest.MockedFunction<typeof currentUser>;
+const selectMock = db.select as jest.Mock;
+
+describe("membership guard", () => {
+    beforeEach(() => {
+        currentUserMock.mockReset();
+        selectMock.mockReset();
+        selectMock.mockImplementation(() => createMembershipQuery());
+        membershipResults.length = 0;
+    });
+
+    it("returns the authenticated Clerk user and primary email", async () => {
+        const user = {
+            primaryEmailAddress: { emailAddress: "student@example.com" },
+        };
+        currentUserMock.mockResolvedValue(user as never);
+
+        await expect(requireAuth()).resolves.toEqual({
+            user,
+            email: "student@example.com",
+        });
+    });
+
+    it("rejects unauthenticated requests with a 401 ApiError", async () => {
+        currentUserMock.mockResolvedValue(null);
+
+        await expect(requireAuth()).rejects.toMatchObject<ApiError>({
+            statusCode: 401,
+            message: "Unauthorized",
+        });
+    });
+
+    it("strictly parses positive classroom IDs", () => {
+        expect(parseClassroomId("42")).toBe(42);
+        expect(parseOptionalClassroomId(null)).toBeNull();
+        expect(() => parseClassroomId("42abc")).toThrow("Invalid classroom ID");
+        expect(() => parseClassroomId("1e2")).toThrow("Invalid classroom ID");
+        expect(() => parseClassroomId(0)).toThrow("Invalid classroom ID");
+    });
+
+    it("returns the classroom membership role", async () => {
+        membershipResults.push([{ role: "student" }]);
+
+        await expect(
+            requireMembership("student@example.com", 7),
+        ).resolves.toEqual({ role: "student" });
+    });
+
+    it("rejects users without classroom membership", async () => {
+        membershipResults.push([]);
+
+        await expect(
+            requireMembership("outsider@example.com", 7),
+        ).rejects.toMatchObject<ApiError>({
+            statusCode: 403,
+            message: "Access denied to this classroom",
+        });
+    });
+
+    it("requires a teacher or owner role for teacher-only actions", async () => {
+        membershipResults.push([{ role: "student" }], [{ role: "teacher" }]);
+
+        await expect(
+            requireTeacher("student@example.com", 7),
+        ).rejects.toMatchObject<ApiError>({ statusCode: 403 });
+        await expect(
+            requireTeacher("teacher@example.com", 7),
+        ).resolves.toEqual({ role: "teacher" });
+    });
+});

--- a/src/__tests__/lib/membership-guard.test.ts
+++ b/src/__tests__/lib/membership-guard.test.ts
@@ -14,13 +14,13 @@ jest.mock("@clerk/nextjs/server", () => ({
     currentUser: jest.fn(),
 }));
 
-const membershipResults: Array<{ role: string }[]> = [];
+const membershipResults: Array<Record<string, string>[]> = [];
 
 const createMembershipQuery = () => {
     const query = {
         from: jest.fn(() => query),
         where: jest.fn(() => query),
-        then: (resolve: (value: { role: string }[]) => unknown) =>
+        then: (resolve: (value: Record<string, string>[]) => unknown) =>
             Promise.resolve(resolve(membershipResults.shift() ?? [])),
     };
     return query;
@@ -64,6 +64,15 @@ describe("membership guard", () => {
         });
     });
 
+    it("rejects authenticated users without a primary email with a 401 ApiError", async () => {
+        currentUserMock.mockResolvedValue({ primaryEmailAddress: null } as never);
+
+        await expect(requireAuth()).rejects.toMatchObject<ApiError>({
+            statusCode: 401,
+            message: "Unauthorized",
+        });
+    });
+
     it("strictly parses positive classroom IDs", () => {
         expect(parseClassroomId("42")).toBe(42);
         expect(parseOptionalClassroomId(null)).toBeNull();
@@ -81,7 +90,7 @@ describe("membership guard", () => {
     });
 
     it("rejects users without classroom membership", async () => {
-        membershipResults.push([]);
+        membershipResults.push([], []);
 
         await expect(
             requireMembership("outsider@example.com", 7),
@@ -91,8 +100,21 @@ describe("membership guard", () => {
         });
     });
 
-    it("requires a teacher or owner role for teacher-only actions", async () => {
-        membershipResults.push([{ role: "student" }], [{ role: "teacher" }]);
+    it("allows the recorded classroom owner without a membership row", async () => {
+        membershipResults.push([], [{ teacherEmail: "owner@example.com" }]);
+
+        await expect(
+            requireMembership("owner@example.com", 7),
+        ).resolves.toEqual({ role: "owner" });
+    });
+
+    it("allows teacher, owner, and admin roles for teacher-only actions", async () => {
+        membershipResults.push(
+            [{ role: "student" }],
+            [{ role: "teacher" }],
+            [{ role: "owner" }],
+            [{ role: "admin" }],
+        );
 
         await expect(
             requireTeacher("student@example.com", 7),
@@ -100,5 +122,11 @@ describe("membership guard", () => {
         await expect(
             requireTeacher("teacher@example.com", 7),
         ).resolves.toEqual({ role: "teacher" });
+        await expect(
+            requireTeacher("owner@example.com", 7),
+        ).resolves.toEqual({ role: "owner" });
+        await expect(
+            requireTeacher("admin@example.com", 7),
+        ).resolves.toEqual({ role: "admin" });
     });
 });

--- a/src/app/api/analytics/personal/route.ts
+++ b/src/app/api/analytics/personal/route.ts
@@ -1,9 +1,14 @@
 import { NextResponse } from 'next/server';
 import { db } from '@/configs/db';
-import { doubtsTable, usersTable } from '@/configs/schema';
+import { doubtsTable } from '@/configs/schema';
 import { and, eq, desc } from 'drizzle-orm';
-import { currentUser } from '@clerk/nextjs/server';
 import Groq from 'groq-sdk';
+import { buildErrorResponse } from '@/lib/error-handler';
+import {
+    parseClassroomId,
+    requireAuth,
+    requireMembership,
+} from '@/lib/auth/membership-guard';
 
 const groq = new Groq({
     apiKey: process.env.GROQ_API_KEY || 'dummy_key',
@@ -12,16 +17,14 @@ const groq = new Groq({
 export async function GET(req: Request) {
     const { searchParams } = new URL(req.url);
     const classroomIdStr = searchParams.get("classroomId");
-    const classroomId = classroomIdStr ? parseInt(classroomIdStr) : null;
-
-    if (!classroomId) {
+    if (!classroomIdStr) {
         return NextResponse.json({ error: "Classroom ID required" }, { status: 400 });
     }
 
     try {
-        const user = await currentUser();
-        if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-        const email = user.primaryEmailAddress?.emailAddress;
+        const { email } = await requireAuth();
+        const classroomId = parseClassroomId(classroomIdStr);
+        await requireMembership(email, classroomId);
 
         // Fetch user's doubts in this classroom
         const userDoubts = await db.select({
@@ -33,7 +36,7 @@ export async function GET(req: Request) {
         .where(
             and(
                 eq(doubtsTable.classroomId, classroomId),
-                eq(doubtsTable.userEmail, email!)
+                eq(doubtsTable.userEmail, email)
             )
         )
         .orderBy(desc(doubtsTable.createdAt));
@@ -82,6 +85,11 @@ export async function GET(req: Request) {
         });
 
     } catch (error: unknown) {
+        const { status, body } = buildErrorResponse(error);
+        if (status < 500) {
+            return NextResponse.json(body, { status });
+        }
+
         console.error("Personal Analytics Error:", error);
         return NextResponse.json({ error: "Failed to generate personal insights" }, { status: 500 });
     }

--- a/src/app/api/analytics/personal/route.ts
+++ b/src/app/api/analytics/personal/route.ts
@@ -15,14 +15,13 @@ const groq = new Groq({
 });
 
 export async function GET(req: Request) {
-    const { searchParams } = new URL(req.url);
-    const classroomIdStr = searchParams.get("classroomId");
-    if (!classroomIdStr) {
-        return NextResponse.json({ error: "Classroom ID required" }, { status: 400 });
-    }
-
     try {
         const { email } = await requireAuth();
+        const { searchParams } = new URL(req.url);
+        const classroomIdStr = searchParams.get("classroomId");
+        if (!classroomIdStr) {
+            return NextResponse.json({ error: "Classroom ID required" }, { status: 400 });
+        }
         const classroomId = parseClassroomId(classroomIdStr);
         await requireMembership(email, classroomId);
 

--- a/src/app/api/analytics/route.ts
+++ b/src/app/api/analytics/route.ts
@@ -1,66 +1,51 @@
 import { NextResponse } from 'next/server';
 import { db } from '@/configs/db';
 import { doubtsTable, repliesTable, membershipsTable, classroomsTable } from '@/configs/schema';
-import { desc, sql, and, isNull, eq, count, countDistinct, ne, inArray } from 'drizzle-orm';
-import { currentUser } from '@clerk/nextjs/server';
+import { desc, sql, and, eq, count, countDistinct, ne, inArray } from 'drizzle-orm';
 import { checkUserBlock } from '@/lib/auth-utils';
+import { buildErrorResponse } from '@/lib/error-handler';
+import {
+    parseOptionalClassroomId,
+    requireAuth,
+    requireMembership,
+} from '@/lib/auth/membership-guard';
 
 export async function GET(req: Request) {
-    const user = await currentUser();
-    if (!user || !user.primaryEmailAddress?.emailAddress) {
-        return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
-
-    const email = user.primaryEmailAddress.emailAddress;
-
-    // Check if user is blocked
-    const { isBlocked, errorResponse } = await checkUserBlock(email);
-    if (isBlocked) return errorResponse;
-
-    const { searchParams } = new URL(req.url);
-    const classroomIdStr = searchParams.get("classroomId");
-    const classroomId = classroomIdStr ? parseInt(classroomIdStr) : null;
-
-    let classroomFilter;
-
-    if (classroomId) {
-        // Verify the user is a member of this classroom
-        const [membership] = await db.select().from(membershipsTable).where(
-            and(
-                eq(membershipsTable.userEmail, email),
-                eq(membershipsTable.classroomId, classroomId)
-            )
-        );
-
-        if (!membership) {
-            return NextResponse.json({ error: 'Access denied: not a member of this classroom' }, { status: 403 });
-        }
-
-        classroomFilter = eq(doubtsTable.classroomId, classroomId);
-    } else {
-        // Get all classrooms user is a member of
-        const userMemberships = await db.select({ classroomId: membershipsTable.classroomId })
-            .from(membershipsTable)
-            .where(eq(membershipsTable.userEmail, email));
-
-        const userClassroomIds = userMemberships.map(m => m.classroomId);
-
-        if (userClassroomIds.length === 0) {
-            return NextResponse.json({
-                trendingDoubts: [],
-                mostAskedTopics: [],
-                solvedStats: [],
-                peakTime: [],
-                engagement: { totalStudents: 0, totalDoubts: 0, totalReplies: 0 },
-                weakTopics: [],
-                topContributors: []
-            });
-        }
-
-        classroomFilter = inArray(doubtsTable.classroomId, userClassroomIds);
-    }
-
     try {
+        const { email } = await requireAuth();
+        const { isBlocked, errorResponse } = await checkUserBlock(email);
+        if (isBlocked) return errorResponse;
+
+        const { searchParams } = new URL(req.url);
+        const classroomId = parseOptionalClassroomId(searchParams.get("classroomId"));
+
+        let classroomFilter;
+
+        if (classroomId) {
+            await requireMembership(email, classroomId);
+            classroomFilter = eq(doubtsTable.classroomId, classroomId);
+        } else {
+            const userMemberships = await db.select({ classroomId: membershipsTable.classroomId })
+                .from(membershipsTable)
+                .where(eq(membershipsTable.userEmail, email));
+
+            const userClassroomIds = userMemberships.map(m => m.classroomId);
+
+            if (userClassroomIds.length === 0) {
+                return NextResponse.json({
+                    trendingDoubts: [],
+                    mostAskedTopics: [],
+                    solvedStats: [],
+                    peakTime: [],
+                    engagement: { totalStudents: 0, totalDoubts: 0, totalReplies: 0 },
+                    weakTopics: [],
+                    topContributors: []
+                });
+            }
+
+            classroomFilter = inArray(doubtsTable.classroomId, userClassroomIds);
+        }
+
         // Run all queries in parallel to eliminate sequential query latency
         const [
             trendingDoubts,
@@ -241,17 +226,7 @@ export async function GET(req: Request) {
         });
 
     } catch (error: unknown) {
-        console.error('Error fetching analytics:', error);
-        return NextResponse.json({
-            trendingDoubts: [],
-            mostAskedTopics: [],
-            solvedStats: [],
-            peakTime: [],
-            engagement: { totalStudents: 0, totalDoubts: 0, totalReplies: 0 },
-            weakTopics: [],
-            topContributors: [],
-            classroomSettings: { pedagogyLevel: "Undergraduate (Freshman)", targetGradeLevel: 13 },
-            recentAIReplies: []
-        });
+        const { status, body } = buildErrorResponse(error);
+        return NextResponse.json(body, { status });
     }
 }

--- a/src/app/api/analytics/route.ts
+++ b/src/app/api/analytics/route.ts
@@ -39,7 +39,12 @@ export async function GET(req: Request) {
                     peakTime: [],
                     engagement: { totalStudents: 0, totalDoubts: 0, totalReplies: 0 },
                     weakTopics: [],
-                    topContributors: []
+                    topContributors: [],
+                    classroomSettings: {
+                        pedagogyLevel: "Undergraduate (Freshman)",
+                        targetGradeLevel: 13
+                    },
+                    recentAIReplies: []
                 });
             }
 

--- a/src/app/api/ask-ai/route.ts
+++ b/src/app/api/ask-ai/route.ts
@@ -6,7 +6,11 @@ import { eq } from 'drizzle-orm';
 import { moderateContent, handleModerationViolation } from '@/lib/moderation';
 import { checkPedagogicalDrift } from '@/lib/pedagogy';
 import { buildErrorResponse } from '@/lib/error-handler';
-import { requireAuth, requireMembership } from '@/lib/auth/membership-guard';
+import {
+    parseClassroomId,
+    requireAuth,
+    requireMembership,
+} from '@/lib/auth/membership-guard';
 import { aiLimiter } from '@/lib/ratelimit';
 import {
     AI_REQUEST_MAX_BYTES,
@@ -370,20 +374,15 @@ export async function POST(req: Request) {
         let classroomIdValue: number | null = null;
 
         if (classroomId !== undefined && classroomId !== null) {
-            const parsedClassroomId =
-                typeof classroomId === 'string' || typeof classroomId === 'number'
-                    ? Number(classroomId)
-                    : Number.NaN;
-
-            if (!Number.isSafeInteger(parsedClassroomId) || parsedClassroomId <= 0) {
+            try {
+                classroomIdValue = parseClassroomId(classroomId);
+            } catch {
                 return jsonError(
                     'Invalid classroomId.',
                     422,
                     'INVALID_CLASSROOM_ID'
                 );
             }
-
-            classroomIdValue = parsedClassroomId;
         }
 
         if (classroomIdValue) {

--- a/src/app/api/ask-ai/route.ts
+++ b/src/app/api/ask-ai/route.ts
@@ -1,11 +1,16 @@
 import { NextResponse } from 'next/server';
 import Groq from 'groq-sdk';
-import { currentUser } from '@clerk/nextjs/server';
 import { db } from '@/configs/db';
 import { doubtsTable, repliesTable, usersTable, classroomsTable } from '@/configs/schema';
 import { eq } from 'drizzle-orm';
 import { moderateContent, handleModerationViolation } from '@/lib/moderation';
 import { checkPedagogicalDrift } from '@/lib/pedagogy';
+import { buildErrorResponse } from '@/lib/error-handler';
+import {
+    parseOptionalClassroomId,
+    requireAuth,
+    requireMembership,
+} from '@/lib/auth/membership-guard';
 
 const groq = new Groq({
     apiKey: process.env.GROQ_API_KEY || 'dummy_key',
@@ -200,30 +205,13 @@ async function callGroqWithFallback(
  */
 export async function POST(req: Request) {
     try {
-        const user = await currentUser();
-
-        if (!user) {
-            return NextResponse.json(
-                { error: 'Unauthorized' },
-                { status: 401 }
-            );
-        }
+        const { user, email } = await requireAuth();
 
         const fullName =
             user.fullName ||
             (user.firstName && user.lastName
                 ? `${user.firstName} ${user.lastName}`
                 : 'Academic Student');
-
-        const email =
-            user.primaryEmailAddress?.emailAddress;
-
-        if (!email) {
-            return NextResponse.json(
-                { error: 'Email required' },
-                { status: 400 }
-            );
-        }
 
         // 0. Check if user is blocked
         const [dbUser] = await db
@@ -254,6 +242,11 @@ export async function POST(req: Request) {
             classroomId,
             history = [],
         } = await req.json();
+        const parsedClassroomId = parseOptionalClassroomId(classroomId);
+
+        if (parsedClassroomId) {
+            await requireMembership(email, parsedClassroomId);
+        }
 
         // Validate and sanitize history entries before injecting them into the
         // LLM context. Accepting arbitrary objects would let an attacker inject
@@ -283,7 +276,7 @@ export async function POST(req: Request) {
         let targetGradeLevel = 13;
         let pedagogyLevel = "Undergraduate (Freshman)";
 
-        if (classroomId) {
+        if (parsedClassroomId) {
             try {
                 const [classroom] = await db
                     .select({
@@ -291,7 +284,7 @@ export async function POST(req: Request) {
                         targetGradeLevel: classroomsTable.targetGradeLevel,
                     })
                     .from(classroomsTable)
-                    .where(eq(classroomsTable.id, parseInt(classroomId.toString())));
+                    .where(eq(classroomsTable.id, parsedClassroomId));
                 if (classroom) {
                     pedagogyLevel = classroom.pedagogyLevel;
                     targetGradeLevel = classroom.targetGradeLevel;
@@ -342,7 +335,7 @@ export async function POST(req: Request) {
 - Symbols: Wrap all variables and greek letters in math delimiters.
 - Cleanliness: No repeated characters or filler text.`;
 
-        const PEDAGOGY_RULES = classroomId ? `
+        const PEDAGOGY_RULES = parsedClassroomId ? `
 ### PEDAGOGICAL LEVEL TARGET:
 - The target student academic level is: ${pedagogyLevel} (Flesch-Kincaid Grade Level Target: ${targetGradeLevel}).
 - Explain concepts at this specific complexity. Do NOT use terms or mathematical proofs beyond this grade level. Avoid oversimplifying unless required.` : '';
@@ -514,11 +507,7 @@ ${prompt ? `Additional context from student: ${prompt}` : ''}`;
                             prompt || 'Visual Inquiry',
                         imageUrl:
                             imageBase64?.slice(0, 500),
-                        classroomId: classroomId
-                            ? parseInt(
-                                  classroomId.toString()
-                              )
-                            : null,
+                        classroomId: parsedClassroomId,
                         type: 'ai',
                         isSolved: 'solved',
                     })
@@ -576,13 +565,7 @@ ${prompt ? `Additional context from student: ${prompt}` : ''}`;
             error
         );
 
-        return NextResponse.json(
-            {
-                error: error instanceof Error ?
-                    error.message :
-                    'The AI service is currently overloaded or experiencing issues. Please try again in 30 seconds.',
-            },
-            { status: 500 }
-        );
+        const { status, body } = buildErrorResponse(error);
+        return NextResponse.json(body, { status });
     }
 }

--- a/src/app/api/classrooms/[id]/export/route.ts
+++ b/src/app/api/classrooms/[id]/export/route.ts
@@ -1,45 +1,23 @@
 import { NextResponse } from "next/server";
 import { db } from "@/configs/db";
-import { doubtsTable, classroomsTable, membershipsTable, repliesTable } from "@/configs/schema";
+import { doubtsTable, classroomsTable, repliesTable } from "@/configs/schema";
 import { and, eq, desc, gte, lte, sql } from "drizzle-orm";
-import { currentUser } from "@clerk/nextjs/server";
+import { buildErrorResponse } from "@/lib/error-handler";
+import {
+    parseClassroomId,
+    requireAuth,
+    requireTeacher,
+} from "@/lib/auth/membership-guard";
 
 export async function GET(
     req: Request,
     { params }: { params: Promise<{ id: string }> }
 ) {
     try {
-        // 1. Authenticate via Clerk
-        const user = await currentUser();
-        if (!user || !user.primaryEmailAddress?.emailAddress) {
-            return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-        }
-
-        const email = user.primaryEmailAddress.emailAddress;
+        const { email } = await requireAuth();
         const { id } = await params;
-        const classroomId = parseInt(id);
-
-        if (isNaN(classroomId)) {
-            return NextResponse.json({ error: "Invalid classroom ID" }, { status: 400 });
-        }
-
-        // 2. Verify user is a teacher of this classroom
-        const [membership] = await db
-            .select()
-            .from(membershipsTable)
-            .where(
-                and(
-                    eq(membershipsTable.userEmail, email),
-                    eq(membershipsTable.classroomId, classroomId)
-                )
-            );
-
-        if (!membership || membership.role !== "teacher") {
-            return NextResponse.json(
-                { error: "Forbidden: Only teachers can export classroom doubts" },
-                { status: 403 }
-            );
-        }
+        const classroomId = parseClassroomId(id);
+        await requireTeacher(email, classroomId);
 
         // 3. Get classroom info
         const [classroom] = await db
@@ -110,8 +88,7 @@ export async function GET(
             doubts: doubtsWithReplies,
         });
     } catch (error: unknown) {
-        console.error("Error exporting doubts:", error);
-        const message = error instanceof Error ? error.message : "Internal Server Error";
-        return NextResponse.json({ error: message }, { status: 500 });
+        const { status, body } = buildErrorResponse(error);
+        return NextResponse.json(body, { status });
     }
 }

--- a/src/app/api/classrooms/[id]/invites/route.ts
+++ b/src/app/api/classrooms/[id]/invites/route.ts
@@ -1,12 +1,10 @@
 import { NextResponse } from "next/server";
-import { currentUser } from "@clerk/nextjs/server";
-import { and, eq } from "drizzle-orm";
+import { eq } from "drizzle-orm";
 
 import { db } from "@/configs/db";
 import {
   classroomInvitesTable,
   classroomsTable,
-  membershipsTable,
 } from "@/configs/schema";
 import { checkUserBlock } from "@/lib/auth-utils";
 import { buildErrorResponse } from "@/lib/error-handler";
@@ -17,6 +15,11 @@ import {
   getInviteExpiry,
   hashInviteToken,
 } from "@/lib/invite-token";
+import {
+  parseClassroomId,
+  requireAuth,
+  requireTeacher,
+} from "@/lib/auth/membership-guard";
 
 export async function POST(
   req: Request,
@@ -29,26 +32,15 @@ export async function POST(
     );
     if (errorResponse) return errorResponse;
 
-    const user = await currentUser();
-    if (!user || !user.primaryEmailAddress?.emailAddress) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
-
-    const email = user.primaryEmailAddress.emailAddress;
+    const { email } = await requireAuth();
 
     const { isBlocked, errorResponse: blockErrorResponse } =
       await checkUserBlock(email);
     if (isBlocked) return blockErrorResponse;
 
     const { id } = await params;
-    const classroomId = parseInt(id);
-
-    if (isNaN(classroomId)) {
-      return NextResponse.json(
-        { error: "Invalid classroom ID" },
-        { status: 400 },
-      );
-    }
+    const classroomId = parseClassroomId(id);
+    await requireTeacher(email, classroomId);
 
     const [classroom] = await db
       .select()
@@ -59,27 +51,6 @@ export async function POST(
       return NextResponse.json(
         { error: "Classroom not found" },
         { status: 404 },
-      );
-    }
-
-    const [teacherMembership] = await db
-      .select()
-      .from(membershipsTable)
-      .where(
-        and(
-          eq(membershipsTable.userEmail, email),
-          eq(membershipsTable.classroomId, classroomId),
-          eq(membershipsTable.role, "teacher"),
-        ),
-      );
-
-    if (classroom.teacherEmail !== email && !teacherMembership) {
-      return NextResponse.json(
-        {
-          error:
-            "Forbidden: only the classroom teacher can generate invite links",
-        },
-        { status: 403 },
       );
     }
 

--- a/src/app/api/confusion/route.ts
+++ b/src/app/api/confusion/route.ts
@@ -1,17 +1,19 @@
 // src/app/api/confusion/route.ts
 import { NextResponse } from "next/server";
-import { auth, currentUser } from "@clerk/nextjs/server";
 import { db } from "@/configs/db";
-import { confusionAlertsTable, membershipsTable } from "@/configs/schema"; 
+import { confusionAlertsTable } from "@/configs/schema";
 import { and, eq, desc } from "drizzle-orm";
+import { buildErrorResponse } from "@/lib/error-handler";
+import {
+    parseClassroomId,
+    requireAuth,
+    requireMembership,
+    requireTeacher,
+} from "@/lib/auth/membership-guard";
 
 export async function GET(req: Request) {
     try {
-        const { userId } = await auth();
-        const user = await currentUser();
-        if (!userId || !user) {
-            return new NextResponse("Unauthorized", { status: 401 });
-        }
+        const { email } = await requireAuth();
 
         const { searchParams } = new URL(req.url);
         const roomIdString = searchParams.get("roomId");
@@ -20,34 +22,9 @@ export async function GET(req: Request) {
             return new NextResponse("Missing roomId parameter", { status: 400 });
         }
 
-        // ✅ Explicitly parse string to Number directly since schema defines it as integer()
-        const classroomId = Number(roomIdString);
-        if (isNaN(classroomId)) {
-            return new NextResponse("Invalid roomId parameter", { status: 400 });
-        }
+        const classroomId = parseClassroomId(roomIdString);
+        await requireMembership(email, classroomId);
 
-        const userEmail = user.emailAddresses[0]?.emailAddress;
-        if (!userEmail) {
-            return new NextResponse("User email not found", { status: 400 });
-        }
-
-        // 🛡️ Authorization Check via userEmail
-        const [isMember] = await db
-            .select()
-            .from(membershipsTable)
-            .where(
-                and(
-                    eq(membershipsTable.classroomId, classroomId),
-                    eq(membershipsTable.userEmail, userEmail) 
-                )
-            )
-            .limit(1);
-
-        if (!isMember) {
-            return new NextResponse("Access denied: You are not enrolled in this classroom", { status: 403 });
-        }
-
-        // ✅ Querying valid varchar 'status' column directly ('isRead' completely omitted)
         const [latestAlert] = await db
             .select()
             .from(confusionAlertsTable)
@@ -62,18 +39,14 @@ export async function GET(req: Request) {
 
         return NextResponse.json(latestAlert || null);
     } catch (error) {
-        console.error("GET_CONFUSION_ALERT_ERROR", error);
-        return new NextResponse("Internal Server Error", { status: 500 });
+        const { status, body } = buildErrorResponse(error);
+        return NextResponse.json(body, { status });
     }
 }
 
 export async function PATCH(req: Request) {
     try {
-        const { userId } = await auth();
-        const user = await currentUser();
-        if (!userId || !user) {
-            return new NextResponse("Unauthorized", { status: 401 });
-        }
+        const { email } = await requireAuth();
 
         const { searchParams } = new URL(req.url);
         const alertIdString = searchParams.get("id");
@@ -82,15 +55,9 @@ export async function PATCH(req: Request) {
             return new NextResponse("Missing alert id parameter", { status: 400 });
         }
 
-        // ✅ No runtime typeof checks on types! Direct numerical parsing for schema column compatibility
         const targetId = Number(alertIdString);
         if (isNaN(targetId)) {
             return new NextResponse("Invalid alert id", { status: 400 });
-        }
-
-        const userEmail = user.emailAddresses[0]?.emailAddress;
-        if (!userEmail) {
-            return new NextResponse("User email not found", { status: 400 });
         }
 
         // Fetch alert context for authorization validation
@@ -104,35 +71,20 @@ export async function PATCH(req: Request) {
             return new NextResponse("Alert not found", { status: 404 });
         }
 
-        // Authorization check via membership mapping
-        const [hasModificationRights] = await db
-            .select()
-            .from(membershipsTable)
-            .where(
-                and(
-                    eq(membershipsTable.classroomId, targetAlert.classroomId),
-                    eq(membershipsTable.userEmail, userEmail)
-                )
-            )
-            .limit(1);
+        await requireTeacher(email, targetAlert.classroomId);
 
-        if (!hasModificationRights) {
-            return new NextResponse("Access denied: Action requires classroom clearance privileges", { status: 403 });
-        }
-
-        // ✅ Safely updating the valid varchar 'status' column to 'acknowledged'
         await db
             .update(confusionAlertsTable)
             .set({ 
                 status: "acknowledged",
                 acknowledgedAt: new Date(),
-                acknowledgedBy: userEmail
+                acknowledgedBy: email
             })
             .where(eq(confusionAlertsTable.id, targetId));
 
         return NextResponse.json({ success: true });
     } catch (error) {
-        console.error("PATCH_CONFUSION_ALERT_ERROR", error);
-        return new NextResponse("Internal Server Error", { status: 500 });
+        const { status, body } = buildErrorResponse(error);
+        return NextResponse.json(body, { status });
     }
 }

--- a/src/app/api/doubts/check-similarity/route.ts
+++ b/src/app/api/doubts/check-similarity/route.ts
@@ -2,8 +2,13 @@ import { db } from "@/configs/db";
 import { doubtsTable, repliesTable } from "@/configs/schema";
 import { and, eq, isNull, desc, inArray } from "drizzle-orm";
 import { NextResponse } from "next/server";
-import { currentUser } from "@clerk/nextjs/server";
 import Groq from "groq-sdk";
+import { buildErrorResponse } from "@/lib/error-handler";
+import {
+  parseOptionalClassroomId,
+  requireAuth,
+  requireMembership,
+} from "@/lib/auth/membership-guard";
 
 const groq = new Groq({
   apiKey: process.env.GROQ_API_KEY || "dummy_key",
@@ -20,16 +25,18 @@ export interface SimilarDoubt {
 
 export async function POST(req: Request) {
   try {
-    const user = await currentUser();
-    if (!user) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
+    const { email } = await requireAuth();
 
     const body = await req.json();
-    const { content, classroomId } = body as {
+    const { content, classroomId: rawClassroomId } = body as {
       content: string;
-      classroomId?: number | null;
+      classroomId?: unknown;
     };
+    const classroomId = parseOptionalClassroomId(rawClassroomId);
+
+    if (classroomId) {
+      await requireMembership(email, classroomId);
+    }
 
     if (
       typeof content !== "string" ||
@@ -173,7 +180,7 @@ Do not include any explanation or markdown.`;
 
     return NextResponse.json({ similarDoubts });
   } catch (error) {
-    console.error("Similarity check failed:", error);
-    return NextResponse.json({ similarDoubts: [] });
+    const { status, body } = buildErrorResponse(error);
+    return NextResponse.json(body, { status });
   }
 }

--- a/src/app/api/doubts/check-similarity/route.ts
+++ b/src/app/api/doubts/check-similarity/route.ts
@@ -25,8 +25,6 @@ export interface SimilarDoubt {
 
 export async function POST(req: Request) {
   try {
-    const { email } = await requireAuth();
-
     const body = await req.json();
     const { content, classroomId: rawClassroomId } = body as {
       content: string;
@@ -35,6 +33,7 @@ export async function POST(req: Request) {
     const classroomId = parseOptionalClassroomId(rawClassroomId);
 
     if (classroomId) {
+      const { email } = await requireAuth();
       await requireMembership(email, classroomId);
     }
 

--- a/src/app/api/doubts/route.ts
+++ b/src/app/api/doubts/route.ts
@@ -1,5 +1,4 @@
 import { NextResponse } from "next/server";
-import { currentUser } from "@clerk/nextjs/server";
 import { db } from "@/configs/db";
 import { 
     bookmarksTable, 
@@ -7,8 +6,6 @@ import {
     doubtsTable, 
     likesTable, 
     repliesTable, 
-    membershipsTable, 
-    classroomsTable, 
     tagsTable 
 } from "@/configs/schema";
 import { categorizeDoubt } from "@/lib/ai/categorizer";
@@ -20,6 +17,11 @@ import { parseAndValidateRequest } from "@/lib/validations/validate";
 import { createDoubtSchema } from "@/lib/validations/doubt";
 import { createClassroomDoubtNotifications } from "@/lib/notifications/service";
 import { inngest } from "@/inngest/client"; 
+import {
+    parseOptionalClassroomId,
+    requireAuth,
+    requireMembership,
+} from "@/lib/auth/membership-guard";
 
 export async function GET(req: Request) {
     const { searchParams } = new URL(req.url);
@@ -27,27 +29,17 @@ export async function GET(req: Request) {
     const search = searchParams.get("search");
     const userName = searchParams.get("userName");
     const classroomIdStr = searchParams.get("classroomId");
-    const classroomId = classroomIdStr ? parseInt(classroomIdStr, 10) : null;
     const type = searchParams.get("type") || "community";
     const tag = searchParams.get("tag");
     const sort = searchParams.get("sort") || "newest";
     const bookmarked = searchParams.get("bookmarked") === "true";
 
     try {
-        const user = await currentUser();
-        if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-        const email = user.primaryEmailAddress?.emailAddress;
-        if (!email) return NextResponse.json({ error: "Email target missing" }, { status: 400 });
-
-        if (classroomId) {
-            const [membership] = await db
-                .select()
-                .from(membershipsTable)
-                .where(and(eq(membershipsTable.userEmail, email), eq(membershipsTable.classroomId, classroomId)));
-            if (!membership) {
-                return NextResponse.json({ error: "Access denied to this classroom" }, { status: 403 });
-            }
-        }
+        const { email } = await requireAuth();
+        const classroomId = parseOptionalClassroomId(classroomIdStr);
+        const membership = classroomId
+            ? await requireMembership(email, classroomId)
+            : null;
 
         const conditions: SQL[] = [];
 
@@ -57,10 +49,8 @@ export async function GET(req: Request) {
             conditions.push(isNull(doubtsTable.classroomId));
         }
 
-        const [room] = classroomId
-            ? await db.select().from(classroomsTable).where(eq(classroomsTable.id, classroomId))
-            : [null];
-        const isTeacher = room && room.teacherEmail === email;
+        const isTeacher =
+            membership?.role === "teacher" || membership?.role === "owner";
 
         if (!isTeacher) {
             const teacherCondition = or(not(eq(doubtsTable.type, "teacher")), eq(doubtsTable.userEmail, email));
@@ -212,25 +202,14 @@ export async function POST(req: Request) {
         
         const { userName, subject, content, imageUrl, classroomId, type, tags } = data;
         const doubtType = type ?? "community";
-        const parsedClassroomId = classroomId ? parseInt(classroomId.toString(), 10) : null;
-
-        const user = await currentUser();
-        if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-
-        const email = user.primaryEmailAddress?.emailAddress;
-        if (!email) return NextResponse.json({ error: "Email required" }, { status: 400 });
+        const parsedClassroomId = parseOptionalClassroomId(classroomId);
+        const { email } = await requireAuth();
 
         const { isBlocked, errorResponse: blockResponse } = await checkUserBlock(email);
         if (isBlocked) return blockResponse;
 
         if (parsedClassroomId) {
-            const [membership] = await db
-                .select()
-                .from(membershipsTable)
-                .where(and(eq(membershipsTable.userEmail, email), eq(membershipsTable.classroomId, parsedClassroomId)));
-            if (!membership) {
-                return NextResponse.json({ error: "Access denied: You are not a member of this classroom" }, { status: 403 });
-            }
+            await requireMembership(email, parsedClassroomId);
         }
         
         if (content) {

--- a/src/app/api/doubts/route.ts
+++ b/src/app/api/doubts/route.ts
@@ -18,6 +18,7 @@ import { createDoubtSchema } from "@/lib/validations/doubt";
 import { createClassroomDoubtNotifications } from "@/lib/notifications/service";
 import { inngest } from "@/inngest/client"; 
 import {
+    getOptionalAuth,
     parseOptionalClassroomId,
     requireAuth,
     requireMembership,
@@ -35,11 +36,21 @@ export async function GET(req: Request) {
     const bookmarked = searchParams.get("bookmarked") === "true";
 
     try {
-        const { email } = await requireAuth();
+        const auth = await getOptionalAuth();
+        const email = auth?.email ?? null;
         const classroomId = parseOptionalClassroomId(classroomIdStr);
-        const membership = classroomId
-            ? await requireMembership(email, classroomId)
-            : null;
+        let membership = null;
+
+        if (classroomId) {
+            if (!email) {
+                return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+            }
+            membership = await requireMembership(email, classroomId);
+        }
+
+        if ((type === "ai" || bookmarked) && !email) {
+            return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+        }
 
         const conditions: SQL[] = [];
 
@@ -50,10 +61,14 @@ export async function GET(req: Request) {
         }
 
         const isTeacher =
-            membership?.role === "teacher" || membership?.role === "owner";
+            membership?.role === "teacher" ||
+            membership?.role === "owner" ||
+            membership?.role === "admin";
 
         if (!isTeacher) {
-            const teacherCondition = or(not(eq(doubtsTable.type, "teacher")), eq(doubtsTable.userEmail, email));
+            const teacherCondition = email
+                ? or(not(eq(doubtsTable.type, "teacher")), eq(doubtsTable.userEmail, email))
+                : not(eq(doubtsTable.type, "teacher"));
             if (teacherCondition) conditions.push(teacherCondition);
         }
 
@@ -72,12 +87,12 @@ export async function GET(req: Request) {
 
         if (type && type !== "All") {
             conditions.push(eq(doubtsTable.type, type));
-            if (type === "ai") {
+            if (type === "ai" && email) {
                 conditions.push(eq(doubtsTable.userEmail, email));
             }
         }
 
-        if (bookmarked) {
+        if (bookmarked && email) {
             const userBookmarks = await db
                 .select({ doubtId: bookmarksTable.doubtId })
                 .from(bookmarksTable)
@@ -153,7 +168,7 @@ export async function GET(req: Request) {
             }));
         }
 
-        if (doubts.length > 0) {
+        if (doubts.length > 0 && email) {
             const userBookmarks = await db
                 .select({ doubtId: bookmarksTable.doubtId })
                 .from(bookmarksTable)
@@ -164,7 +179,9 @@ export async function GET(req: Request) {
                 ...doubt,
                 hasBookmarked: bookmarkedIds.has(doubt.id)
             }));
+        }
 
+        if (doubts.length > 0) {
             const tagRows = await db
                 .select({
                     doubtId: doubtTagsTable.doubtId,

--- a/src/app/api/rooms/[id]/route.ts
+++ b/src/app/api/rooms/[id]/route.ts
@@ -2,31 +2,26 @@ import { NextResponse } from 'next/server';
 import { db } from '@/configs/db';
 import { classroomsTable, membershipsTable } from '@/configs/schema';
 import { eq, and } from 'drizzle-orm';
-import { currentUser } from '@clerk/nextjs/server';
 import { checkUserBlock } from '@/lib/auth-utils';
 import { buildErrorResponse } from '@/lib/error-handler';
+import {
+    parseClassroomId,
+    requireAuth,
+    requireTeacher,
+} from '@/lib/auth/membership-guard';
 
 export async function GET(
     req: Request,
     { params }: { params: Promise<{ id: string }> }
 ) {
     try {
-        const user = await currentUser();
-        if (!user || !user.primaryEmailAddress?.emailAddress) {
-            return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-        }
-
-        const email = user.primaryEmailAddress.emailAddress;
+        const { email } = await requireAuth();
 
         // 0. Check if user is blocked
         const { isBlocked, errorResponse } = await checkUserBlock(email);
         if (isBlocked) return errorResponse;
         const { id } = await params;
-        const roomId = parseInt(id);
-
-        if (isNaN(roomId)) {
-            return NextResponse.json({ error: 'Invalid room ID' }, { status: 400 });
-        }
+        const roomId = parseClassroomId(id);
 
         // Optimised query: Fetch classroom and membership in a single join
         const [roomData] = await db
@@ -64,33 +59,15 @@ export async function PATCH(
     { params }: { params: Promise<{ id: string }> }
 ) {
     try {
-        const user = await currentUser();
-        if (!user || !user.primaryEmailAddress?.emailAddress) {
-            return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-        }
-
-        const email = user.primaryEmailAddress.emailAddress;
+        const { email } = await requireAuth();
 
         // 0. Check if user is blocked
         const { isBlocked, errorResponse } = await checkUserBlock(email);
         if (isBlocked) return errorResponse;
 
         const { id } = await params;
-        const roomId = parseInt(id);
-
-        if (isNaN(roomId)) {
-            return NextResponse.json({ error: 'Invalid room ID' }, { status: 400 });
-        }
-
-        // Verify the user is the teacher of this classroom
-        const [classroom] = await db
-            .select()
-            .from(classroomsTable)
-            .where(and(eq(classroomsTable.id, roomId), eq(classroomsTable.teacherEmail, email)));
-
-        if (!classroom) {
-            return NextResponse.json({ error: 'Forbidden: only the teacher can modify this classroom' }, { status: 403 });
-        }
+        const roomId = parseClassroomId(id);
+        await requireTeacher(email, roomId);
 
         const { pedagogyLevel, targetGradeLevel } = await req.json();
 

--- a/src/app/api/rooms/[id]/route.ts
+++ b/src/app/api/rooms/[id]/route.ts
@@ -1,12 +1,13 @@
 import { NextResponse } from 'next/server';
 import { db } from '@/configs/db';
-import { classroomsTable, membershipsTable } from '@/configs/schema';
-import { eq, and } from 'drizzle-orm';
+import { classroomsTable } from '@/configs/schema';
+import { eq } from 'drizzle-orm';
 import { checkUserBlock } from '@/lib/auth-utils';
 import { buildErrorResponse } from '@/lib/error-handler';
 import {
     parseClassroomId,
     requireAuth,
+    requireMembership,
     requireTeacher,
 } from '@/lib/auth/membership-guard';
 
@@ -22,8 +23,8 @@ export async function GET(
         if (isBlocked) return errorResponse;
         const { id } = await params;
         const roomId = parseClassroomId(id);
+        const membership = await requireMembership(email, roomId);
 
-        // Optimised query: Fetch classroom and membership in a single join
         const [roomData] = await db
             .select({
                 id: classroomsTable.id,
@@ -34,20 +35,15 @@ export async function GET(
                 inviteCode: classroomsTable.inviteCode,
                 pedagogyLevel: classroomsTable.pedagogyLevel,
                 targetGradeLevel: classroomsTable.targetGradeLevel,
-                role: membershipsTable.role,
             })
             .from(classroomsTable)
-            .innerJoin(
-                membershipsTable,
-                and(eq(membershipsTable.classroomId, classroomsTable.id), eq(membershipsTable.userEmail, email))
-            )
             .where(eq(classroomsTable.id, roomId));
 
         if (!roomData) {
-            return NextResponse.json({ error: 'Room not found or access denied' }, { status: 404 });
+            return NextResponse.json({ error: 'Room not found' }, { status: 404 });
         }
 
-        return NextResponse.json(roomData);
+        return NextResponse.json({ ...roomData, role: membership.role });
     } catch (error) {
         const { status, body } = buildErrorResponse(error);
         return NextResponse.json(body, { status });

--- a/src/app/api/rooms/members/route.ts
+++ b/src/app/api/rooms/members/route.ts
@@ -1,19 +1,18 @@
 import { NextResponse } from 'next/server';
 import { db } from '@/configs/db';
 import { membershipsTable } from '@/configs/schema';
-import { eq, and, count } from 'drizzle-orm';
-import { currentUser } from '@clerk/nextjs/server';
+import { eq, count } from 'drizzle-orm';
 import { checkUserBlock } from '@/lib/auth-utils';
 import { buildErrorResponse } from '@/lib/error-handler';
+import {
+    parseClassroomId,
+    requireAuth,
+    requireMembership,
+} from '@/lib/auth/membership-guard';
 
 export async function GET(req: Request) {
     try {
-        const user = await currentUser();
-        if (!user || !user.primaryEmailAddress?.emailAddress) {
-            return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-        }
-
-        const email = user.primaryEmailAddress.emailAddress;
+        const { email } = await requireAuth();
 
         // 0. Check if user is blocked
         const { isBlocked, errorResponse } = await checkUserBlock(email);
@@ -25,25 +24,12 @@ export async function GET(req: Request) {
             return NextResponse.json({ error: 'Classroom ID is required' }, { status: 400 });
         }
 
-        const classroomId = Number(classroomIdStr);
+        const classroomId = parseClassroomId(classroomIdStr);
         const page = Math.max(Number(searchParams.get('page')) || 1, 1);
         const limit = Math.min(Math.max(Number(searchParams.get('limit')) || 20, 1), 100);
         const offset = (page - 1) * limit;
         
-        // Security: Check if requesting user is a member of this classroom
-       const [membership] = await db
-            .select()
-            .from(membershipsTable)
-            .where(
-                and(
-                    eq(membershipsTable.userEmail, email),
-                    eq(membershipsTable.classroomId, classroomId)
-                )
-            );
-
-        if (!membership) {
-            return NextResponse.json({ error: 'Access denied' }, { status: 403 });
-        }
+        await requireMembership(email, classroomId);
 
         // Total members count
         const totalMembersResult = await db

--- a/src/app/api/rooms/members/route.ts
+++ b/src/app/api/rooms/members/route.ts
@@ -29,7 +29,7 @@ export async function GET(req: Request) {
         const limit = Math.min(Math.max(Number(searchParams.get('limit')) || 20, 1), 100);
         const offset = (page - 1) * limit;
         
-        await requireMembership(email, classroomId);
+        const membership = await requireMembership(email, classroomId);
 
         // Total members count
         const totalMembersResult = await db
@@ -52,8 +52,21 @@ export async function GET(req: Request) {
             .limit(limit)
             .offset(offset);
 
+        const canViewEmails = ["teacher", "owner", "admin"].includes(membership.role);
+        const visibleMembers = canViewEmails
+            ? members.map((member) => ({
+                userEmail: member.userEmail,
+                role: member.role,
+                joinedAt: member.joinedAt,
+            }))
+            : members.map((member, index) => ({
+                displayName: `Student_${offset + index + 1}`,
+                role: member.role,
+                joinedAt: member.joinedAt,
+            }));
+
         return NextResponse.json({
-            members,
+            members: visibleMembers,
             pagination: {
                 total,
                 page,

--- a/src/app/api/tags/route.ts
+++ b/src/app/api/tags/route.ts
@@ -1,37 +1,27 @@
 import { db } from "@/configs/db";
-import { membershipsTable, tagsTable } from "@/configs/schema";
+import { tagsTable } from "@/configs/schema";
 import { and, desc, eq, ilike, isNull, or, type SQL } from "drizzle-orm";
 import { NextResponse } from "next/server";
-import { currentUser } from "@clerk/nextjs/server";
+import { buildErrorResponse } from "@/lib/error-handler";
+import {
+    parseOptionalClassroomId,
+    requireAuth,
+    requireMembership,
+} from "@/lib/auth/membership-guard";
 
 const normalizeTagName = (name: string) => name.trim().replace(/\s+/g, " ").toLowerCase();
 
-async function canAccessClassroom(classroomId: number, email?: string | null) {
-    if (!email) return false;
-
-    const [membership] = await db.select().from(membershipsTable).where(
-        and(
-            eq(membershipsTable.userEmail, email),
-            eq(membershipsTable.classroomId, classroomId)
-        )
-    ).limit(1);
-
-    return !!membership;
-}
-
 export async function GET(req: Request) {
     try {
-        const user = await currentUser();
-        if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+        const { email } = await requireAuth();
 
         const { searchParams } = new URL(req.url);
         const classroomIdParam = searchParams.get("classroomId");
         const query = searchParams.get("q")?.trim();
-        const classroomId = classroomIdParam ? parseInt(classroomIdParam) : null;
-        const email = user.primaryEmailAddress?.emailAddress;
+        const classroomId = parseOptionalClassroomId(classroomIdParam);
 
-        if (classroomId && !(await canAccessClassroom(classroomId, email))) {
-            return NextResponse.json({ error: "Access denied to this classroom" }, { status: 403 });
+        if (classroomId) {
+            await requireMembership(email, classroomId);
         }
 
         const conditions: SQL<unknown>[] = [
@@ -50,27 +40,24 @@ export async function GET(req: Request) {
 
         return NextResponse.json(tags);
     } catch (error) {
-        console.error("Error fetching tags:", error);
-        return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+        const { status, body } = buildErrorResponse(error);
+        return NextResponse.json(body, { status });
     }
 }
 
 export async function POST(req: Request) {
     try {
-        const user = await currentUser();
-        if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-
-        const email = user.primaryEmailAddress?.emailAddress;
+        const { email } = await requireAuth();
         const { name, classroomId: rawClassroomId } = await req.json();
         const normalizedName = normalizeTagName(name || "");
-        const classroomId = rawClassroomId ? parseInt(rawClassroomId.toString()) : null;
+        const classroomId = parseOptionalClassroomId(rawClassroomId);
 
         if (!normalizedName) {
             return NextResponse.json({ error: "Tag name is required" }, { status: 400 });
         }
 
-        if (classroomId && !(await canAccessClassroom(classroomId, email))) {
-            return NextResponse.json({ error: "Access denied to this classroom" }, { status: 403 });
+        if (classroomId) {
+            await requireMembership(email, classroomId);
         }
 
         const [existing] = await db.select().from(tagsTable).where(
@@ -86,15 +73,12 @@ export async function POST(req: Request) {
             name: normalizedName.replace(/\b\w/g, (char) => char.toUpperCase()),
             normalizedName,
             classroomId,
-            createdByEmail: email || null,
+            createdByEmail: email,
         }).returning();
 
         return NextResponse.json(tag, { status: 201 });
     } catch (error: unknown) {
-        console.error("Error saving tag:", error);
-        return NextResponse.json(
-            { error: error instanceof Error ? error.message : "Internal Server Error" },
-            { status: 500 },
-        );
+        const { status, body } = buildErrorResponse(error);
+        return NextResponse.json(body, { status });
     }
 }

--- a/src/app/api/teacher/analytics/route.ts
+++ b/src/app/api/teacher/analytics/route.ts
@@ -4,22 +4,17 @@ import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/configs/db";
 import { doubtsTable, repliesTable, classroomsTable, usersTable } from "@/configs/schema";
 import { and, eq, inArray, gte, lte } from "drizzle-orm";
-import { auth, currentUser } from "@clerk/nextjs/server";
 import { DoubtRecord, ReplyRecord } from "@/types";
+import {
+    parseOptionalClassroomId,
+    requireAuth,
+    requireTeacher,
+} from "@/lib/auth/membership-guard";
+import { buildErrorResponse } from "@/lib/error-handler";
 
 export async function GET(req: NextRequest) {
     try {
-        // 1. Authenticate user
-        const { userId } = await auth();
-        if (!userId) {
-            return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-        }
-
-        const clerkUser = await currentUser();
-        const email = clerkUser?.primaryEmailAddress?.emailAddress;
-        if (!email) {
-            return NextResponse.json({ error: "No email found for Clerk user" }, { status: 400 });
-        }
+        const { email } = await requireAuth();
 
         // 2. Fetch user and check role
         const [dbUser] = await db.select().from(usersTable).where(eq(usersTable.email, email));
@@ -38,7 +33,9 @@ export async function GET(req: NextRequest) {
         // 3. Parse query parameters
         const { searchParams } = new URL(req.url);
         const classroomIdStr = searchParams.get("classroomId");
-        const classroomId = classroomIdStr && classroomIdStr !== "all" ? parseInt(classroomIdStr) : null;
+        const classroomId = classroomIdStr === "all"
+            ? null
+            : parseOptionalClassroomId(classroomIdStr);
         
         const startDateStr = searchParams.get("startDate");
         const endDateStr = searchParams.get("endDate");
@@ -66,12 +63,10 @@ export async function GET(req: NextRequest) {
         // Determine which classroom IDs we should query
         let selectedClassroomIds: number[] = [];
         if (classroomId) {
-            // Check if teacher/admin is allowed to see this specific classroom
-            if (role === 'admin' || classroomsList.some(c => c.id === classroomId)) {
-                selectedClassroomIds = [classroomId];
-            } else {
-                return NextResponse.json({ error: "Forbidden: No access to this classroom" }, { status: 403 });
+            if (role !== 'admin') {
+                await requireTeacher(email, classroomId);
             }
+            selectedClassroomIds = [classroomId];
         } else {
             selectedClassroomIds = classroomsList.map(c => c.id);
         }
@@ -259,7 +254,7 @@ export async function GET(req: NextRequest) {
             classroomsList
         });
     } catch (error: unknown) {
-        console.error("Teacher Analytics Endpoint failed:", error);
-        return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+        const { status, body } = buildErrorResponse(error);
+        return NextResponse.json(body, { status });
     }
 }

--- a/src/app/api/teacher/analytics/route.ts
+++ b/src/app/api/teacher/analytics/route.ts
@@ -2,7 +2,7 @@ export const dynamic = "force-dynamic";
 
 import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/configs/db";
-import { doubtsTable, repliesTable, classroomsTable, usersTable } from "@/configs/schema";
+import { doubtsTable, repliesTable, classroomsTable, membershipsTable, usersTable } from "@/configs/schema";
 import { and, eq, inArray, gte, lte } from "drizzle-orm";
 import { DoubtRecord, ReplyRecord } from "@/types";
 import {
@@ -21,8 +21,22 @@ export async function GET(req: NextRequest) {
         
         // Find if user is a teacher in classrooms even if role field is not fully populated
         const classroomsTaught = await db.select().from(classroomsTable).where(eq(classroomsTable.teacherEmail, email));
+        const teacherMemberships = await db
+            .select({
+                classroomId: membershipsTable.classroomId,
+                role: membershipsTable.role,
+            })
+            .from(membershipsTable)
+            .where(eq(membershipsTable.userEmail, email));
+        const teacherMembershipIds = teacherMemberships
+            .filter((membership) => ["teacher", "owner", "admin"].includes(membership.role))
+            .map((membership) => membership.classroomId);
         
-        const isTeacherOrAdmin = dbUser?.role === 'teacher' || dbUser?.role === 'admin' || classroomsTaught.length > 0;
+        const isTeacherOrAdmin =
+            dbUser?.role === 'teacher' ||
+            dbUser?.role === 'admin' ||
+            classroomsTaught.length > 0 ||
+            teacherMembershipIds.length > 0;
         
         if (!isTeacherOrAdmin) {
             return NextResponse.json({ error: "Forbidden: Teachers or admins only" }, { status: 403 });
@@ -53,7 +67,17 @@ export async function GET(req: NextRequest) {
                 university: classroomsTable.university
             }).from(classroomsTable);
         } else {
-            classroomsList = classroomsTaught.map(c => ({
+            const membershipClassrooms = teacherMembershipIds.length > 0
+                ? await db.select({
+                    id: classroomsTable.id,
+                    name: classroomsTable.name,
+                    university: classroomsTable.university
+                }).from(classroomsTable).where(inArray(classroomsTable.id, teacherMembershipIds))
+                : [];
+            const accessibleClassrooms = new Map(
+                [...classroomsTaught, ...membershipClassrooms].map((classroom) => [classroom.id, classroom])
+            );
+            classroomsList = [...accessibleClassrooms.values()].map(c => ({
                 id: c.id,
                 name: c.name,
                 university: c.university

--- a/src/app/api/teacher/insights/route.ts
+++ b/src/app/api/teacher/insights/route.ts
@@ -1,19 +1,19 @@
 export const dynamic = "force-dynamic";
 
 import { db } from "@/configs/db";
-import { classroomsTable, doubtsTable } from "@/configs/schema";
+import { doubtsTable } from "@/configs/schema";
 import { and, eq, sql } from "drizzle-orm";
-import { currentUser } from "@clerk/nextjs/server";
 import { NextResponse } from "next/server";
+import { buildErrorResponse } from "@/lib/error-handler";
+import {
+    parseClassroomId,
+    requireAuth,
+    requireTeacher,
+} from "@/lib/auth/membership-guard";
 
 export async function GET(req: Request) {
     try {
-        const clerkUser = await currentUser();
-        const email = clerkUser?.primaryEmailAddress?.emailAddress;
-
-        if (!email) {
-            return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-        }
+        const { email } = await requireAuth();
 
         const { searchParams } = new URL(req.url);
         const classroomIdStr = searchParams.get("classroomId");
@@ -21,16 +21,8 @@ export async function GET(req: Request) {
             return NextResponse.json({ error: "classroomId is required" }, { status: 400 });
         }
 
-        const classroomId = Number(classroomIdStr);
-
-        const [classroom] = await db
-            .select({ id: classroomsTable.id })
-            .from(classroomsTable)
-            .where(and(eq(classroomsTable.id, classroomId), eq(classroomsTable.teacherEmail, email)));
-
-        if (!classroom) {
-            return NextResponse.json({ error: "Forbidden: not the teacher of this classroom" }, { status: 403 });
-        }
+        const classroomId = parseClassroomId(classroomIdStr);
+        await requireTeacher(email, classroomId);
 
         const classroomFilter = eq(doubtsTable.classroomId, classroomId);
 
@@ -73,7 +65,7 @@ export async function GET(req: Request) {
             subjectVolume,
         });
     } catch (error) {
-        console.error("Teacher Insights failed:", error);
-        return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+        const { status, body } = buildErrorResponse(error);
+        return NextResponse.json(body, { status });
     }
 }

--- a/src/app/api/teacher/insights/route.ts
+++ b/src/app/api/teacher/insights/route.ts
@@ -17,7 +17,7 @@ export async function GET(req: Request) {
 
         const { searchParams } = new URL(req.url);
         const classroomIdStr = searchParams.get("classroomId");
-        if (!classroomIdStr || !/^[1-9]\d*$/.test(classroomIdStr)) {
+        if (!classroomIdStr) {
             return NextResponse.json({ error: "classroomId is required" }, { status: 400 });
         }
 

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -27,6 +27,7 @@ type AnalyticsData = {
 }
 
 const COLORS = ["#8b5cf6", "#3b82f6", "#ec4899", "#f59e0b", "#10b981", "#06b6d4"];
+const ANALYTICS_UNAVAILABLE_MESSAGE = "Analytics are unavailable right now.";
 
 function DashboardSkeleton() {
     return (
@@ -83,9 +84,16 @@ export default function Dashboard() {
 
     if (!data) {
         return (
-            <div className="p-10 text-center text-sm text-slate-500 dark:text-zinc-400">
-                Analytics are unavailable right now.
-            </div>
+            <>
+                <SignedIn>
+                    <div role="status" className="p-10 text-center text-sm text-slate-500 dark:text-zinc-400">
+                        {ANALYTICS_UNAVAILABLE_MESSAGE}
+                    </div>
+                </SignedIn>
+                <SignedOut>
+                    <RedirectToSignIn />
+                </SignedOut>
+            </>
         );
     }
 

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -60,10 +60,14 @@ export default function Dashboard() {
     const fetchAnalytics = async () => {
         try {
             const res = await fetch('/api/analytics');
+            if (!res.ok) {
+                throw new Error(`Analytics request failed with status ${res.status}`);
+            }
             const result = await res.json();
             setData(result);
         } catch (error) {
             console.error("Error loading analytics:", error);
+            setData(null);
         } finally {
             setLoading(false);
         }
@@ -75,6 +79,14 @@ export default function Dashboard() {
 
     if (loading) {
         return <DashboardSkeleton />;
+    }
+
+    if (!data) {
+        return (
+            <div className="p-10 text-center text-sm text-slate-500 dark:text-zinc-400">
+                Analytics are unavailable right now.
+            </div>
+        );
     }
 
     const solvedCount = data?.solvedStats?.find((s: any) => s.status === 'solved')?.count || 0;

--- a/src/app/rooms/[id]/page.tsx
+++ b/src/app/rooms/[id]/page.tsx
@@ -68,6 +68,12 @@ interface Classroom {
   role: string;
 }
 
+const TEACHER_ROLES = new Set(["teacher", "owner", "admin"]);
+const CLASSROOM_ANALYTICS_UNAVAILABLE_MESSAGE =
+  "Classroom analytics are unavailable right now.";
+
+const isTeacherRole = (role?: string) => TEACHER_ROLES.has(role ?? "");
+
 export default function ClassroomPage() {
   const { id } = useParams();
   const router = useRouter();
@@ -100,6 +106,7 @@ export default function ClassroomPage() {
   const [tagFilter, setTagFilter] = useState("");
   const sort = (searchParams.get("sort") as DoubtSortValue) || "newest";
   const notificationTab = searchParams.get("tab");
+  const hasTeacherAccess = isTeacherRole(classroom?.role);
 
   useEffect(() => {
     const timer = setTimeout(() => {
@@ -322,10 +329,10 @@ export default function ClassroomPage() {
               <ExportButton
                 classroomId={String(id)}
                 classroomName={classroom?.name || ""}
-                isTeacher={classroom?.role === "teacher"}
+                isTeacher={hasTeacherAccess}
               />
 
-              {classroom?.role === "teacher" && (
+              {hasTeacherAccess && (
                 <button
                   onClick={() => setIsCodeModalOpen(true)}
                   className="flex items-center gap-2 px-4 py-2 bg-slate-50 dark:bg-zinc-900 border border-slate-200 dark:border-zinc-800 rounded-xl text-[11px] font-bold uppercase tracking-wider text-slate-600 dark:text-zinc-400 hover:bg-slate-100 dark:hover:bg-zinc-800/60 hover:text-slate-900 dark:hover:text-white transition-all duration-300 shadow-sm shrink-0"
@@ -378,7 +385,7 @@ export default function ClassroomPage() {
                 {
                   id: "teacher-doubts",
                   label:
-                    classroom?.role === "teacher"
+                    hasTeacherAccess
                       ? "Students Doubt"
                       : "Ask Teacher",
                   icon: GraduationCap,
@@ -697,7 +704,7 @@ export default function ClassroomPage() {
           <div className="animate-in fade-in slide-in-from-bottom-4 duration-500 space-y-8">
             <div className="flex flex-col sm:flex-row items-center justify-between gap-4 bg-slate-50/50 dark:bg-zinc-950/20 border border-slate-200 dark:border-zinc-900 p-4 rounded-xl shadow-sm">
               <h2 className="text-lg font-bold tracking-tight px-2">
-                {classroom?.role === "teacher" ? (
+                {hasTeacherAccess ? (
                   <>Students Doubts</>
                 ) : (
                   <>Direct Teacher Doubts</>
@@ -741,7 +748,7 @@ export default function ClassroomPage() {
                     Clear
                   </button>
                 )}
-                {classroom?.role !== "teacher" && (
+                {!hasTeacherAccess && (
                   <button
                     onClick={() => setIsAskModalOpen(true)}
                     className="px-5 py-2.5 bg-purple-600 hover:bg-purple-700 text-white rounded-xl font-bold uppercase tracking-wider text-xs transition-all duration-300 shadow-md shadow-purple-600/10 flex items-center gap-2 shrink-0"
@@ -823,11 +830,11 @@ export default function ClassroomPage() {
                         <div className="col-span-full py-24 text-center space-y-4 bg-slate-100 dark:bg-white/5 border border-dashed border-slate-200 dark:border-white/10 rounded-[2.5rem]">
                           <GraduationCap className="w-12 h-12 text-slate-700 mx-auto" />
                           <p className="text-slate-500 dark:text-slate-500 font-bold uppercase tracking-widest text-xs">
-                            {classroom?.role === "teacher"
+                            {hasTeacherAccess
                               ? "No unsolved doubts from students."
                               : "No unsolved teacher doubts."}
                           </p>
-                          {classroom?.role !== "teacher" && (
+                          {!hasTeacherAccess && (
                             <button
                               onClick={() => setIsAskModalOpen(true)}
                               className="text-purple-600 dark:text-purple-400 font-bold uppercase tracking-wider text-xs hover:underline underline-offset-4"
@@ -955,7 +962,7 @@ export default function ClassroomPage() {
       )}
 
       {/* INVITE STUDENTS MODAL */}
-      {isCodeModalOpen && classroom?.role === "teacher" && (
+      {isCodeModalOpen && hasTeacherAccess && (
         <div className="fixed inset-0 z-50 flex items-center justify-center p-4 backdrop-blur-xl bg-white/60 dark:bg-black/60 animate-in fade-in duration-300">
           <div className="bg-white dark:bg-zinc-950 border border-slate-200 dark:border-zinc-900 w-full max-w-lg rounded-2xl p-6 md:p-8 shadow-2xl space-y-6 animate-in zoom-in-95 duration-300 text-slate-900 dark:text-zinc-100">
             <div className="flex items-center justify-between">
@@ -1092,7 +1099,7 @@ function ClassroomInsightsView({
   const [data, setData] = useState<AnalyticsData | null>(null);
   const [loading, setLoading] = useState(true);
 
-  const isTeacher = role === "teacher" || role === "owner" || role === "admin";
+  const isTeacher = isTeacherRole(role);
 
   const fetchData = async () => {
     setLoading(true);
@@ -1123,8 +1130,8 @@ function ClassroomInsightsView({
 
   if (!data)
     return (
-      <div className="rounded-2xl border border-slate-200 dark:border-zinc-900 p-8 text-center text-sm text-slate-500 dark:text-zinc-400">
-        Classroom analytics are unavailable right now.
+      <div role="status" className="rounded-2xl border border-slate-200 dark:border-zinc-900 p-8 text-center text-sm text-slate-500 dark:text-zinc-400">
+        {CLASSROOM_ANALYTICS_UNAVAILABLE_MESSAGE}
       </div>
     );
 

--- a/src/app/rooms/[id]/page.tsx
+++ b/src/app/rooms/[id]/page.tsx
@@ -1092,16 +1092,22 @@ function ClassroomInsightsView({
   const [data, setData] = useState<AnalyticsData | null>(null);
   const [loading, setLoading] = useState(true);
 
-  const isTeacher = role === "teacher";
+  const isTeacher = role === "teacher" || role === "owner" || role === "admin";
 
-  const fetchData = () => {
+  const fetchData = async () => {
     setLoading(true);
-    fetch(`/api/analytics?classroomId={classroomId}`)
-      .then((res) => res.json())
-      .then((d) => {
-        setData(d);
-        setLoading(false);
-      });
+    try {
+      const res = await fetch(`/api/analytics?classroomId=${classroomId}`);
+      if (!res.ok) {
+        throw new Error(`Analytics request failed with status ${res.status}`);
+      }
+      setData(await res.json());
+    } catch (error) {
+      console.error("Error loading classroom analytics:", error);
+      setData(null);
+    } finally {
+      setLoading(false);
+    }
   };
 
   useEffect(() => {
@@ -1112,6 +1118,13 @@ function ClassroomInsightsView({
     return (
       <div className="flex justify-center p-20">
         <Loader2 className="w-6 h-6 text-purple-500 animate-spin" />
+      </div>
+    );
+
+  if (!data)
+    return (
+      <div className="rounded-2xl border border-slate-200 dark:border-zinc-900 p-8 text-center text-sm text-slate-500 dark:text-zinc-400">
+        Classroom analytics are unavailable right now.
       </div>
     );
 

--- a/src/configs/database-url.ts
+++ b/src/configs/database-url.ts
@@ -1,9 +1,5 @@
 export function getDatabaseUrl() {
-    const isTest = process.env.NODE_ENV === 'test';
-    const databaseUrl = (
-        process.env.DATABASE_URL || 
-        (!isTest ? process.env.NEXT_PUBLIC_NEON_DB_CONNECTION_STRING : undefined)
-    )?.trim();
+    const databaseUrl = process.env.DATABASE_URL?.trim();
 
     if (!databaseUrl) {
         throw new Error('DATABASE_URL is required. Please check your .env file.');

--- a/src/configs/db.tsx
+++ b/src/configs/db.tsx
@@ -1,6 +1,7 @@
 import { drizzle } from 'drizzle-orm/neon-http';
+import { getDatabaseUrl } from './database-url';
 
-export const db = drizzle(process.env.NEXT_PUBLIC_NEON_DB_CONNECTION_STRING!);
+export const db = drizzle(getDatabaseUrl());
 
 /** Re-export the transaction helper so callers import from one place. */
 export { db as default };

--- a/src/lib/auth/membership-guard.ts
+++ b/src/lib/auth/membership-guard.ts
@@ -1,0 +1,90 @@
+import { currentUser } from "@clerk/nextjs/server";
+import { and, eq } from "drizzle-orm";
+
+import { db } from "@/configs/db";
+import { membershipsTable } from "@/configs/schema";
+import { ApiError } from "@/lib/error-handler";
+
+const TEACHER_ROLES = new Set(["teacher", "owner"]);
+
+export type AuthenticatedUser = NonNullable<
+    Awaited<ReturnType<typeof currentUser>>
+>;
+
+export type ClassroomMembership = {
+    role: string;
+};
+
+export async function requireAuth(): Promise<{
+    user: AuthenticatedUser;
+    email: string;
+}> {
+    const user = await currentUser();
+
+    if (!user) {
+        throw new ApiError(401, "Unauthorized");
+    }
+
+    const email = user.primaryEmailAddress?.emailAddress;
+    if (!email) {
+        throw new ApiError(400, "Email required");
+    }
+
+    return { user, email };
+}
+
+export function parseClassroomId(value: unknown): number {
+    const classroomId = typeof value === "number"
+        ? value
+        : typeof value === "string" && /^[1-9]\d*$/.test(value)
+          ? Number(value)
+          : Number.NaN;
+
+    if (!Number.isSafeInteger(classroomId) || classroomId <= 0) {
+        throw new ApiError(400, "Invalid classroom ID");
+    }
+
+    return classroomId;
+}
+
+export function parseOptionalClassroomId(value: unknown): number | null {
+    if (value === null || value === undefined || value === "") {
+        return null;
+    }
+
+    return parseClassroomId(value);
+}
+
+export async function requireMembership(
+    email: string,
+    classroomId: number,
+): Promise<ClassroomMembership> {
+    const [membership] = await db
+        .select({ role: membershipsTable.role })
+        .from(membershipsTable)
+        .where(
+            and(
+                eq(membershipsTable.userEmail, email),
+                eq(membershipsTable.classroomId, classroomId),
+            ),
+        );
+
+    if (!membership) {
+        throw new ApiError(403, "Access denied to this classroom");
+    }
+
+    return membership;
+}
+
+export async function requireTeacher(
+    email: string,
+    classroomId: number,
+): Promise<ClassroomMembership> {
+    const membership = await requireMembership(email, classroomId);
+
+    if (!TEACHER_ROLES.has(membership.role)) {
+        throw new ApiError(403, "Forbidden: teacher access required");
+    }
+
+    return membership;
+}

--- a/src/lib/auth/membership-guard.ts
+++ b/src/lib/auth/membership-guard.ts
@@ -2,10 +2,10 @@ import { currentUser } from "@clerk/nextjs/server";
 import { and, eq } from "drizzle-orm";
 
 import { db } from "@/configs/db";
-import { membershipsTable } from "@/configs/schema";
+import { classroomsTable, membershipsTable } from "@/configs/schema";
 import { ApiError } from "@/lib/error-handler";
 
-const TEACHER_ROLES = new Set(["teacher", "owner"]);
+const TEACHER_ROLES = new Set(["teacher", "owner", "admin"]);
 
 export type AuthenticatedUser = NonNullable<
     Awaited<ReturnType<typeof currentUser>>
@@ -15,22 +15,34 @@ export type ClassroomMembership = {
     role: string;
 };
 
-export async function requireAuth(): Promise<{
+export type AuthenticatedContext = {
     user: AuthenticatedUser;
     email: string;
-}> {
+};
+
+export async function getOptionalAuth(): Promise<AuthenticatedContext | null> {
     const user = await currentUser();
 
     if (!user) {
-        throw new ApiError(401, "Unauthorized");
+        return null;
     }
 
     const email = user.primaryEmailAddress?.emailAddress;
     if (!email) {
-        throw new ApiError(400, "Email required");
+        throw new ApiError(401, "Unauthorized");
     }
 
     return { user, email };
+}
+
+export async function requireAuth(): Promise<AuthenticatedContext> {
+    const auth = await getOptionalAuth();
+
+    if (!auth) {
+        throw new ApiError(401, "Unauthorized");
+    }
+
+    return auth;
 }
 
 export function parseClassroomId(value: unknown): number {
@@ -70,6 +82,20 @@ export async function requireMembership(
         );
 
     if (!membership) {
+        const [ownedClassroom] = await db
+            .select({ teacherEmail: classroomsTable.teacherEmail })
+            .from(classroomsTable)
+            .where(
+                and(
+                    eq(classroomsTable.id, classroomId),
+                    eq(classroomsTable.teacherEmail, email),
+                ),
+            );
+
+        if (ownedClassroom) {
+            return { role: "owner" };
+        }
+
         throw new ApiError(403, "Access denied to this classroom");
     }
 


### PR DESCRIPTION
## **User description**
Closes #505

## Summary

This adds a shared classroom authorization boundary and applies it across the API routes that directly accept classroom IDs.

- adds `requireAuth`, `requireMembership`, `requireTeacher`, and strict classroom ID parsing in `src/lib/auth/membership-guard.ts`
- closes the missing membership checks in `/api/ask-ai`, doubt similarity checks, and personal analytics
- replaces duplicated membership/teacher queries in doubts, analytics, tags, room members/settings, exports, invites, confusion alerts, and teacher endpoints
- requires teacher access before acknowledging classroom confusion alerts
- returns consistent 401/403 error responses from the protected routes

## Verification

- focused authorization tests: 13/13 passing
- added guard unit coverage and a regression test proving non-members cannot persist AI doubts into a classroom
- scoped TypeScript check for all changed production files passes
- `git diff --check` passes
- full Jest suite: 93 passing; the remaining five failures are existing failures in doubts sorting/filtering, room-members response expectations, and DB configuration
- local build reaches compilation but is blocked by existing upstream conflict markers in `src/app/api/karma/route.ts`, an existing missing `./client` import in the Inngest detector, and unavailable Google Fonts

This contribution is part of GSSoC 2026.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Consistent auth/authorization and centralized error responses across APIs with clearer 400/401/403 messages (e.g. "Invalid classroom ID", "Access denied to this classroom")
  * Membership/teacher checks tightened so non-members and non-teachers are consistently denied
  * Room members API now returns paginated payloads and role-aware member views

* **New Features**
  * UI shows explicit "analytics unavailable" fallbacks when analytics fail
  * Owner/admin are treated as teacher-equivalent for teacher-only UI/actions

* **Tests**
  * Expanded test coverage for auth, membership, teacher roles, pagination, and doubt-similarity behaviors
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Tighten classroom access checks and show clearer fallback states**

### What Changed
- Classroom-only actions now reject non-members and non-teachers consistently, with clearer access-denied and invalid-ID messages
- Member lists are paginated and hide student emails from student viewers while still showing them to teachers and classroom owners/admins
- Anonymous access is allowed for public doubt browsing and community similarity checks, while classroom-scoped requests still require sign-in and membership
- Dashboard and classroom analytics now show a visible “unavailable” message instead of failing silently when data cannot be loaded
- Teacher and owner/admin roles are treated as teacher access in classroom views and invite/export tools

### Impact
`✅ Fewer unauthorized classroom actions`
`✅ Clearer access-denied errors`
`✅ Safer member and email visibility`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
