### PR TITLE
fix(analytics): multi-topic clustering and per-topic cooldown for confusion spike detection

### DIFF
--- a/src/app/api/inngest/ConfusionSpikeDetector.ts
+++ b/src/app/api/inngest/ConfusionSpikeDetector.ts
@@ -1,11 +1,15 @@
 // src/app/api/inngest/ConfusionSpikeDetector.ts
 import { inngest } from "@/inngest/client";
 import { db } from "@/configs/db";
-import { doubtsTable, confusionAlertsTable } from "@/configs/schema"; 
+import { doubtsTable, confusionAlertsTable } from "@/configs/schema";
 import { and, gte, eq, desc } from "drizzle-orm";
 import Groq from "groq-sdk";
 
 const groq = new Groq({ apiKey: process.env.GROQ_API_KEY || "dummy_key" });
+
+const LOOKBACK_MS = 30 * 60 * 1000; // 30 minutes
+const COOLDOWN_MS = 30 * 60 * 1000; // 30 minutes per topic
+const SPIKE_THRESHOLD = 5;
 
 // Explicit interface mapping to clear compiler type-inference ambiguities
 interface DoubtPayload {
@@ -15,16 +19,20 @@ interface DoubtPayload {
     createdAt: Date;
 }
 
-interface AnalysisResult {
-    isSpike: boolean;
-    coreConcept: string;
+interface TopicCluster {
+    topic: string;
+    doubtIndices: number[]; // 1-based indices into the provided doubts list
     confidenceScore: number;
     summary: string;
 }
 
+interface ClusteringResult {
+    clusters: TopicCluster[];
+}
+
 export const detectConfusionSpikes = inngest.createFunction(
-    { 
-        id: "detect-confusion-spikes", 
+    {
+        id: "detect-confusion-spikes",
         name: "Detect Confusion Spikes",
         // Native architectural debounce drops back-to-back spam requests gracefully
         debounce: {
@@ -38,32 +46,10 @@ export const detectConfusionSpikes = inngest.createFunction(
 
         if (!classroomId) return { skipped: "No classroomId provided" };
 
-        // 1. Cooldown check: Deterministic query timeframe generation
-        const hasRecentAlert = await step.run("check-cooldown-window", async (): Promise<boolean> => {
-            const lookbackTime = new Date(Date.now() - 30 * 60 * 1000);
-            
-            const [recentAlert] = await db
-                .select({ id: confusionAlertsTable.id })
-                .from(confusionAlertsTable)
-                .where(
-                    and(
-                        eq(confusionAlertsTable.classroomId, Number(classroomId)),
-                        gte(confusionAlertsTable.createdAt, lookbackTime)
-                    )
-                )
-                .orderBy(desc(confusionAlertsTable.createdAt))
-                .limit(1);
-
-            return !!recentAlert; 
-        });
-
-        if (hasRecentAlert) {
-            return { skipped: "Cooldown window active for this classroom" };
-        }
-
+        // 1. Fetch recent doubts for this classroom
         const dynamicDoubts: DoubtPayload[] = await step.run("fetch-recent-classroom-doubts", async (): Promise<DoubtPayload[]> => {
-            const lookbackTime = new Date(Date.now() - 30 * 60 * 1000);
-            
+            const lookbackTime = new Date(Date.now() - LOOKBACK_MS);
+
             return await db
                 .select({
                     id: doubtsTable.id,
@@ -80,28 +66,39 @@ export const detectConfusionSpikes = inngest.createFunction(
                 );
         });
 
-        if (!dynamicDoubts || dynamicDoubts.length < 5) {
-            return { 
-                status: "Threshold not met", 
-                count: dynamicDoubts ? dynamicDoubts.length : 0 
+        if (!dynamicDoubts || dynamicDoubts.length < SPIKE_THRESHOLD) {
+            return {
+                status: "Threshold not met",
+                count: dynamicDoubts ? dynamicDoubts.length : 0
             };
         }
 
-        const clusteringAnalysis = await step.run("cluster-doubts-with-groq", async (): Promise<AnalysisResult> => {
+        // 2. Ask Groq to group doubts into one or more topic clusters
+        const clusteringResult = await step.run("cluster-doubts-with-groq", async (): Promise<ClusteringResult> => {
             const formattedDoubts = dynamicDoubts
                 .map((d: DoubtPayload, index: number) => `${index + 1}. [Subject: ${d.subject || 'General'}] ${d.content || ''}`)
                 .join("\n");
 
-            const systemPrompt = `You are an advanced academic internal tracking assistant analyzing real-time classroom friction points. 
-Review the list of students' technical doubts below and determine if there is a core cluster or theme pointing to a specific misunderstood sub-topic.
+            const systemPrompt = `You are an advanced academic internal tracking assistant analyzing real-time classroom friction points.
+Review the numbered list of students' technical doubts below and group them into one or more topic clusters based on the underlying concept each doubt is about. A cluster represents a distinct sub-topic that multiple students appear confused about.
 
 Return a valid, strict JSON object with this exact shape:
 {
-  "isSpike": boolean,
-  "coreConcept": "string description of the shared topic or root point of confusion",
-  "confidenceScore": number (between 0 and 1),
-  "summary": "Brief summary explaining what the students are collectively struggling with"
-}`;
+  "clusters": [
+    {
+      "topic": "string description of the shared sub-topic",
+      "doubtIndices": [number, ...],
+      "confidenceScore": number (between 0 and 1),
+      "summary": "Brief summary explaining what the students are collectively struggling with"
+    }
+  ]
+}
+
+Rules:
+- "doubtIndices" must reference the 1-based numbers from the provided list.
+- Only include a cluster if at least ${SPIKE_THRESHOLD} doubts genuinely share that sub-topic.
+- If no cluster meets that bar, return { "clusters": [] }.
+- A doubt may belong to at most one cluster.`;
 
             const response = await groq.chat.completions.create({
                 model: "llama3-8b-8192",
@@ -119,48 +116,74 @@ Return a valid, strict JSON object with this exact shape:
             }
 
             try {
-                return JSON.parse(contentText) as AnalysisResult;
+                const parsed = JSON.parse(contentText) as ClusteringResult;
+                return { clusters: Array.isArray(parsed.clusters) ? parsed.clusters : [] };
             } catch (parseError) {
                 console.error("Failed to parse Groq raw content structure:", parseError);
-                return {
-                    isSpike: false,
-                    coreConcept: "Parsing Error Fallback",
-                    confidenceScore: 0,
-                    summary: "Failed to cleanly parse structured analytical metrics from model output."
-                };
+                return { clusters: [] };
             }
         });
 
-        if (!clusteringAnalysis.isSpike) {
+        // 3. Filter down to clusters that actually meet the spike threshold
+        const spikeClusters = clusteringResult.clusters.filter(
+            (c) => Array.isArray(c.doubtIndices) && c.doubtIndices.length >= SPIKE_THRESHOLD && c.topic
+        );
+
+        if (spikeClusters.length === 0) {
             return { status: "Analyzed, but no significant thematic confusion spike detected." };
         }
 
-        // 4. Fully isolated deterministic database log execution (SYNCED WITH SCHEMA)
-        await step.run("persist-confusion-alert-log", async () => {
-            const executionTimestamp = new Date();
-            
-            // Generate standard fallbacks for missing values safely
-            const computedAction = `Consider hosting a brief interactive discussion or query resolution session regarding "${clusteringAnalysis.coreConcept || 'this topic'}".`;
-            const mappedIds = dynamicDoubts ? dynamicDoubts.slice(0, 5).map((d: DoubtPayload) => d.id) : [];
+        // 4. For each spiking cluster, check per-topic cooldown then persist an alert
+        const results = [];
 
-            await db.insert(confusionAlertsTable).values({
-                classroomId: Number(classroomId),                     // Explicit cast to integer
-                topic: clusteringAnalysis.coreConcept || "General Confusion Spike", // Explicit fallback mapping
-                summary: clusteringAnalysis.summary || "Multiple students are exhibiting core structural concept doubts.",
-                suggestedAction: computedAction,                     // Fully satisfies required field mapping
-                confidence: Math.round((clusteringAnalysis.confidenceScore || 0) * 100), // Scale conversion to safe integer
-                doubtCount: dynamicDoubts ? dynamicDoubts.length : 0, // Fallback tracking for notNull mapping
-                sampleDoubtIds: JSON.stringify(mappedIds),           // Stringified valid payload array
-                status: "active",                                     // Strict status constraint mapping
-                createdAt: executionTimestamp
+        for (const cluster of spikeClusters) {
+            const clusterResult = await step.run(`process-cluster-${cluster.topic}`, async () => {
+                const lookbackTime = new Date(Date.now() - COOLDOWN_MS);
+
+                // Per-topic cooldown: skip if an alert for this exact topic in this
+                // classroom was already created recently.
+                const [recentAlert] = await db
+                    .select({ id: confusionAlertsTable.id })
+                    .from(confusionAlertsTable)
+                    .where(
+                        and(
+                            eq(confusionAlertsTable.classroomId, Number(classroomId)),
+                            eq(confusionAlertsTable.topic, cluster.topic),
+                            gte(confusionAlertsTable.createdAt, lookbackTime)
+                        )
+                    )
+                    .orderBy(desc(confusionAlertsTable.createdAt))
+                    .limit(1);
+
+                if (recentAlert) {
+                    return { topic: cluster.topic, skipped: "Cooldown window active for this topic" };
+                }
+
+                const mappedIds = cluster.doubtIndices
+                    .map((idx) => dynamicDoubts[idx - 1]?.id)
+                    .filter((id): id is number => typeof id === "number")
+                    .slice(0, 5);
+
+                const computedAction = `Consider hosting a brief interactive discussion or query resolution session regarding "${cluster.topic}".`;
+
+                await db.insert(confusionAlertsTable).values({
+                    classroomId: Number(classroomId),
+                    topic: cluster.topic,
+                    summary: cluster.summary || "Multiple students are exhibiting core structural concept doubts.",
+                    suggestedAction: computedAction,
+                    confidence: Math.round((cluster.confidenceScore || 0) * 100),
+                    doubtCount: cluster.doubtIndices.length,
+                    sampleDoubtIds: JSON.stringify(mappedIds),
+                    status: "active",
+                    createdAt: new Date()
+                });
+
+                return { topic: cluster.topic, status: "Alert processed" };
             });
-            
-            return { success: true };
-        });
 
-        return { 
-            status: "Alert processed", 
-            topic: clusteringAnalysis.coreConcept 
-        };
+            results.push(clusterResult);
+        }
+
+        return { status: "Processed clusters", clusters: results };
     }
 );


### PR DESCRIPTION
## **User description**
Closes #535 (partially — addresses the multi-cluster and per-topic cooldown checklist items)

ConfusionSpikeDetector.ts now prompts Groq to return multiple topic clusters per run instead of a single isSpike verdict, so distinct confusion themes occurring simultaneously are each detected.
Cooldown logic moved from a flat 30-min classroom-wide check to a per-topic check against confusionAlertsTable, queried right before inserting each cluster's alert.
Spike threshold (5 doubts) is now applied per cluster rather than to the whole batch.
No schema changes required — existing confusionAlertsTable columns are sufficient.

Not addressed in this PR: notificationsTable integration — the existing /api/confusion + ConfusionAlertPanel dashboard already serves as the "teacher notification," but flagging in case the maintainer wants a separate notification row too.


___

## **CodeAnt-AI Description**
**Detect multiple confusion topics and skip repeats per topic**

### What Changed
- Confusion spikes can now be detected for several different topics in the same classroom session, instead of only one overall verdict.
- Each topic now has its own 30-minute cooldown, so a new alert is only skipped when that same topic was already flagged recently.
- Alerts are created only for topic groups that meet the 5-doubt threshold, and the result shows which clusters were processed or skipped.

### Impact
`✅ Fewer missed confusion spikes`
`✅ Fewer repeated alerts for the same topic`
`✅ Clearer teacher notifications for mixed-topic doubt bursts`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced confusion detection to identify and cluster multiple related topics simultaneously instead of single concepts
  * Confusion alerts now include suggested actions and confidence scoring for better insights
  * Improved detection accuracy with configurable sensitivity thresholds

<!-- end of auto-generated comment: release notes by coderabbit.ai -->