### PR TITLE
fix: rename package name to doubtdesk

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "nextjs-boilerplate-1",
+  "name": "doubtdesk",
   "version": "0.1.0",
   "private": true,
   "scripts": {

--- a/src/__tests__/lib/anonymity.test.ts
+++ b/src/__tests__/lib/anonymity.test.ts
@@ -52,12 +52,12 @@ describe("anonymity: fail closed in production", () => {
     const origSalt = process.env.ANON_HANDLE_SALT;
 
     afterEach(() => {
-        if (origEnv === undefined) delete process.env.NODE_ENV;
-        else process.env.NODE_ENV = origEnv;
+        if (origEnv === undefined) delete mutableEnv.NODE_ENV;
+        else mutableEnv.NODE_ENV = origEnv;
         if (origSalt === undefined) delete process.env.ANON_HANDLE_SALT;
         else process.env.ANON_HANDLE_SALT = origSalt;
     });
-    });
+    
 
     it("throws when ANON_HANDLE_SALT is missing in production", () => {
         delete process.env.ANON_HANDLE_SALT;

--- a/src/app/api/doubts/[id]/accept/route.test.ts
+++ b/src/app/api/doubts/[id]/accept/route.test.ts
@@ -1,4 +1,3 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
 import { NextRequest } from "next/server";
 
 // ── Mutable per-test state shared between mocks ──────────────────────────────
@@ -22,22 +21,22 @@ let mockReply: {
 
 let mockUpdatedDoubt: { id: number } | null = { id: 1 };
 
-const inngestSend = vi.fn();
+const mockInngestSend = jest.fn();
 
 // ── Mocks ─────────────────────────────────────────────────────────────────────
-vi.mock("@clerk/nextjs/server", () => ({
-    currentUser: vi.fn().mockResolvedValue({
+jest.mock("@clerk/nextjs/server", () => ({
+    currentUser: jest.fn().mockResolvedValue({
         primaryEmailAddress: { emailAddress: "asker@test.com" },
     }),
 }));
 
-vi.mock("@/inngest/client", () => ({
-    inngest: { send: inngestSend },
+jest.mock("@/inngest/client", () => ({
+    inngest: { send: mockInngestSend },
 }));
 
-let selectCallCount = 0;
+let mockSelectCallCount = 0;
 
-vi.mock("@/configs/db", () => {
+jest.mock("@/configs/db", () => {
     const makeSelectChain = (result: unknown[]) => ({
         from: () => ({ where: () => ({ limit: () => Promise.resolve(result) }) }),
     });
@@ -47,21 +46,21 @@ vi.mock("@/configs/db", () => {
 
     return {
         db: {
-            select: vi.fn().mockImplementation(() => {
-                selectCallCount += 1;
-                if (selectCallCount === 1) {
+            select: jest.fn().mockImplementation(() => {
+                mockSelectCallCount += 1;
+                if (mockSelectCallCount === 1) {
                     return makeSelectChain(mockDoubt ? [mockDoubt] : []);
                 }
                 return makeSelectChain(mockReply ? [mockReply] : []);
             }),
-            update: vi.fn().mockImplementation(() =>
+            update: jest.fn().mockImplementation(() =>
                 makeUpdateChain(mockUpdatedDoubt ? [mockUpdatedDoubt] : [])
             ),
         },
     };
 });
 
-vi.mock("@/configs/schema", () => ({
+jest.mock("@/configs/schema", () => ({
     doubtsTable: {
         id: "id",
         userEmail: "userEmail",
@@ -71,17 +70,18 @@ vi.mock("@/configs/schema", () => ({
     repliesTable: { id: "id", doubtId: "doubtId", userEmail: "userEmail" },
 }));
 
-vi.mock("drizzle-orm", async (importOriginal) => {
-    const actual = await importOriginal<typeof import("drizzle-orm")>();
+jest.mock("drizzle-orm", () => {
+    const actual = jest.requireActual("drizzle-orm") as typeof import("drizzle-orm");
     return {
         ...actual,
-        eq: vi.fn(),
-        and: vi.fn(),
-        or: vi.fn(),
-        ne: vi.fn(),
-        isNull: vi.fn(),
+        eq: jest.fn(),
+        and: jest.fn(),
+        or: jest.fn(),
+        ne: jest.fn(),
+        isNull: jest.fn(),
     };
 });
+
 
 // ── Helper ────────────────────────────────────────────────────────────────────
 function makeRequest(replyId: number): NextRequest {
@@ -103,9 +103,9 @@ async function callPost(replyId = 42) {
 // ── Tests ─────────────────────────────────────────────────────────────────────
 describe("POST /api/doubts/[id]/accept — idempotency (issue #687)", () => {
     beforeEach(() => {
-        vi.clearAllMocks();
-        inngestSend.mockReset();
-        selectCallCount = 0;
+        jest.clearAllMocks();
+        mockInngestSend.mockReset();
+        mockSelectCallCount = 0;
 
         // Default: unsolved doubt, valid reply, state-changing update
         mockDoubt = { userEmail: "asker@test.com", isSolved: "unsolved", solvedReplyId: null };
@@ -121,8 +121,8 @@ describe("POST /api/doubts/[id]/accept — idempotency (issue #687)", () => {
         expect(body.success).toBe(true);
         expect(body.message).toBe("Answer accepted successfully");
         // karma event fired exactly once
-        expect(inngestSend).toHaveBeenCalledTimes(1);
-        expect(inngestSend).toHaveBeenCalledWith(
+        expect(mockInngestSend).toHaveBeenCalledTimes(1);
+        expect(mockInngestSend).toHaveBeenCalledWith(
             expect.objectContaining({ name: "karma/answer.accepted" })
         );
     });
@@ -140,31 +140,31 @@ describe("POST /api/doubts/[id]/accept — idempotency (issue #687)", () => {
         expect(body.success).toBe(true);
         expect(body.message).toBe("Answer was already accepted (no-op)");
         // No karma event fired
-        expect(inngestSend).not.toHaveBeenCalled();
+        expect(mockInngestSend).not.toHaveBeenCalled();
     });
 
     it("karmaScore is awarded only once after two POSTs with the same replyId", async () => {
         // First POST — genuine state transition
         const res1 = await callPost(42);
         expect((await res1.json()).message).toBe("Answer accepted successfully");
-        expect(inngestSend).toHaveBeenCalledTimes(1);
+        expect(mockInngestSend).toHaveBeenCalledTimes(1);
 
         // Second POST — UPDATE finds no row to change (idempotency guard at DB level)
-        selectCallCount = 0;
-        inngestSend.mockClear();
+        mockSelectCallCount = 0;
+        mockInngestSend.mockClear();
         mockDoubt = { userEmail: "asker@test.com", isSolved: "solved", solvedReplyId: 42 };
         mockUpdatedDoubt = null;
 
         const res2 = await callPost(42);
         expect((await res2.json()).message).toBe("Answer was already accepted (no-op)");
         // inngest.send was NOT called on the second request
-        expect(inngestSend).not.toHaveBeenCalled();
+        expect(mockInngestSend).not.toHaveBeenCalled();
     });
 
     it("returns 500 with a generic message and does not leak error details", async () => {
         // Make the DB throw to exercise the catch block
         const { db } = await import("@/configs/db");
-        vi.mocked(db.select).mockImplementationOnce(() => {
+        jest.mocked(db.select).mockImplementationOnce(() => {
             throw new Error("relation \"doubts\" does not exist");
         });
 


### PR DESCRIPTION
## **User description**
## Description

This PR updates the `name` field in `package.json` from `nextjs-boilerplate-1` to `doubtdesk` to reflect the actual project name.

### Changes Made

- Changed `"name": "nextjs-boilerplate-1"` to `"name": "doubtdesk"` in `package.json`.

### Verification

- ✅ `npm install` completed successfully.
- ✅ `npm run build` completed successfully.

Closes #168

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the project name in package metadata to **doubtdesk**.
* **Tests**
  * Migrated the doubt acceptance API route test to a Jest-based setup, including improved mocks and assertions for karma-event behavior and internal error responses.
  * Adjusted anonymity test cleanup to restore `NODE_ENV` using the environment helper rather than writing directly to `process.env`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Rename the package to match the project name**

### What Changed
- The app package name now shows as `doubtdesk` instead of `nextjs-boilerplate-1`
- Install and build output now use the correct project name

### Impact
`✅ Clearer project identity`
`✅ Fewer setup mismatches`
`✅ Cleaner install output`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
