### PR TITLE
Fix/alt text accessibility

### DIFF
--- a/src/components/DoubtCard.tsx
+++ b/src/components/DoubtCard.tsx
@@ -324,7 +324,7 @@ export default function DoubtCard({ doubt, onUpdate, onViewAISolution, role, ope
                         >
                             <img
                                 src={doubt.imageUrl}
-                                alt="Doubt"
+                                alt={`Doubt image for ${doubt.subject} by ${doubt.userName}`} 
                                 className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-700"
                             />
                             <div className="absolute inset-0 bg-black/20 opacity-0 group-hover/img:opacity-100 transition-opacity flex items-center justify-center">
@@ -503,7 +503,7 @@ export default function DoubtCard({ doubt, onUpdate, onViewAISolution, role, ope
                     >
                         <img
                             src={doubt.imageUrl ?? undefined}
-                            alt="Full View"
+                            alt={`Full view of doubt image for ${doubt.subject} by ${doubt.userName}`}
                             className="max-w-full max-h-full object-contain rounded-xl shadow-2xl border border-slate-200 dark:border-white/10"
                         />
                     </div>

--- a/src/components/DoubtCard.tsx
+++ b/src/components/DoubtCard.tsx
@@ -200,24 +200,10 @@ export default function DoubtCard({ doubt, onUpdate, onViewAISolution, role, ope
     const getShareUrl = () => `${window.location.origin}/doubts/${doubt.id}`;
 
     const handleShare = async () => {
-        const url = getShareUrl();
         try {
-            if (navigator.clipboard && window.isSecureContext) {
-                await navigator.clipboard.writeText(url);
-            } else {
-                // Fallback for non-HTTPS or older browsers
-                const textArea = document.createElement("textarea");
-                textArea.value = url;
-                textArea.style.position = "fixed";
-                textArea.style.opacity = "0";
-                document.body.appendChild(textArea);
-                textArea.select();
-                document.execCommand("copy");
-                document.body.removeChild(textArea);
-            }
+            await navigator.clipboard.writeText(getShareUrl());
             toast.success(SHARE_MESSAGES.COPY_SUCCESS);
         } catch (error) {
-            console.error("Failed to copy link:", error);
             toast.error(SHARE_MESSAGES.COPY_ERROR);
         }
     };
@@ -338,7 +324,7 @@ export default function DoubtCard({ doubt, onUpdate, onViewAISolution, role, ope
                         >
                             <img
                                 src={doubt.imageUrl}
-                                alt={`Doubt image for ${doubt.subject} by ${doubt.userName}`} 
+                                alt={`Doubt image for ${doubt.subject} by ${doubt.userEmail?.split('@')[0] || 'Anonymous'}`}
                                 className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-700"
                             />
                             <div className="absolute inset-0 bg-black/20 opacity-0 group-hover/img:opacity-100 transition-opacity flex items-center justify-center">
@@ -517,7 +503,7 @@ export default function DoubtCard({ doubt, onUpdate, onViewAISolution, role, ope
                     >
                         <img
                             src={doubt.imageUrl ?? undefined}
-                            alt={`Full view of doubt image for ${doubt.subject} by ${doubt.userName}`}
+                            alt={`Full view of doubt image for ${doubt.subject} by ${doubt.userEmail?.split('@')[0] || 'Anonymous'}`}
                             className="max-w-full max-h-full object-contain rounded-xl shadow-2xl border border-slate-200 dark:border-white/10"
                         />
                     </div>

--- a/src/components/DoubtCard.tsx
+++ b/src/components/DoubtCard.tsx
@@ -200,10 +200,24 @@ export default function DoubtCard({ doubt, onUpdate, onViewAISolution, role, ope
     const getShareUrl = () => `${window.location.origin}/doubts/${doubt.id}`;
 
     const handleShare = async () => {
+        const url = getShareUrl();
         try {
-            await navigator.clipboard.writeText(getShareUrl());
+            if (navigator.clipboard && window.isSecureContext) {
+                await navigator.clipboard.writeText(url);
+            } else {
+                // Fallback for non-HTTPS or older browsers
+                const textArea = document.createElement("textarea");
+                textArea.value = url;
+                textArea.style.position = "fixed";
+                textArea.style.opacity = "0";
+                document.body.appendChild(textArea);
+                textArea.select();
+                document.execCommand("copy");
+                document.body.removeChild(textArea);
+            }
             toast.success(SHARE_MESSAGES.COPY_SUCCESS);
         } catch (error) {
+            console.error("Failed to copy link:", error);
             toast.error(SHARE_MESSAGES.COPY_ERROR);
         }
     };


### PR DESCRIPTION
fixes #636 
Solved the issue by Replacing static alt strings with dynamic text composed from doubt.subject and doubt.userName.

Summary by CodeRabbit
Bug Fixes
Enhanced image accessibility with improved descriptive text for screen readers.
CodeAnt-AI Description
Add descriptive image text for doubt photos

What Changed
Doubt images now use descriptive text based on the doubt subject and the poster’s name instead of a generic label
The fullscreen image view also uses matching descriptive text
Impact
✅ Clearer screen reader descriptions
✅ Better support for users who rely on accessibility tools
✅ More meaningful image labels



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved alt text descriptions for doubt images to include subject and author information, enhancing accessibility for screen reader users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->