### PR TITLE
[Feature]: Add tooltips to icon-only buttons in classroom view

### DIFF
--- a/src/components/DoubtCard.tsx
+++ b/src/components/DoubtCard.tsx
@@ -338,34 +338,42 @@ export default function DoubtCard({ doubt, onUpdate, onViewAISolution, role, ope
                 {!doubt.isPendingSync && (
                     <div className="mt-auto pt-6 border-t border-slate-200 dark:border-white/5 flex flex-col md:flex-row items-stretch md:items-center justify-between gap-4">
                         <div className="flex flex-wrap items-center gap-2.5 flex-1">
-                            <button
-                                onClick={() => handleAction("like")}
-                                disabled={isLiking}
-                                aria-label={doubt.hasLiked ? ARIA_LABELS.UNLIKE_DOUBT : ARIA_LABELS.LIKE_DOUBT}
-                                aria-busy={isLiking}
-                                className={`flex-1 sm:flex-none flex items-center justify-center gap-2.5 px-6 py-3 rounded-2xl transition-all group/btn ${ doubt.hasLiked ? "bg-blue-600/20 text-blue-400 border border-blue-500/30 shadow-lg shadow-blue-500/10" : "bg-white/5 hover:bg-white/10 text-slate-400 hover:text-white border border-white/5" }`}
-                            >
-                                <ThumbsUp className={`w-4 h-4 ${isLiking ? 'animate-pulse' : 'group-hover/btn:scale-110 transition-transform'} ${doubt.hasLiked ? 'fill-blue-400' : ''}`} />
-                                <span className="text-xs font-black">{likes}</span>
-                            </button>
+                            {/* Like Button with Tooltip */}
+                            <Tooltip>
+                                <TooltipTrigger asChild>
+                                    <button
+                                        onClick={() => handleAction("like")}
+                                        disabled={isLiking}
+                                        aria-label={doubt.hasLiked ? ARIA_LABELS.UNLIKE_DOUBT : ARIA_LABELS.LIKE_DOUBT}
+                                        aria-busy={isLiking}
+                                        className={`flex-1 sm:flex-none flex items-center justify-center gap-2.5 px-6 py-3 rounded-2xl transition-all group/btn ${ doubt.hasLiked ? "bg-blue-600/20 text-blue-400 border border-blue-500/30 shadow-lg shadow-blue-500/10" : "bg-white/5 hover:bg-white/10 text-slate-400 hover:text-white border border-white/5" }`}
+                                    >
+                                        <ThumbsUp className={`w-4 h-4 ${isLiking ? 'animate-pulse' : 'group-hover/btn:scale-110 transition-transform'} ${doubt.hasLiked ? 'fill-blue-400' : ''}`} />
+                                        <span className="text-xs font-black">{likes}</span>
+                                    </button>
+                                </TooltipTrigger>
+                                <TooltipContent>{doubt.hasLiked ? "Unlike this doubt" : "Like this doubt"}</TooltipContent>
+                            </Tooltip>
 
+                            {/* Bookmark Button with Tooltip */}
                             {isSignedIn && (
                                 <Tooltip>
-                                <TooltipTrigger asChild>
-                                <button
-                                    onClick={handleBookmark}
-                                    disabled={isBookmarking}
-                                    aria-label={doubt.hasBookmarked ? ARIA_LABELS.REMOVE_BOOKMARK : ARIA_LABELS.BOOKMARK_DOUBT}
-                                    aria-busy={isBookmarking}
-                                    className={`flex items-center justify-center p-3 rounded-2xl transition-all ${ doubt.hasBookmarked ? "bg-purple-600/20 text-purple-400 border border-purple-500/30 shadow-lg shadow-purple-500/10" : "bg-white/5 hover:bg-white/10 text-slate-400 hover:text-white border border-white/5" }`}
-                                >
-                                    <Bookmark className={`w-4 h-4 ${isBookmarking ? 'animate-pulse' : ''} ${doubt.hasBookmarked ? 'fill-purple-400' : ''}`} />
-                                </button>
-                                </TooltipTrigger>
-                                <TooltipContent>{doubt.hasBookmarked ? ARIA_LABELS.REMOVE_BOOKMARK : ARIA_LABELS.BOOKMARK_DOUBT}</TooltipContent>
+                                    <TooltipTrigger asChild>
+                                        <button
+                                            onClick={handleBookmark}
+                                            disabled={isBookmarking}
+                                            aria-label={doubt.hasBookmarked ? ARIA_LABELS.REMOVE_BOOKMARK : ARIA_LABELS.BOOKMARK_DOUBT}
+                                            aria-busy={isBookmarking}
+                                            className={`flex items-center justify-center p-3 rounded-2xl transition-all ${ doubt.hasBookmarked ? "bg-purple-600/20 text-purple-400 border border-purple-500/30 shadow-lg shadow-purple-500/10" : "bg-white/5 hover:bg-white/10 text-slate-400 hover:text-white border border-white/5" }`}
+                                        >
+                                            <Bookmark className={`w-4 h-4 ${isBookmarking ? 'animate-pulse' : ''} ${doubt.hasBookmarked ? 'fill-purple-400' : ''}`} />
+                                        </button>
+                                    </TooltipTrigger>
+                                    <TooltipContent>{doubt.hasBookmarked ? ARIA_LABELS.REMOVE_BOOKMARK : ARIA_LABELS.BOOKMARK_DOUBT}</TooltipContent>
                                 </Tooltip>
                             )}
 
+                            {/* Share Dropdown */}
                             <DropdownMenu>
                                 <DropdownMenuTrigger asChild>
                                     <button
@@ -425,22 +433,34 @@ export default function DoubtCard({ doubt, onUpdate, onViewAISolution, role, ope
                         <div className="flex items-center gap-2.5">
                             {(isOwner || isTeacher) && (
                                 <div className="flex items-center gap-1.5 p-1.5 bg-slate-100 dark:bg-white/5 rounded-2xl border border-slate-200 dark:border-white/5 flex-1 sm:flex-none justify-center">
+                                    {/* Edit Button with Tooltip */}
                                     {isOwner && (
-                                        <button
-                                            onClick={() => setIsEditModalOpen(true)}
-                                            className="flex-1 sm:flex-none p-3 rounded-xl hover:bg-blue-600/20 text-slate-500 dark:text-slate-500 hover:text-blue-400 transition-all group/edit"
-                                            aria-label="Edit doubt"
-                                        >
-                                            <Edit2 className="w-4 h-4 group-hover/edit:scale-110 transition-transform" />
-                                        </button>
+                                        <Tooltip>
+                                            <TooltipTrigger asChild>
+                                                <button
+                                                    onClick={() => setIsEditModalOpen(true)}
+                                                    className="flex-1 sm:flex-none p-3 rounded-xl hover:bg-blue-600/20 text-slate-500 dark:text-slate-500 hover:text-blue-400 transition-all group/edit"
+                                                    aria-label="Edit doubt"
+                                                >
+                                                    <Edit2 className="w-4 h-4 group-hover/edit:scale-110 transition-transform" />
+                                                </button>
+                                            </TooltipTrigger>
+                                            <TooltipContent>Edit doubt</TooltipContent>
+                                        </Tooltip>
                                     )}
-                                    <button
-                                        onClick={() => setIsDeleteDialogOpen(true)}
-                                        className="flex-1 sm:flex-none p-3 rounded-xl hover:bg-red-500/20 text-slate-500 dark:text-slate-500 hover:text-red-400 transition-all group/trash"
-                                        aria-label="Delete doubt"
-                                    >
-                                        <Trash2 className="w-4 h-4 group-hover/trash:scale-110 transition-transform" />
-                                    </button>
+                                    {/* Delete Button with Tooltip */}
+                                    <Tooltip>
+                                        <TooltipTrigger asChild>
+                                            <button
+                                                onClick={() => setIsDeleteDialogOpen(true)}
+                                                className="flex-1 sm:flex-none p-3 rounded-xl hover:bg-red-500/20 text-slate-500 dark:text-slate-500 hover:text-red-400 transition-all group/trash"
+                                                aria-label="Delete doubt"
+                                            >
+                                                <Trash2 className="w-4 h-4 group-hover/trash:scale-110 transition-transform" />
+                                            </button>
+                                        </TooltipTrigger>
+                                        <TooltipContent>Delete doubt</TooltipContent>
+                                    </Tooltip>
                                 </div>
                             )}
                             <button


### PR DESCRIPTION
## Description
Added tooltips to icon-only buttons in DoubtCard component for better UX and accessibility. Users can now hover over action buttons to understand their functionality without clicking.

**Changes made:**
- Added `Tooltip` wrapper around **Like** button with "Like this doubt" / "Unlike this doubt"
- Added `Tooltip` wrapper around **Edit** button with "Edit doubt"
- Added `Tooltip` wrapper around **Delete** button with "Delete doubt"
- **Bookmark** and **Pin** buttons already had tooltips (kept as-is)
- Used existing `TooltipProvider` wrapper (already present in component)

## Related Issue
Closes #649

## Type of Change
- [x] New feature (non-breaking change that adds functionality)

## Screenshots (if UI change)

| Before | After |
| :---: | :---: |
| (No tooltip on Edit/Delete/Like) | ![Tooltip Demo](https://i.imgur.com/placeholder.png) |

**Actual Screenshot:**
<img width="1905" height="964" alt="Screenshot 2026-06-18 220344" src="https://github.com/user-attachments/assets/3be8dbc4-38dc-40f1-8e29-b696cdcb6603" />


## How Has This Been Tested?
- [x] Tested locally with `npm run dev`
- [x] Verified hover tooltips appear on all icon buttons
- [x] Verified keyboard focus triggers tooltips (Tab key)
- [x] Verified dark mode compatibility

## Checklist
- [x] I have tested my changes locally (`npm run dev`)
- [x] My code follows the existing code style (TypeScript, Tailwind, no `any` types)
- [x] I have not introduced unrelated changes (each PR should address one issue)
- [x] I have added comments where necessary
- [x] My branch is up to date with `main`
- [x] I have linked the related issue above
- [x] Screenshots are included (if this is a UI change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added helpful tooltips to action buttons (Like, Bookmark, Edit, and Delete) to provide improved user guidance and enhance interface accessibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->