### PR TITLE
test: add integration tests for video generate request body consumption

### DIFF
--- a/__tests__/lib/video-generate.test.ts
+++ b/__tests__/lib/video-generate.test.ts
@@ -1,0 +1,75 @@
+import { parseAndValidateRequest } from "@/lib/validations/validate";
+import { generateVideoSchema } from "@/lib/validations/video";
+
+function makeRequest(body: unknown): Request {
+  return new Request("http://localhost/api/video/generate", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("video generate endpoint - request body consumption", () => {
+  it("parses request body exactly once via parseAndValidateRequest", async () => {
+    const req = makeRequest({ content: "What is photosynthesis?" });
+    const jsonSpy = jest.spyOn(req, "json");
+
+    await parseAndValidateRequest(req, generateVideoSchema);
+
+    expect(jsonSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns parsed content and imageUrl from data, not a second req.json()", async () => {
+    const payload = { content: "Explain Newton's laws" };
+    const req = makeRequest(payload);
+
+    const { errorResponse, data } = await parseAndValidateRequest(req, generateVideoSchema);
+
+    expect(errorResponse).toBeNull();
+    expect(data).not.toBeNull();
+    expect(data?.content).toBe(payload.content);
+    expect(data?.imageUrl).toBeUndefined();
+  });
+
+  it("returns parsed imageUrl when provided without content", async () => {
+    const payload = { imageUrl: "https://example.com/doubt.png" };
+    const req = makeRequest(payload);
+
+    const { errorResponse, data } = await parseAndValidateRequest(req, generateVideoSchema);
+
+    expect(errorResponse).toBeNull();
+    expect(data?.imageUrl).toBe(payload.imageUrl);
+    expect(data?.content).toBeUndefined();
+  });
+
+  it("returns errorResponse when both content and imageUrl are missing", async () => {
+    const req = makeRequest({});
+
+    const { errorResponse, data } = await parseAndValidateRequest(req, generateVideoSchema);
+
+    expect(errorResponse).not.toBeNull();
+    expect(data).toBeNull();
+  });
+
+  it("returns errorResponse on invalid JSON body", async () => {
+    const req = new Request("http://localhost/api/video/generate", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "not valid json",
+    });
+
+    const { errorResponse, data } = await parseAndValidateRequest(req, generateVideoSchema);
+
+    expect(errorResponse).not.toBeNull();
+    expect(data).toBeNull();
+  });
+
+  it("consuming body a second time after parseAndValidateRequest throws or returns empty", async () => {
+    const req = makeRequest({ content: "Test question" });
+
+    await parseAndValidateRequest(req, generateVideoSchema);
+
+    // This simulates what the old buggy code did - calling req.json() again
+    await expect(req.json()).rejects.toThrow();
+  });
+});


### PR DESCRIPTION
## Description
Adds integration tests for the video generation endpoint to prevent regression of the double request body consumption bug. Tests verify that `parseAndValidateRequest` consumes `req.json()` exactly once, that `content` and `imageUrl` are correctly extracted from the returned `data` object, and that a second call to `req.json()` after validation fails as expected — confirming the fix in #328 is protected going forward.

## Related Issue
<!-- Link the issue this PR addresses. Use "Closes #<number>" to auto-close the issue on merge. -->
Closes #315 

## Type of Change
- [x] Test addition or update

## How Has This Been Tested?
Ran the test suite directly against the new test file:
`npx jest __tests__/lib/video-generate.test.ts --no-coverage`
All 6 tests passed locally.

## Checklist
- [x] I have tested my changes locally (`npm run dev`)
- [x] My code follows the existing code style (TypeScript, Tailwind, no `any` types)
- [x] I have not introduced unrelated changes (each PR should address one issue)
- [x] I have added comments where necessary
- [x] My branch is up to date with `main`
- [x] I have linked the related issue above

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for request body validation in the video generation endpoint to ensure proper handling of required fields and error cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->