### PR TITLE
feat(auth): add cross-tab logout synchronization via storage events

### DIFF
--- a/src/components/auth/SessionTracker.tsx
+++ b/src/components/auth/SessionTracker.tsx
@@ -8,6 +8,16 @@ export default function SessionTracker() {
     const SESSION_DURATION = 24 * 60 * 60 * 1000; // 24 hours in milliseconds
     const STORAGE_KEY = "mentorix_last_activity";
 
+    // Dedicated logout broadcast key
+    const LOGOUT_EVENT_KEY = "mentorix_logout";
+
+    // Publishes a cross-tab logout event and signs out the current tab
+    const broadcastLogout = async () => {
+        localStorage.removeItem(STORAGE_KEY);
+        localStorage.setItem(LOGOUT_EVENT_KEY, Date.now().toString());
+        await signOut();
+    }
+
     useEffect(() => {
         if (!user) return;
 
@@ -19,8 +29,7 @@ export default function SessionTracker() {
                 const elapsed = now - parseInt(lastActivity);
                 if (elapsed > SESSION_DURATION) {
                     console.log("[SessionTracker] Session expired. Signing out...");
-                    localStorage.removeItem(STORAGE_KEY);
-                    await signOut();
+                    await broadcastLogout();
                     return;
                 }
             }
@@ -38,8 +47,20 @@ export default function SessionTracker() {
             }
         };
 
+        // Listen for logout broadcasts from other tabs
+        const handleStorageEvent = async (event: StorageEvent) => {
+            if (event.key === LOGOUT_EVENT_KEY) {
+                await signOut();
+            }
+        }
+
         document.addEventListener("visibilitychange", handleVisibilityChange);
-        return () => document.removeEventListener("visibilitychange", handleVisibilityChange);
+        window.addEventListener("storage", handleStorageEvent);
+
+        return () => {
+            document.removeEventListener("visibilitychange", handleVisibilityChange);
+            window.removeEventListener("storage", handleStorageEvent);
+        }
     }, [user, signOut]);
 
     return null;

--- a/src/components/auth/SessionTracker.tsx
+++ b/src/components/auth/SessionTracker.tsx
@@ -11,12 +11,22 @@ export default function SessionTracker() {
     // Dedicated logout broadcast key
     const LOGOUT_EVENT_KEY = "mentorix_logout";
 
+    // Clears session activity data
+    const clearSessionState = () => {
+        localStorage.removeItem(STORAGE_KEY);
+    };
+
     // Publishes a cross-tab logout event and signs out the current tab
     const broadcastLogout = async () => {
-        localStorage.removeItem(STORAGE_KEY);
+        clearSessionState();
         localStorage.setItem(LOGOUT_EVENT_KEY, Date.now().toString());
-        await signOut();
-    }
+        try {
+            await signOut();
+        } 
+        catch (error) {
+            console.error("[SessionTracker] Failed to signout after broadcasting logout.", error);
+        }
+    };
 
     useEffect(() => {
         if (!user) return;
@@ -49,10 +59,18 @@ export default function SessionTracker() {
 
         // Listen for logout broadcasts from other tabs
         const handleStorageEvent = async (event: StorageEvent) => {
-            if (event.key === LOGOUT_EVENT_KEY) {
-                await signOut();
+            if (event.key !== LOGOUT_EVENT_KEY) {
+                return;
             }
-        }
+
+            clearSessionState();
+            try {
+                await signOut();
+            } 
+            catch (error) {
+                console.error("[SessionTracker] Failed to signout after receiving logout broadcast.", error);
+            }
+        };
 
         document.addEventListener("visibilitychange", handleVisibilityChange);
         window.addEventListener("storage", handleStorageEvent);

--- a/src/components/auth/SessionTracker.tsx
+++ b/src/components/auth/SessionTracker.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { useClerk } from "@clerk/nextjs";
 
 export default function SessionTracker() {
@@ -11,21 +11,44 @@ export default function SessionTracker() {
     // Dedicated logout broadcast key
     const LOGOUT_EVENT_KEY = "mentorix_logout";
 
+    // In-flight logout flag
+    const logoutInProgressRef = useRef(false);
+
     // Clears session activity data
     const clearSessionState = () => {
         localStorage.removeItem(STORAGE_KEY);
     };
 
-    // Publishes a cross-tab logout event and signs out the current tab
-    const broadcastLogout = async () => {
-        clearSessionState();
-        localStorage.setItem(LOGOUT_EVENT_KEY, Date.now().toString());
+    // Helper function to perform logout safely
+    const performLogout = async () => {
+        if (logoutInProgressRef.current) {
+            return false;
+        }
+
+        logoutInProgressRef.current = true;
+
         try {
             await signOut();
+            clearSessionState();
+            return true;
         } 
         catch (error) {
-            console.error("[SessionTracker] Failed to signout after broadcasting logout.", error);
+            console.error("[SessionTracker] Failed to sign out.", error);
+            logoutInProgressRef.current = false;
+            return false;
         }
+    };
+
+    // Publishes a cross-tab logout event and signs out the current tab
+    const broadcastLogout = async () => {
+
+        const didLogout = await performLogout();
+
+        if (!didLogout) {
+            return;
+        }
+
+        localStorage.setItem(LOGOUT_EVENT_KEY, Date.now().toString());
     };
 
     useEffect(() => {
@@ -63,13 +86,7 @@ export default function SessionTracker() {
                 return;
             }
 
-            clearSessionState();
-            try {
-                await signOut();
-            } 
-            catch (error) {
-                console.error("[SessionTracker] Failed to signout after receiving logout broadcast.", error);
-            }
+            await performLogout();
         };
 
         document.addEventListener("visibilitychange", handleVisibilityChange);

--- a/src/components/auth/SessionTracker.tsx
+++ b/src/components/auth/SessionTracker.tsx
@@ -11,7 +11,7 @@ export default function SessionTracker() {
     // Dedicated logout broadcast key
     const LOGOUT_EVENT_KEY = "mentorix_logout";
 
-    // In-flight logout flag
+    // Prevent concurrent logout race conditions
     const logoutInProgressRef = useRef(false);
 
     // Clears session activity data
@@ -19,7 +19,7 @@ export default function SessionTracker() {
         localStorage.removeItem(STORAGE_KEY);
     };
 
-    // Helper function to perform logout safely
+    // Handles logout with concurrency and error protection
     const performLogout = async () => {
         if (logoutInProgressRef.current) {
             return false;
@@ -39,7 +39,7 @@ export default function SessionTracker() {
         }
     };
 
-    // Publishes a cross-tab logout event and signs out the current tab
+    // Signs out the current tab and broadcasts logout to other tabs
     const broadcastLogout = async () => {
 
         const didLogout = await performLogout();
@@ -48,7 +48,12 @@ export default function SessionTracker() {
             return;
         }
 
-        localStorage.setItem(LOGOUT_EVENT_KEY, Date.now().toString());
+        try {
+            localStorage.setItem(LOGOUT_EVENT_KEY, Date.now().toString());
+        } 
+        catch (error) {
+            console.error("[SessionTracker] Failed to publish logout broadcast.", error);
+        }
     };
 
     useEffect(() => {


### PR DESCRIPTION
## **User description**
## Target file: src/components/auth/SessionTracker.tsx

## Description
- Implements cross-tab logout synchronization in `SessionTracker` using the browser's storage event and a dedicated logout broadcast key to publish logout event across tabs.
- Previously, when a session expired, only the tab that detected the expiration would sign the user out. Other open tabs remained authenticated until they were refreshed or Clerk performed a session validation.
- Kept logout synchronization separate from activity tracking logic.

## Related Issue
- Fixes #660 

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Documentation update (README, guides, comments)
- [ ] Style / UI change (no logic change)
- [ ] Code refactor (no behavior change)
- [ ] Test addition or update
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## How Has This Been Tested?
<!-- Describe the tests you ran to verify your changes. -->
- [x] Tested locally with `npm run dev`
- [x] `tsc --noEmit` passed successfully

## Checklist
- [x] I have tested my changes locally (`npm run dev`)
- [x] My code follows the existing code style (TypeScript, Tailwind, no `any` types)
- [x] I have not introduced unrelated changes (each PR should address one issue)
- [x] I have added comments where necessary
- [x] My branch is up to date with `main`
- [x] I have linked the related issue above

## Additional details
- Label: GSSoC'2026, type:*, level:*, quality:*
- Closes #660


___

## **CodeAnt-AI Description**
**Keep logouts in sync across open tabs**

### What Changed
- When a session expires in one tab, all other open tabs now sign the user out too.
- Logging out from any tab clears the saved activity state and triggers a shared logout event.
- Logout listeners are cleaned up when the page unloads, so only active tabs respond.

### Impact
`✅ Fewer signed-in tabs after logout`
`✅ Fewer stale sessions in open windows`
`✅ Clearer account state across tabs`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved session logout behavior across multiple open browser tabs. Logging out in one tab now automatically signs out all other open tabs.
  * Updated session-expiration handling so it uses the same cross-tab logout flow.
  * Ensures related local session activity data is cleared after a successful sign-out.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->