### PR TITLE
fix: add reduced-motion support to chats and modals

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -102,3 +102,24 @@ body {
   scrollbar-width: thin;
   scrollbar-color: #1e293b #020617;
 }
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+
+  .animate-spin,
+  .animate-pulse,
+  .animate-bounce {
+    animation: none !important;
+  }
+}

--- a/components/DoubtRepliesModal.tsx
+++ b/components/DoubtRepliesModal.tsx
@@ -47,8 +47,17 @@ export default function DoubtRepliesModal({ doubt, isOpen, onClose, onReplyChang
     const [menuOpenId, setMenuOpenId] = useState<number | null>(null);
     const [isFullscreenImageOpen, setIsFullscreenImageOpen] = useState(false);
     const [fullscreenImageUrl, setFullscreenImageUrl] = useState("");
+    const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
     
     const chatEndRef = useRef<HTMLDivElement>(null);
+
+    useEffect(() => {
+        const mediaQuery = window.matchMedia("(prefers-reduced-motion: reduce)");
+        const updatePreference = () => setPrefersReducedMotion(mediaQuery.matches);
+        updatePreference();
+        mediaQuery.addEventListener("change", updatePreference);
+        return () => mediaQuery.removeEventListener("change", updatePreference);
+    }, []);
 
     useEffect(() => {
         if (isOpen) {
@@ -60,7 +69,9 @@ export default function DoubtRepliesModal({ doubt, isOpen, onClose, onReplyChang
     }, [isOpen, doubt.id, doubt.userName]);
 
     useEffect(() => {
-        chatEndRef.current?.scrollIntoView({ behavior: "smooth" });
+        chatEndRef.current?.scrollIntoView({
+            behavior: prefersReducedMotion ? "auto" : "smooth"
+        });
     }, [replies]);
 
     const fetchReplies = async () => {


### PR DESCRIPTION
Closes #556\n\n### What changed\n- Added a global  override to minimize animations, transitions, and smooth scrolling\n- Disabled motion-heavy utility animations when users prefer reduced motion\n- Switched reply modal auto-scroll behavior to  when reduced motion is enabled\n\n### Validation\n- \n- 
> nextjs-boilerplate-1@0.1.0 lint
> next lint could not be completed in this shell because  is not installed locally\n- 
> nextjs-boilerplate-1@0.1.0 build
> next build could not be completed in this shell because  is not installed locally\n\n### Notes\nThis is intentionally scoped to the app-wide motion behavior and one modal interaction that directly affects user comfort.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced accessibility support for reduced motion preferences. The app now respects this system-level setting, automatically disabling all animations and smooth scrolling when enabled. Changes apply throughout the interface, including chat features and interactive elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->