### PR TITLE
feat(search): replace ilike with Postgres FTS for public doubts

### DIFF
--- a/src/__tests__/api/doubts.test.ts
+++ b/src/__tests__/api/doubts.test.ts
@@ -1,6 +1,7 @@
 import { GET, POST } from '@/app/api/doubts/route';
 import { db } from '@/configs/db';
 import { currentUser } from '@clerk/nextjs/server';
+import { buildSearchCondition, buildRankOrder } from '@/lib/search/search';
 
 jest.mock('@/lib/search/search', () => ({
     buildSearchCondition: jest.fn().mockReturnValue(null),
@@ -206,6 +207,8 @@ describe('Doubts API Endpoints', () => {
             primaryEmailAddress: { emailAddress: 'student@example.com' },
             fullName: 'Test Student'
         });
+        (buildSearchCondition as jest.Mock).mockReset().mockReturnValue(null);
+        (buildRankOrder as jest.Mock).mockReset().mockReturnValue(null);
     });
 
     it('GET allows anonymous community doubt reads', async () => {
@@ -340,6 +343,38 @@ describe('Doubts API Endpoints', () => {
         expect(res?.status).toBe(200);
         expect(json.id).toBe(2);
         expect(json.subject).toBe('Physics');
+    });
+
+    it('GET should call buildSearchCondition and buildRankOrder when search param is provided', async () => {
+        const req = new Request('http://localhost/api/doubts?search=physics');
+        await GET(req);
+
+        expect(buildSearchCondition).toHaveBeenCalledWith('physics');
+        expect(buildRankOrder).toHaveBeenCalledWith('physics');
+    });
+
+    it('GET should not invoke search helpers when search param is absent', async () => {
+        const req = new Request('http://localhost/api/doubts?subject=Physics');
+        await GET(req);
+
+        expect(buildSearchCondition).not.toHaveBeenCalled();
+        expect(buildRankOrder).not.toHaveBeenCalled();
+    });
+
+    it('GET returns empty doubts and correct metadata when full-text search finds nothing', async () => {
+        (buildSearchCondition as jest.Mock).mockReturnValueOnce({ sql: 'search_vector @@ query' });
+        (db.select as jest.Mock)
+            .mockImplementationOnce(() => createChainWithData([{ count: 0 }]))
+            .mockImplementationOnce(() => createChainWithData([]));
+
+        const req = new Request('http://localhost/api/doubts?search=xyznoresults');
+        const res = await GET(req);
+        const json = await res.json();
+
+        expect(res.status).toBe(200);
+        expect(json.doubts).toHaveLength(0);
+        expect(json.totalCount).toBe(0);
+        expect(json.hasMore).toBe(false);
     });
 });
 

--- a/src/app/api/doubts/route.ts
+++ b/src/app/api/doubts/route.ts
@@ -34,7 +34,7 @@ import { createClassroomDoubtNotifications } from "@/lib/notifications/service";
 import { inngest } from "@/inngest/client";
 import { enforceApiRateLimit } from "@/lib/ratelimit/api-rate-limit";
 import { generalLimiter } from "@/lib/ratelimit/ratelimit";
-import { buildRankOrder } from "@/lib/search/search";
+import { buildSearchCondition, buildRankOrder } from "@/lib/search/search";
 import { canTeach } from "@/lib/auth/membership-guard";
 import { currentUser } from "@clerk/nextjs/server";
 import { parsePositiveInt } from "@/lib/utils/utils";
@@ -106,11 +106,7 @@ export async function GET(req: Request) {
       // NOTE: we deliberately do NOT match on userEmail. Matching the author's
       // email here would let a caller probe email fragments and infer which
       // anonymized posts belong to a given author from result presence/counts.
-      const searchCondition = or(
-        ilike(doubtsTable.content, `%${search}%`),
-        ilike(doubtsTable.subject, `%${search}%`),
-      );
-      if (searchCondition) conditions.push(searchCondition);
+      conditions.push(buildSearchCondition(search) ?? sql`false`);
     }
 
     if (type && type !== "All") {


### PR DESCRIPTION
## **User description**
## Description
Wires the existing `buildSearchCondition` helper into `GET /api/doubts`, replacing the slow `ilike %pattern%` sequential scan with a GIN-indexed Postgres full-text search using `tsvector`/`tsquery`. Also removes the now-unused `ilike` import and adds three test cases covering the search path.

## Related Issue
Closes #512

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Documentation update (README, guides, comments)
- [ ] Style / UI change (no logic change)
- [ ] Code refactor (no behavior change)
- [x] Test addition or update
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Screenshots (if UI change)
N/A - backend-only change, no UI affected.

## How Has This Been Tested?
- [x] Tested locally with `npm run dev`
- [ ] Verified on mobile viewport (375px)
- [ ] Verified on desktop viewport (1440px)

Ran the doubts test suite directly:
```bash
npx jest src/__tests__/api/doubts.test.ts --forceExit --verbose
```
All 13 tests pass (10 existing + 3 new).


## Checklist
- [x] I have tested my changes locally (`npm run dev`)
- [x] My code follows the existing code style (TypeScript, Tailwind, no `any` types)
- [x] I have not introduced unrelated changes (each PR should address one issue)
- [x] I have added comments where necessary
- [x] My branch is up to date with `main`
- [x] I have linked the related issue above
- [x] Screenshots are included (if this is a UI change)

**Note on pre-existing TypeScript errors:** Running `tsc --noEmit` on `main` before this PR already shows failures in `analytics/export/route.ts`, `rooms/[id]/page.tsx`, `moderation.ts`, and `doubts/[id]/accept/route.test.ts`. These are unrelated to this PR,

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added full-text search support for the doubts list, improving relevance via ranking.
* **Bug Fixes**
  * Improved search filtering for the doubts list to produce more consistent results.
  * When a search term yields no matches, the API now returns an empty list with `totalCount: 0` and `hasMore: false`.
* **Tests**
  * Added/updated endpoint tests to verify search behavior with a search term present (including ranking/search condition usage) and absent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Use full-text search for public doubt search**

### What Changed
- Searching doubts now uses full-text matching for the public doubts list, instead of simple text matching on subject and content.
- Search still avoids exposing author email details, and empty or fully sanitized queries now return no results instead of the full feed.
- Added coverage for search helper calls, skipped search behavior when no query is provided, and the no-results case.

### Impact
`✅ Faster doubt search`
`✅ Fewer unrelated search results`
`✅ Safer anonymous doubt browsing`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
