### PR TITLE
perf(db): add high-traffic query indexes

### DIFF
--- a/drizzle/0009_query_indexes.sql
+++ b/drizzle/0009_query_indexes.sql
@@ -1,0 +1,3 @@
+CREATE INDEX IF NOT EXISTS "classrooms_teacherEmail_idx" ON "classrooms" USING btree ("teacherEmail");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "doubts_userEmail_classroomId_idx" ON "doubts" USING btree ("userEmail", "classroomId");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "moderation_logs_userEmail_createdAt_idx" ON "moderation_logs" USING btree ("userEmail", "createdAt");

--- a/src/configs/schema.ts
+++ b/src/configs/schema.ts
@@ -27,17 +27,23 @@ export const usersTable = pgTable("users", {
     createdAt: timestamp().defaultNow().notNull(),
 });
 
-export const classroomsTable = pgTable("classrooms", {
-    id: integer().primaryKey().generatedAlwaysAsIdentity(),
-    name: varchar({ length: 255 }).notNull(),
-    university: varchar({ length: 255 }).notNull(),
-    year: varchar({ length: 50 }).notNull(),
-    teacherEmail: varchar({ length: 255 }).notNull(),
-    inviteCode: varchar({ length: 10 }).notNull().unique(),
-    pedagogyLevel: varchar({ length: 50 }).default("Undergraduate (Freshman)").notNull(),
-    targetGradeLevel: integer().default(13).notNull(),
-    createdAt: timestamp().defaultNow().notNull(),
-});
+export const classroomsTable = pgTable(
+    "classrooms",
+    {
+        id: integer().primaryKey().generatedAlwaysAsIdentity(),
+        name: varchar({ length: 255 }).notNull(),
+        university: varchar({ length: 255 }).notNull(),
+        year: varchar({ length: 50 }).notNull(),
+        teacherEmail: varchar({ length: 255 }).notNull(),
+        inviteCode: varchar({ length: 10 }).notNull().unique(),
+        pedagogyLevel: varchar({ length: 50 }).default("Undergraduate (Freshman)").notNull(),
+        targetGradeLevel: integer().default(13).notNull(),
+        createdAt: timestamp().defaultNow().notNull(),
+    },
+    (table) => ({
+        teacherEmailIndex: index("classrooms_teacherEmail_idx").on(table.teacherEmail),
+    }),
+);
 
 export const membershipsTable = pgTable("memberships", {
     id: integer().primaryKey().generatedAlwaysAsIdentity(),
@@ -192,6 +198,10 @@ export const doubtsTable = pgTable("doubts", {
         subjectIndex: index("subject_idx").on(table.subject),
         createdAtIndex: index("idx_doubts_created").on(table.createdAt),
         isSolvedIndex: index("idx_doubts_solved").on(table.isSolved),
+        userEmailClassroomIdIndex: index("doubts_userEmail_classroomId_idx").on(
+            table.userEmail,
+            table.classroomId,
+        ),
         userEmailFk: foreignKey({
             columns: [table.userEmail],
             foreignColumns: [usersTable.email],
@@ -304,6 +314,10 @@ export const moderationLogsTable = pgTable("moderation_logs", {
     status: varchar({ length: 20 }).default("pending").notNull(),
     createdAt: timestamp().defaultNow().notNull(),
 }, (table) => ({
+    userEmailCreatedAtIndex: index("moderation_logs_userEmail_createdAt_idx").on(
+        table.userEmail,
+        table.createdAt,
+    ),
     userEmailFk: foreignKey({
         columns: [table.userEmail],
         foreignColumns: [usersTable.email],


### PR DESCRIPTION
## Summary
- add a teacher-email index for teacher-scoped classroom queries
- add a composite doubt author/classroom index
- add a composite moderation user/created-at index
- add an idempotent `0009_query_indexes.sql` migration without changing existing constraints

## Why
These indexes cover the high-traffic lookup shapes identified in #507 while preserving existing schema behavior and constraints.

## Testing
- `git diff --check`
- verified the migration and Drizzle schema declare the same three indexes
- hosted Build, TypeScript, ESLint, security scan, and dependency audit checks pass
- hosted unit tests reproduce the existing upstream baseline only: 5 failures in room-members, doubts sorting/filtering, and DB config; 90/95 tests pass
- local Drizzle generation is blocked because this checkout contains Linux esbuild binaries on macOS

Closes #507