### PR TITLE
fix: prevent role escalation when joining classrooms

### DIFF
--- a/src/app/api/rooms/join/route.ts
+++ b/src/app/api/rooms/join/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { db } from '@/configs/db';
-import { classroomsTable, membershipsTable, usersTable } from '@/configs/schema';
+import { classroomsTable, membershipsTable } from '@/configs/schema';
 import { eq, and } from 'drizzle-orm';
 import { currentUser } from '@clerk/nextjs/server';
 import { checkUserBlock } from '@/lib/auth-utils';
@@ -63,9 +63,12 @@ export async function POST(req: Request) {
             return NextResponse.json({ error: 'Already a member of this classroom' }, { status: 400 });
         }
 
-        // 3. Get user role to determine membership role
-        const [dbUser] = await db.select().from(usersTable).where(eq(usersTable.email, email));
-        const role = dbUser?.role || 'student';
+        // 3. Joining via an invite code always grants a baseline 'student' membership
+        //    for this classroom. A user's global profile role (e.g. self-selected
+        //    'teacher' at onboarding) must NEVER be copied into classroom membership --
+        //    real teacher access to a classroom only comes from being its owner
+        //    (classroomsTable.teacherEmail) or an explicit promotion by the owner/admin.
+        const role = 'student' as const;
 
         // 4. Add membership (the foreign key ensures referential integrity; the unique
         //    constraint on memberships(userEmail, classroomId) prevents duplicates at the DB level too)


### PR DESCRIPTION
## **User description**
## Description

Fixes a classroom privilege escalation issue in the invite-based join flow.

Previously, the join endpoint derived a user's classroom membership role from their global profile role. This allowed classroom permissions to be influenced by a global role value rather than by classroom-specific authorization.

This change ensures that users joining a classroom via an invite code are always assigned a baseline `student` membership role. Teacher-level classroom access remains restricted to classroom owners and explicitly promoted members.

### Changes Made

* Removed membership role derivation from `usersTable.role`
* Assigned `student` as the default role for invite-based joins
* Removed the now-unused `usersTable` import from the join route

## Related Issue

Closes #680 

## Type of Change

* [x] Bug fix (non-breaking change that fixes an issue)
* [ ] New feature (non-breaking change that adds functionality)
* [ ] Documentation update (README, guides, comments)
* [ ] Style / UI change (no logic change)
* [ ] Code refactor (no behavior change)
* [ ] Test addition or update
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## How Has This Been Tested?

* [x] Tested locally with `npm run dev`
* [x] Verified successful production build with `npm run build`
* [ ] Verified on mobile viewport (375px)
* [ ] Verified on desktop viewport (1440px)

## Checklist

* [x] I have tested my changes locally (`npm run dev`)
* [x] My code follows the existing code style (TypeScript, Tailwind, no `any` types)
* [x] I have not introduced unrelated changes (each PR should address one issue)
* [x] I have added comments where necessary
* [x] My branch is up to date with `main`
* [x] I have linked the related issue above
* [ ] Screenshots are included (if this is a UI change)


___

## **CodeAnt-AI Description**
**Prevent classroom invite joins from copying a user's global role**

### What Changed
- Joining a classroom through an invite now always adds the user as a student
- Classroom access no longer depends on a user's global profile role from onboarding
- Teacher-level classroom access stays limited to classroom owners or users who were explicitly promoted

### Impact
`✅ Fewer classroom role escalation cases`
`✅ Safer invite-based classroom joins`
`✅ Clearer student vs teacher access`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed classroom membership role assignment when joining via invite code. Users now consistently receive the 'student' role to ensure proper separation between global profile roles and classroom-specific permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->