### PR TITLE
Fix/live char counter askdoubt

### DIFF
--- a/src/components/AskDoubt.tsx
+++ b/src/components/AskDoubt.tsx
@@ -505,7 +505,15 @@ export default function AskDoubt({ defaultSubject = "", isOpen, onClose, onSucce
                                             <span className="text-green-400 font-semibold">Looks good!</span>
                                         )}
                                         {charCount === 0 && (
-                                            <span className="text-slate-500">Min {minLength} · Max {maxLength} characters</span>
+                                         <span className={`font-medium tabular-nums ${
+                                            charCount > maxLength
+                                                ? "text-red-500 dark:text-red-400"
+                                                : charCount >= maxLength * 0.9
+                                                ? "text-amber-500 dark:text-amber-400"
+                                                : "text-slate-500 dark:text-slate-400"
+                                        }`}>
+                                            {charCount}/{maxLength}
+                                        </span>
                                         )}
                                     </div>
                                     <span className={`text-xs font-semibold ${colorClass}`}>

--- a/src/components/DoubtCard.tsx
+++ b/src/components/DoubtCard.tsx
@@ -324,7 +324,7 @@ export default function DoubtCard({ doubt, onUpdate, onViewAISolution, role, ope
                         >
                             <img
                                 src={doubt.imageUrl}
-                                alt="Doubt"
+                                alt={`Doubt image for ${doubt.subject} by ${doubt.userName}`} 
                                 className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-700"
                             />
                             <div className="absolute inset-0 bg-black/20 opacity-0 group-hover/img:opacity-100 transition-opacity flex items-center justify-center">
@@ -503,7 +503,7 @@ export default function DoubtCard({ doubt, onUpdate, onViewAISolution, role, ope
                     >
                         <img
                             src={doubt.imageUrl ?? undefined}
-                            alt="Full View"
+                            alt={`Full view of doubt image for ${doubt.subject} by ${doubt.userName}`}
                             className="max-w-full max-h-full object-contain rounded-xl shadow-2xl border border-slate-200 dark:border-white/10"
                         />
                     </div>

--- a/src/components/DoubtCard.tsx
+++ b/src/components/DoubtCard.tsx
@@ -200,24 +200,10 @@ export default function DoubtCard({ doubt, onUpdate, onViewAISolution, role, ope
     const getShareUrl = () => `${window.location.origin}/doubts/${doubt.id}`;
 
     const handleShare = async () => {
-        const url = getShareUrl();
         try {
-            if (navigator.clipboard && window.isSecureContext) {
-                await navigator.clipboard.writeText(url);
-            } else {
-                // Fallback for non-HTTPS or older browsers
-                const textArea = document.createElement("textarea");
-                textArea.value = url;
-                textArea.style.position = "fixed";
-                textArea.style.opacity = "0";
-                document.body.appendChild(textArea);
-                textArea.select();
-                document.execCommand("copy");
-                document.body.removeChild(textArea);
-            }
+            await navigator.clipboard.writeText(getShareUrl());
             toast.success(SHARE_MESSAGES.COPY_SUCCESS);
         } catch (error) {
-            console.error("Failed to copy link:", error);
             toast.error(SHARE_MESSAGES.COPY_ERROR);
         }
     };
@@ -338,7 +324,7 @@ export default function DoubtCard({ doubt, onUpdate, onViewAISolution, role, ope
                         >
                             <img
                                 src={doubt.imageUrl}
-                                alt={`Doubt image for ${doubt.subject} by ${doubt.userName}`} 
+                                alt={`Doubt image for ${doubt.subject} by ${doubt.userEmail?.split('@')[0] || 'Anonymous'}`}
                                 className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-700"
                             />
                             <div className="absolute inset-0 bg-black/20 opacity-0 group-hover/img:opacity-100 transition-opacity flex items-center justify-center">
@@ -517,7 +503,7 @@ export default function DoubtCard({ doubt, onUpdate, onViewAISolution, role, ope
                     >
                         <img
                             src={doubt.imageUrl ?? undefined}
-                            alt={`Full view of doubt image for ${doubt.subject} by ${doubt.userName}`}
+                            alt={`Full view of doubt image for ${doubt.subject} by ${doubt.userEmail?.split('@')[0] || 'Anonymous'}`}
                             className="max-w-full max-h-full object-contain rounded-xl shadow-2xl border border-slate-200 dark:border-white/10"
                         />
                     </div>

--- a/src/components/DoubtCard.tsx
+++ b/src/components/DoubtCard.tsx
@@ -200,10 +200,24 @@ export default function DoubtCard({ doubt, onUpdate, onViewAISolution, role, ope
     const getShareUrl = () => `${window.location.origin}/doubts/${doubt.id}`;
 
     const handleShare = async () => {
+        const url = getShareUrl();
         try {
-            await navigator.clipboard.writeText(getShareUrl());
+            if (navigator.clipboard && window.isSecureContext) {
+                await navigator.clipboard.writeText(url);
+            } else {
+                // Fallback for non-HTTPS or older browsers
+                const textArea = document.createElement("textarea");
+                textArea.value = url;
+                textArea.style.position = "fixed";
+                textArea.style.opacity = "0";
+                document.body.appendChild(textArea);
+                textArea.select();
+                document.execCommand("copy");
+                document.body.removeChild(textArea);
+            }
             toast.success(SHARE_MESSAGES.COPY_SUCCESS);
         } catch (error) {
+            console.error("Failed to copy link:", error);
             toast.error(SHARE_MESSAGES.COPY_ERROR);
         }
     };


### PR DESCRIPTION
## **User description**
CLOSES #638 
Replaced the static "Min 20 · Max 500 characters" hint in src/components/AskDoubt.tsx (line 508) with a live color-coded counter that updates as the user types. The counter displays {charCount}/{maxLength} and shifts from gray (normal) → amber (≥ 90% of limit) → red (over limit), giving users real-time visual feedback before they hit submit instead of only seeing an error toast after the fact. This improves UX especially on mobile where users can't easily judge text length, and aligns the empty-state hint with the existing live counter already shown during typing.


___

## **CodeAnt-AI Description**
**Improve text length feedback, sharing, and image labels**

### What Changed
- The AskDoubt text field now shows a live character counter in the empty-state area, with color changes as users approach or pass the limit.
- Sharing a doubt link now works in more browsers and on non-secure pages by using a fallback copy method when the standard clipboard action is unavailable.
- Doubt images now have more descriptive labels, including the subject and author name, so screen readers can announce them more clearly.

### Impact
`✅ Clearer write limits while typing`
`✅ Fewer failed copy-link actions`
`✅ Better screen reader support for doubt images`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
