### PR TITLE
feat: protect /rooms and /ask-ai routes using clerkMiddleware

### DIFF
--- a/src/middleware.tsx
+++ b/src/middleware.tsx
@@ -5,7 +5,13 @@ import { db } from '@/configs/db';
 import { usersTable } from '@/configs/schema';
 import { eq } from 'drizzle-orm';
 
-const isProtectedRoute = createRouteMatcher(['/dashboard(.*)', '/profile(.*)', '/admin(.*)']);
+const isProtectedRoute = createRouteMatcher([
+    '/dashboard(.*)',
+    '/profile(.*)',
+    '/admin(.*)',
+    '/rooms(.*)',
+    '/ask-ai(.*)'
+]);
 
 const isPublicRoute = createRouteMatcher(['/sign-in', '/sign-up', '/api/inngest', '/', '/public-rooms(.*)', '/onboarding']);
 


### PR DESCRIPTION
## **User description**
---

# feat(middleware): protect /rooms and /ask-ai routes via clerkMiddleware

## Related Issue
Closes #347

---

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Documentation Update
- [ ] Refactor
- [ ] Chore

---

## Description

This PR closes a routing security hole where unauthenticated users could directly navigate to the `/rooms` (Virtual Classrooms) and `/ask-ai` (AI Doubt Solver) pages in their browser.

Although the backend API routes correctly rejected requests with `401 Unauthorized`, the client-side pages would still render and fire fetch requests, resulting in confusing toast errors and broken/empty layouts for logged-out users.

The fix extends the `isProtectedRoute` matcher in `src/middleware.tsx` to include `/rooms(.*)` and `/ask-ai(.*)`, so unauthenticated users are cleanly redirected to the Clerk sign-in page before any page rendering or API call occurs.

---

## Changes Made

- **`src/middleware.tsx`**: Added `/rooms(.*)` and `/ask-ai(.*)` to the `isProtectedRoute` `createRouteMatcher` array. Also reformatted the existing entries (`/dashboard(.*)`, `/profile(.*)`, `/admin(.*)`) into a multi-line array for readability and consistency.

---

## How to Verify Locally

1. Start the dev server:
```bash
npm run dev
```

2. Sign out of your account (or open a fresh incognito/private window).

3. Try directly navigating to:
   - `http://localhost:3000/rooms`
   - `http://localhost:3000/ask-ai`

4. **Expected behaviour**: You are immediately redirected to the Clerk sign-in page with no page rendering, no toast errors, and no API calls fired.

5. **Before this fix**: The page would render partially and display toast errors like `"Failed to load classrooms"` due to API 401 responses.

---

## Checklist

- [x] My code follows the project's coding style
- [x] I have tested my changes locally
- [x] No existing functionality has been broken
- [x] All checks and linting pass successfully (`tsc --noEmit` exits with code 0)

---

## GSSoC'26 Contributor Declaration

- [x] I confirm that I am a participant of GSSoC'26
- [x] I have followed the contribution guidelines of this project
- [x] This PR is ready for review

---


___

## **CodeAnt-AI Description**
Prevent logged-out users from opening the Rooms and Ask AI pages

### What Changed
- Guests are now redirected to sign in before the `/rooms` and `/ask-ai` pages load
- This blocks the broken page states and error messages that used to appear when unauthenticated users opened those links directly

### Impact
`✅ Fewer login-state errors on protected pages`
`✅ Cleaner sign-in flow for guest users`
`✅ No broken Rooms or Ask AI page loads for logged-out visitors`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
