### PR TITLE
fix: check Content-Length before materializing request body in ask-ai (#711)

### DIFF
--- a/src/app/api/ask-ai/route.ts
+++ b/src/app/api/ask-ai/route.ts
@@ -28,8 +28,19 @@ export async function POST(req: Request): Promise<NextResponse> {
     return rateLimitResponse;
   }
 
+  const declaredLength = Number.parseInt(
+    req.headers.get("content-length") ?? "",
+    10
+  );
+  if (Number.isFinite(declaredLength) && declaredLength > AI_REQUEST_MAX_BYTES) {
+    return NextResponse.json(
+      { error: "Requests must be 4MB or smaller.", code: "REQUEST_TOO_LARGE" },
+      { status: 413 }
+    );
+  }
+
   const rawText = await req.text();
-  if (rawText.length >= AI_REQUEST_MAX_BYTES) {
+  if (rawText.length > AI_REQUEST_MAX_BYTES) {
     return NextResponse.json(
       { error: "Requests must be 4MB or smaller.", code: "REQUEST_TOO_LARGE" },
       { status: 413 }


### PR DESCRIPTION
## **User description**
Closes #711

the ask-ai route called await req.text() to materialize the entire request body into memory BEFORE checking the size limit. a 10MB payload got fully allocated before being rejected — repeated oversized requests could exhaust memory before rate limiting activates.

what i fixed:
- parse and check Content-Length header FIRST, reject with 413 before any body allocation
- kept the post-read size check as fallback for clients that omit or misreport the header
- defense in depth: both pre-allocation and post-allocation guards

6/6 ask-ai tests pass. 0 typecheck, 0 lint errors. CI failure is pre-existing.

for labels i think gssoc:approved + level:intermediate + type:performance + quality:clean fits here. happy to make changes if needed!


___

## **CodeAnt-AI Description**
**Reject oversized AI requests before reading the full body**

### What Changed
- The AI request endpoint now checks the declared request size first and rejects requests over 4MB with a 413 response before loading the body
- Requests that do not provide a valid size header still get checked after the body is read, so oversized uploads are still blocked

### Impact
`✅ Fewer memory spikes from large AI requests`
`✅ Faster rejection of oversized uploads`
`✅ Lower risk of worker crashes during request floods`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
