### PR TITLE
fix: resolve silent failure when teacher sets doubt status

### DIFF
--- a/src/app/api/doubts/action/[id]/route.ts
+++ b/src/app/api/doubts/action/[id]/route.ts
@@ -15,7 +15,7 @@ export async function PATCH(req: Request, { params }: { params: Promise<{ id: st
         const { errorResponse, data } = await parseAndValidateRequest(req, updateDoubtActionSchema);
         if (errorResponse) return errorResponse;
 
-        const { action, content, subject, imageUrl, userName, replyId, tags = [] } = data;
+        const { action, content, subject, imageUrl, userName, replyId, tags = [], status } = data;
 
         const user = await currentUser();
         const email = user?.primaryEmailAddress?.emailAddress;

--- a/src/lib/validations/doubt.ts
+++ b/src/lib/validations/doubt.ts
@@ -22,7 +22,8 @@ export const updateDoubtActionSchema = z.object({
   imageUrl: z.union([safeUrl, z.literal('')]).optional().nullable().transform(e => e === '' ? null : e),
   userName: trimmedString.max(255).optional(),
   replyId: positiveInt.optional().nullable(),
-  tags: z.array(trimmedString.min(1).max(80)).max(8).optional()
+  tags: z.array(trimmedString.min(1).max(80)).max(8).optional(),
+  status: z.enum(["unsolved", "in-progress", "solved"]).optional()
 }).refine((data) => {
   if (data.action === "like" && !data.userName) return false;
   return true;


### PR DESCRIPTION
## **User description**
## Description

**Fixes a silent failure where teachers could not explicitly update a doubt's status via the UI dropdown.**

### Problem
In `src/app/api/doubts/action/[id]/route.ts`, the code relies on a `status` variable to override the default toggle behavior when a teacher explicitly sets a status (e.g., `in-progress` or `solved`). However, `status` was neither defined in `updateDoubtActionSchema` nor destructured from the `data` object. Because it evaluated to `undefined`, the condition `if (status !== undefined)` was always `false`, causing the explicit override path to become silent dead code.

### Solution
1. **Validation Schema Update**: Added `status` to `updateDoubtActionSchema` in `src/lib/validations/doubt.ts` so that explicit statuses passed from the client are correctly parsed and validated.
2. **API Route Update**: Destructured `status` from `data` in `src/app/api/doubts/action/[id]/route.ts` to ensure the route logic has access to the explicitly requested status.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Steps to Test
1. Log in as a user with the **Teacher** role.
2. Navigate to a virtual classroom and open a pending doubt.
3. Use the status dropdown to manually set the doubt's status to `in-progress` or `solved`.
4. Observe that the status now successfully updates in the UI and database instead of failing silently.

### Checklist:
- [x] I have read the `CONTRIBUTING.md` document.
- [x] My code follows the code style of this project.
- [x] My commit messages follow the Conventional Commits specification.
- [x] I have tested my changes locally.


___

## **CodeAnt-AI Description**
**Teacher status updates from the doubt dropdown now save correctly instead of failing silently**

### What Changed
- Teachers can now explicitly set a doubt’s status to `in-progress` or `solved` from the UI dropdown
- The API now accepts the selected status and applies it when updating the doubt
- Status changes no longer get ignored when a teacher chooses a specific value

### Impact
`✅ Reliable doubt status updates`
`✅ Fewer silent classroom actions`
`✅ Clearer teacher workflow`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
