### PR TITLE
fix: pin unbounded dependency versions in chat-system

### DIFF
--- a/chat-system/package-lock.json
+++ b/chat-system/package-lock.json
@@ -12,10 +12,10 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^1.16.0",
-        "next": "latest",
-        "react": "latest",
-        "react-dom": "latest",
-        "socket.io-client": "latest",
+        "next": "16.2.6",
+        "react": "19.2.6",
+        "react-dom": "19.2.6",
+        "socket.io-client": "4.8.3",
         "tailwind-merge": "^3.6.0"
       },
       "devDependencies": {
@@ -23,7 +23,7 @@
         "autoprefixer": "^10.5.0",
         "postcss": "^8.5.15",
         "tailwindcss": "^4.3.0",
-        "typescript": "latest"
+        "typescript": "6.0.3"
       }
     },
     "node_modules/@alloc/quick-lru": {

--- a/chat-system/package.json
+++ b/chat-system/package.json
@@ -14,10 +14,10 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^1.16.0",
-    "next": "latest",
-    "react": "latest",
-    "react-dom": "latest",
-    "socket.io-client": "latest",
+    "next": "16.2.6",
+    "react": "19.2.6",
+    "react-dom": "19.2.6",
+    "socket.io-client": "4.8.3",
     "tailwind-merge": "^3.6.0"
   },
   "devDependencies": {
@@ -25,6 +25,6 @@
     "autoprefixer": "^10.5.0",
     "postcss": "^8.5.15",
     "tailwindcss": "^4.3.0",
-    "typescript": "latest"
+    "typescript": "6.0.3"
   }
 }


### PR DESCRIPTION
## **User description**
### Description
This pull request resolves the unbounded dependency issue in the nested `chat-system` package.
Previously, several dependencies were defined using the `"latest"` tag, leading to non-deterministic resolves and configuration drifts during installs. These dependencies have been pinned to the exact matching versions resolved in the lockfile:
- `next`: `16.2.6`
- `react`: `19.2.6`
- `react-dom`: `19.2.6`
- `socket.io-client`: `4.8.3`
- `typescript`: `6.0.3`

### Related Issue
Closes #627

### Affected Files
- [chat-system/package.json](file:///c:/Users/HP/OneDrive/Desktop/Padhai/OpenSource/WorkingOnCurrently/DoubtDesk/chat-system/package.json)
- [chat-system/package-lock.json](file:///c:/Users/HP/OneDrive/Desktop/Padhai/OpenSource/WorkingOnCurrently/DoubtDesk/chat-system/package-lock.json)

### Checklist
- [x] Pinned `next`, `react`, `react-dom`, `socket.io-client`, and `typescript` dependencies to exact versions.
- [x] Synced root packages registry in lockfile with manifest changes.
- [x] Verified project builds cleanly.


___

## **CodeAnt-AI Description**
Pin chat-system dependencies to fixed versions

### What Changed
- Replaced unbounded `latest` dependency versions with exact versions for the chat app and build tools
- Keeps installs and builds on the same package versions over time, instead of changing unexpectedly

### Impact
`✅ Consistent chat app installs`
`✅ Fewer build surprises after dependency updates`
`✅ Lower risk of version drift`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
