### PR TITLE
fix: add clipboard API fallback in handleShare and improve image alt text

### DIFF
--- a/src/components/DoubtCard.tsx
+++ b/src/components/DoubtCard.tsx
@@ -201,9 +201,23 @@ export default function DoubtCard({ doubt, onUpdate, onViewAISolution, role, ope
 
     const handleShare = async () => {
         try {
-            await navigator.clipboard.writeText(getShareUrl());
+            const url = getShareUrl();
+            if (navigator.clipboard && window.isSecureContext) {
+                await navigator.clipboard.writeText(url);
+            } else {
+                // Fallback for non-HTTPS or older browsers
+                const textArea = document.createElement("textarea");
+                textArea.value = url;
+                textArea.style.position = "fixed";
+                textArea.style.opacity = "0";
+                document.body.appendChild(textArea);
+                textArea.select();
+                document.execCommand("copy");
+                document.body.removeChild(textArea);
+            }
             toast.success(SHARE_MESSAGES.COPY_SUCCESS);
         } catch (error) {
+            console.error("Failed to copy link:", error);
             toast.error(SHARE_MESSAGES.COPY_ERROR);
         }
     };
@@ -324,7 +338,7 @@ export default function DoubtCard({ doubt, onUpdate, onViewAISolution, role, ope
                         >
                             <img
                                 src={doubt.imageUrl}
-                                alt="Doubt"
+                                alt={`Doubt image for ${doubt.subject} by ${doubt.userEmail?.split('@')[0] || 'Anonymous'}`}
                                 className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-700"
                             />
                             <div className="absolute inset-0 bg-black/20 opacity-0 group-hover/img:opacity-100 transition-opacity flex items-center justify-center">
@@ -503,7 +517,7 @@ export default function DoubtCard({ doubt, onUpdate, onViewAISolution, role, ope
                     >
                         <img
                             src={doubt.imageUrl ?? undefined}
-                            alt="Full View"
+                            alt={`Full view of doubt image for ${doubt.subject} by ${doubt.userEmail?.split('@')[0] || 'Anonymous'}`}
                             className="max-w-full max-h-full object-contain rounded-xl shadow-2xl border border-slate-200 dark:border-white/10"
                         />
                     </div>


### PR DESCRIPTION
## **User description**
### Description
This pull request addresses two usability and accessibility improvements in `DoubtCard.tsx`:
1. **Clipboard API Fallback (Issue #637)**: Adds feature detection for `navigator.clipboard` and `isSecureContext`. For non-HTTPS environments or older browsers, it implements a reliable fallback using a temporary `textarea` and `document.execCommand("copy")`.
2. **Image Alt Text Accessibility (Issue #636)**: Replaces generic static alt descriptions (`alt="Doubt"` / `alt="Full View"`) with dynamic descriptions utilizing `doubt.subject` and user identity properties. This aligns with WCAG 2.1 Success Criterion 1.1.1.

### Related Issues
Closes #637
Closes #636

### Affected Files
- [src/components/DoubtCard.tsx](file:///c:/Users/HP/OneDrive/Desktop/Padhai/OpenSource/WorkingOnCurrently/DoubtDesk/src/components/DoubtCard.tsx)

### Checklist
- [x] Handled asynchronous Clipboard API with `await`.
- [x] Added `document.execCommand` textarea fallback logic for non-secure contexts.
- [x] Updated standard image thumbnail `alt` property dynamically.
- [x] Updated fullscreen image overlay `alt` property dynamically.
- [x] Verified build compilation.


___

## **CodeAnt-AI Description**
**Let users copy share links in more browsers and get clearer image descriptions**

### What Changed
- Sharing now falls back to a copy method that works in non-HTTPS pages and older browsers, so the link can still be copied when the modern clipboard API is unavailable
- Failed copy attempts are now logged and still show the existing error message
- Doubt thumbnails and fullscreen images now describe the subject and author instead of using the same generic text for every image

### Impact
`✅ Fewer share failures on older browsers`
`✅ Copy links works in more non-secure environments`
`✅ Clearer screen reader descriptions for doubt images`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
