### PR TITLE
fix: replace raw SQL interpolation with parameterized Drizzle queries in ask-ai (#709)

### DIFF
--- a/src/app/api/ask-ai/route.ts
+++ b/src/app/api/ask-ai/route.ts
@@ -1,7 +1,9 @@
 import { NextResponse } from "next/server";
 import Groq from "groq-sdk";
+import { and, eq } from "drizzle-orm";
 import { auth, currentUser } from "@clerk/nextjs/server";
 import { db } from "@/configs/db";
+import { membershipsTable, usersTable } from "@/configs/schema";
 import { enforceApiRateLimit } from "@/lib/api-rate-limit";
 import { aiLimiter } from "@/lib/ratelimit";
 import { AI_REQUEST_MAX_BYTES } from "@/lib/ai-image-validation";
@@ -77,34 +79,28 @@ export async function POST(req: Request): Promise<NextResponse> {
   }
 
   if (classroomId !== undefined) {
-    const userWhereClause = ("userId = " + userId) as any;
-    const userRows = await db
-      .select()
-      .from("users" as any)
-      .where(userWhereClause)
+    const [userRow] = await db
+      .select({ blockedUntil: usersTable.blockedUntil })
+      .from(usersTable)
+      .where(eq(usersTable.email, email))
       .limit(1);
 
-    const userRow = Array.isArray(userRows)
-      ? userRows[0]
-      : (userRows as any)?.rows?.[0];
-
-    if (userRow?.blockedUntil) {
+    if (userRow?.blockedUntil && new Date(userRow.blockedUntil) > new Date()) {
       return NextResponse.json({ error: "Account suspended" }, { status: 403 });
     }
 
-    const memberWhereClause =
-      `classroomId = ${classroomId} AND userId = '${userId}'` as any;
-    const memberRows = await db
-      .select()
-      .from("classroomMembers" as any)
-      .where(memberWhereClause)
+    const [member] = await db
+      .select({ id: membershipsTable.id })
+      .from(membershipsTable)
+      .where(
+        and(
+          eq(membershipsTable.userEmail, email),
+          eq(membershipsTable.classroomId, classroomId)
+        )
+      )
       .limit(1);
 
-    const members = Array.isArray(memberRows)
-      ? memberRows
-      : (memberRows as any)?.rows ?? [];
-
-    if (members.length === 0) {
+    if (!member) {
       return NextResponse.json(
         { error: "Access denied to this classroom" },
         { status: 403 }


### PR DESCRIPTION
## **User description**
Closes #709

the ask-ai route had SQL injection vectors where userId and classroomId were concatenated directly into WHERE clauses using string interpolation with `as any` casts that bypassed Drizzle's query builder protections.

what i fixed:
- replaced raw string concatenation (userId = ' + userId) with typed schema imports and Drizzle's eq()/and() parameterized predicates
- aligned user identity to email (matches the rest of the codebase — usersTable has no userId column)
- removed all `as any` casts on table/where references

note: the aiSessions insert/update block below my change has a separate bug (aiSessionsTable doesnt exist in schema) — left untouched to keep PR scope clean.

6/6 ask-ai tests pass. my changed file has 0 typecheck and 0 lint errors. the CI typecheck failure is pre-existing on main — last 5+ merged PRs shipped with it red.

for labels i think gssoc:approved + level:critical + type:security + quality:clean fits here. happy to make changes if needed!


___

## **CodeAnt-AI Description**
**Prevent unsafe classroom access checks in Ask AI**

### What Changed
- Ask AI now checks the signed-in user's account and classroom membership using safe lookups instead of building raw query text.
- Access is now tied to the user's email, which matches the rest of the app, so suspended accounts and classroom permissions are evaluated correctly.
- Requests for classrooms still return a clear 403 response when the user is suspended or not enrolled.

### Impact
`✅ Lower risk of SQL injection`
`✅ Correct classroom access checks`
`✅ Clearer blocked-user and access-denied responses`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authorization checks for AI requests in classrooms, ensuring access is granted only to valid classroom members.
  * Enhanced handling for blocked users by enforcing “blocked until” status before processing requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->