### PR TITLE
fix: user name to email migration for doubt api routes

### DIFF
--- a/src/app/api/doubts/[id]/route.ts
+++ b/src/app/api/doubts/[id]/route.ts
@@ -61,21 +61,24 @@ export async function GET(
             .innerJoin(tagsTable, eq(doubtTagsTable.tagId, tagsTable.id))
             .where(eq(doubtTagsTable.doubtId, doubtId));
 
-        // Interaction flags
-        const { searchParams } = new URL(req.url);
-        const userName = searchParams.get("userName");
-        const userLikesCheck = userName || email;
-
+        // Interaction flags.
+        //
+        // `hasLiked` is derived strictly from the authenticated session. A leftover
+        // `userName` query param from the userName -> userEmail migration used to be
+        // accepted here and compared against `likesTable.userEmail`. That was both
+        // dead (a client handle never matched the email column) and unsafe: it let an
+        // unauthenticated caller pass an arbitrary identifier to probe whether a
+        // specific user had liked a doubt. We now trust only the server-side session.
         let hasLiked = false;
         let hasBookmarked = false;
 
-        if (userLikesCheck) {
+        if (email) {
             const [likeRecord] = await db
                 .select()
                 .from(likesTable)
                 .where(
                     and(
-                        eq(likesTable.userEmail, userLikesCheck),
+                        eq(likesTable.userEmail, email),
                         eq(likesTable.doubtId, doubtId)
                     )
                 )

--- a/src/app/doubts/[id]/DoubtPermalinkClient.tsx
+++ b/src/app/doubts/[id]/DoubtPermalinkClient.tsx
@@ -22,9 +22,7 @@ export default function DoubtPermalinkClient({ initialDoubt }: DoubtPermalinkCli
 
     const fetchDoubt = async () => {
         try {
-            const userName = localStorage.getItem("anonymous_user");
-            const url = `/api/doubts/${initialDoubt.id}` + (userName ? `?userName=${encodeURIComponent(userName)}` : "");
-            const res = await fetch(url);
+            const res = await fetch(`/api/doubts/${initialDoubt.id}`);
             if (res.ok) {
                 const data = await res.json();
                 setDoubt(data);

--- a/src/app/public-rooms/page.tsx
+++ b/src/app/public-rooms/page.tsx
@@ -85,7 +85,6 @@ export default function PublicRoomsPage() {
             if (!hasMore) return null;
         }
         
-        const userName = typeof window !== 'undefined' ? localStorage.getItem("anonymous_user") : "";
         const params = new URLSearchParams();
         
         if (filter !== "All") {
@@ -109,7 +108,6 @@ export default function PublicRoomsPage() {
             params.append("sort", sort);
         }
 
-        if (userName) params.append("userName", userName);
         params.append("page", (pageIndex + 1).toString());
         params.append("limit", String(PAGE_SIZE));
         
@@ -159,8 +157,7 @@ export default function PublicRoomsPage() {
             const query = searchQuery.toLowerCase();
             const contentMatch = d.content?.toLowerCase().includes(query);
             const subjectMatch = d.subject?.toLowerCase().includes(query);
-            const userNameMatch = d.userName?.toLowerCase().includes(query);
-            if (!contentMatch && !subjectMatch && !userNameMatch) {
+            if (!contentMatch && !subjectMatch) {
                 return false;
             }
         }

--- a/src/app/rooms/[id]/page.tsx
+++ b/src/app/rooms/[id]/page.tsx
@@ -147,8 +147,6 @@ export default function ClassroomPage() {
       : activeTab === "community"
         ? "community"
         : "ai";
-  const userName =
-    typeof window !== "undefined" ? localStorage.getItem("anonymous_user") : "";
 
   const fetcher = (url: string) => fetch(url).then((res) => res.json());
   const updateSort = (nextSort: DoubtSortValue) => {
@@ -176,7 +174,6 @@ export default function ClassroomPage() {
     if (activeTab === "insights") return null;
     const params = new URLSearchParams({
       classroomId: String(id),
-      userName: userName || "",
       type: String(type),
       page: String(pageIndex + 1),
       limit: String(PAGE_SIZE),

--- a/src/components/AskDoubt.tsx
+++ b/src/components/AskDoubt.tsx
@@ -333,7 +333,7 @@ export default function AskDoubt({ defaultSubject = "", isOpen, onClose, onSucce
                     return;
                 }
 
-                const payload = { userName, subject, content, imageUrl, classroomId, type, tags };
+                const payload = { subject, content, imageUrl, classroomId, type, tags };
                 const { addToQueue } = await import("@/lib/offline/syncQueue");
                 await addToQueue("/api/doubts", "POST", payload);
 
@@ -358,7 +358,7 @@ export default function AskDoubt({ defaultSubject = "", isOpen, onClose, onSucce
             const method = doubtToEdit ? "PATCH" : "POST";
             const body = doubtToEdit
                 ? { action: "edit", content, subject, imageUrl, tags }
-                : { userName, subject, content, imageUrl, classroomId, type, tags };
+                : { subject, content, imageUrl, classroomId, type, tags };
 
             const res = await fetch(url, {
                 method,


### PR DESCRIPTION
## Description

Completes the `userName` to `userEmail` identity migration by removing the remaining dead and unsafe `userName` references it left behind.

> **Important finding:** the three TypeScript build errors reported in #658 are **already fixed on `main`.** They were resolved by **PR #562** (`fix(#316)`, Jun 13: fixed `src/lib/validations/doubt.ts` and `src/app/api/doubts/action/[id]/route.ts`) and **PR #587** (Jun 18: fixed `src/app/api/doubts/[id]/route.ts:78`). Running the exact reproduction from the issue on the current `main` is clean:

```bash
$ npx tsc --noEmit
$ echo $?
0
```

> So this PR is **not** "fix the build" (the build already compiles). It finishes the migration by deleting the leftover `userName` plumbing that PR #562/#587 did not reach, one piece of which is also a small security footgun.

## Related Issue

Closes #658

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Code refactor (no behavior change)

## What this PR changes

**Server-side**
- `src/app/api/doubts/[id]/route.ts`: removed the leftover `userName` query param. It was read from the URL and compared against `likesTable.userEmail`, which implied:
   1. It was **dead**: a client handle never equals an email column, so the `hasLiked` branch never matched for it.
   2. It was **unsafe**: an unauthenticated caller could pass `?userName=victim@example.com` to probe whether a specific user had liked a doubt.

`hasLiked` is now derived strictly from the authenticated session.

**Client (dead plumbing removed)**
- `src/app/doubts/[id]/DoubtPermalinkClient.tsx`: stopped appending the dead `?userName=` param when fetching the doubt detail.
- `src/app/public-rooms/page.tsx`: removed the dead `userName` read and append to the doubts list endpoint (the list route never read it), and removed the dead client-side search match on `d.userName` (the field no longer exists after the migration).
- `src/app/rooms/[id]/page.tsx`: removed the dead `userName` read + param on the classroom doubts list URL.
- `src/components/AskDoubt.tsx`: stopped sending the dead `userName` field in the create-doubt payload (the server's Zod schema already strips unknown keys).

No user-visible behavior changes: the cosmetic local "anonymous handle" label shown to the author while composing is untouched; only dead/ignored data paths are removed.

### Approach

The migration in PR #562 renamed the `likes` identity column and the validation schema from `userName` to `userEmail`, and PR #587 fixed the last compile error. But several call sites kept constructing and sending a `userName` value that the server no longer consumes. This PR traces every remaining `userName` reference in the doubts/replies request path and removes it, so the rename is actually complete and the detail route no longer trusts a client-supplied identifier for the like-status check.

## Testing

- [x] `npx tsc --noEmit`: clean (0 errors), both before and after.
- [x] `npm test`: full suite green (36 suites / 185 tests).
- [x] `npx eslint . --ext .ts,.tsx`: clean on changed files.
- [x] Verified the existing `doubts.test.ts` / `doubts-id.test.ts` still pass (the `hasLiked` change keeps the same select order).

## Edge cases

- Unauthenticated detail fetch: previously the `userName` fallback could run a like query for an arbitrary identifier; now the query is skipped entirely when there is no session, so anonymous reads do no `likes` lookup.
- Offline create queue (`AskDoubt`): the queued payload no longer carries the dead `userName`; replay still validates because the server schema never required it.

## Checklist

- [x] Code follows existing style (TypeScript, no new `any`)
- [x] No unrelated changes (single-purpose: finish the `userName` migration)
- [x] Added explanatory comments where the dead/unsafe path was removed
- [x] No new dependencies; no schema/migration changes
- [x] Linked the related issue above


___

## **CodeAnt-AI Description**
**Stop using stale anonymous usernames in doubt requests and results**

### What Changed
- Doubt details now use the signed-in session only to show whether the current user has liked a post, instead of accepting a `userName` value from the page URL.
- The doubt list and doubt detail pages no longer send the old anonymous username with their requests.
- Search on the public rooms page now matches doubt content and subject only, so usernames no longer affect results.
- New doubt submissions, including offline queued ones, no longer include the removed username field.

### Impact
`✅ Fewer incorrect like states`
`✅ Lower risk of exposing who liked a doubt`
`✅ Cleaner doubt search results`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
