### PR TITLE
feat: add moderation tools for flagging inappropriate content (#735)

### DIFF
--- a/drizzle/0017_add_content_flags.sql
+++ b/drizzle/0017_add_content_flags.sql
@@ -1,0 +1,15 @@
+CREATE TABLE "content_flags" (
+	"id" integer PRIMARY KEY GENERATED ALWAYS AS IDENTITY (sequence name "content_flags_id_seq" INCREMENT BY 1 MINVALUE 1 MAXVALUE 2147483647 START WITH 1 CACHE 1),
+	"doubt_id" integer NOT NULL,
+	"reporter_email" varchar(255) NOT NULL,
+	"reason" varchar(20) NOT NULL,
+	"status" varchar(20) DEFAULT 'open' NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "content_flags_doubtId_reporterEmail_unique" UNIQUE("doubt_id","reporter_email")
+);
+--> statement-breakpoint
+ALTER TABLE "doubts" ADD COLUMN "isHidden" boolean DEFAULT false NOT NULL;--> statement-breakpoint
+ALTER TABLE "content_flags" ADD CONSTRAINT "content_flags_doubt_id_doubts_id_fk" FOREIGN KEY ("doubt_id") REFERENCES "public"."doubts"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "content_flags" ADD CONSTRAINT "content_flags_reporter_email_users_email_fk" FOREIGN KEY ("reporter_email") REFERENCES "public"."users"("email") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "content_flags_doubtId_idx" ON "content_flags" USING btree ("doubt_id");--> statement-breakpoint
+CREATE INDEX "content_flags_createdAt_idx" ON "content_flags" USING btree ("created_at");

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -18,6 +18,7 @@
     { "idx": 13, "version": "7", "when": 1781300000000, "tag": "0013_identity_system_update", "breakpoints": true },
     { "idx": 14, "version": "7", "when": 1781340000000, "tag": "0014_practice_attempts", "breakpoints": true },
     { "idx": 15, "version": "7", "when": 1781354492608, "tag": "0015_add_onboarding_fields", "breakpoints": true },
-    { "idx": 16, "version": "7", "when": 1781400000000, "tag": "0016_video_jobs", "breakpoints": true }
+    { "idx": 16, "version": "7", "when": 1781400000000, "tag": "0016_video_jobs", "breakpoints": true },
+    { "idx": 17, "version": "7", "when": 1783200000000, "tag": "0017_add_content_flags", "breakpoints": true }
   ]
 }

--- a/src/__tests__/api/doubts-flag.test.ts
+++ b/src/__tests__/api/doubts-flag.test.ts
@@ -1,0 +1,232 @@
+import { GET, PATCH, POST } from '@/app/api/doubts/flag/route';
+
+const currentUserMock = jest.fn();
+
+jest.mock('@clerk/nextjs/server', () => ({
+    currentUser: () => currentUserMock(),
+}));
+
+jest.mock('@/lib/auth/membership-guard', () => {
+    const actual = jest.requireActual('@/lib/auth/membership-guard');
+    return {
+        ...actual,
+        requireTeacher: jest.fn(),
+    };
+});
+
+const selectResultQueue: any[] = [];
+const insertMock = jest.fn();
+const updateMock = jest.fn();
+
+const createQueryMock = (data: any) => ({
+    from: () => createQueryMock(data),
+    where: () => createQueryMock(data),
+    innerJoin: () => createQueryMock(data),
+    groupBy: () => createQueryMock(data),
+    orderBy: () => createQueryMock(data),
+    then: (resolve: any) => Promise.resolve(resolve(data)),
+});
+
+jest.mock('@/configs/db', () => ({
+    db: {
+        select: jest.fn().mockImplementation(() => createQueryMock(selectResultQueue.shift() ?? [])),
+        insert: jest.fn().mockImplementation((...args: any[]) => ({
+            values: jest.fn().mockImplementation(async (...valueArgs: any[]) => insertMock(...args, ...valueArgs)),
+        })),
+        update: jest.fn().mockImplementation((...args: any[]) => ({
+            set: jest.fn().mockImplementation((...setArgs: any[]) => ({
+                where: jest.fn().mockImplementation(async (...whereArgs: any[]) => updateMock(...args, ...setArgs, ...whereArgs)),
+            })),
+        })),
+    },
+}));
+
+import { requireTeacher } from '@/lib/auth/membership-guard';
+
+describe('Doubts Flag API Endpoint (issue #735)', () => {
+    beforeEach(() => {
+        currentUserMock.mockReset();
+        insertMock.mockReset();
+        updateMock.mockReset();
+        selectResultQueue.length = 0;
+        (requireTeacher as jest.Mock).mockReset();
+    });
+
+    describe('POST /api/doubts/flag', () => {
+        it('rejects unauthenticated requests', async () => {
+            currentUserMock.mockResolvedValue(null);
+
+            const req = new Request('http://localhost/api/doubts/flag', {
+                method: 'POST',
+                body: JSON.stringify({ doubtId: 1, reason: 'spam' }),
+            });
+
+            const res = await POST(req as any);
+            expect(res.status).toBe(401);
+        });
+
+        it('rejects invalid reason values', async () => {
+            currentUserMock.mockResolvedValue({ primaryEmailAddress: { emailAddress: 'student@test.com' } });
+
+            const req = new Request('http://localhost/api/doubts/flag', {
+                method: 'POST',
+                body: JSON.stringify({ doubtId: 1, reason: 'not_a_real_reason' }),
+            });
+
+            const res = await POST(req as any);
+            expect(res.status).toBe(400);
+        });
+
+        it('returns 404 when the doubt does not exist', async () => {
+            currentUserMock.mockResolvedValue({ primaryEmailAddress: { emailAddress: 'student@test.com' } });
+            selectResultQueue.push([]);
+
+            const req = new Request('http://localhost/api/doubts/flag', {
+                method: 'POST',
+                body: JSON.stringify({ doubtId: 999, reason: 'spam' }),
+            });
+
+            const res = await POST(req as any);
+            expect(res.status).toBe(404);
+        });
+
+        it('records a flag and does not auto-hide below the threshold', async () => {
+            currentUserMock.mockResolvedValue({ primaryEmailAddress: { emailAddress: 'student@test.com' } });
+            selectResultQueue.push([{ id: 1 }]); // doubt exists
+            selectResultQueue.push([{ value: 1 }]); // recent flag count after insert
+
+            const req = new Request('http://localhost/api/doubts/flag', {
+                method: 'POST',
+                body: JSON.stringify({ doubtId: 1, reason: 'spam' }),
+            });
+
+            const res = await POST(req as any);
+            const json = await res.json();
+
+            expect(res.status).toBe(200);
+            expect(json.autoHidden).toBe(false);
+            expect(insertMock).toHaveBeenCalled();
+            expect(updateMock).not.toHaveBeenCalled();
+        });
+
+        it('auto-hides the doubt once the flag threshold is reached', async () => {
+            currentUserMock.mockResolvedValue({ primaryEmailAddress: { emailAddress: 'student@test.com' } });
+            selectResultQueue.push([{ id: 1 }]); // doubt exists
+            selectResultQueue.push([{ value: 3 }]); // recent flag count after insert
+
+            const req = new Request('http://localhost/api/doubts/flag', {
+                method: 'POST',
+                body: JSON.stringify({ doubtId: 1, reason: 'inappropriate' }),
+            });
+
+            const res = await POST(req as any);
+            const json = await res.json();
+
+            expect(res.status).toBe(200);
+            expect(json.autoHidden).toBe(true);
+            expect(updateMock).toHaveBeenCalled();
+        });
+
+        it('returns 409 when the same user flags a doubt twice', async () => {
+            currentUserMock.mockResolvedValue({ primaryEmailAddress: { emailAddress: 'student@test.com' } });
+            selectResultQueue.push([{ id: 1 }]);
+            insertMock.mockImplementation(() => {
+                throw Object.assign(new Error('duplicate'), { code: '23505' });
+            });
+
+            const req = new Request('http://localhost/api/doubts/flag', {
+                method: 'POST',
+                body: JSON.stringify({ doubtId: 1, reason: 'spam' }),
+            });
+
+            const res = await POST(req as any);
+            expect(res.status).toBe(409);
+        });
+    });
+
+    describe('GET /api/doubts/flag', () => {
+        it('requires a classroomId', async () => {
+            currentUserMock.mockResolvedValue({ primaryEmailAddress: { emailAddress: 'teacher@test.com' } });
+
+            const req = new Request('http://localhost/api/doubts/flag');
+            const res = await GET(req as any);
+            expect(res.status).toBe(400);
+        });
+
+        it('requires the caller to be a teacher of the classroom', async () => {
+            currentUserMock.mockResolvedValue({ primaryEmailAddress: { emailAddress: 'student@test.com' } });
+            const { ApiError } = jest.requireActual('@/lib/errors/error-handler');
+            (requireTeacher as jest.Mock).mockRejectedValue(new ApiError(403, 'Forbidden: teacher access required'));
+
+            const req = new Request('http://localhost/api/doubts/flag?classroomId=7');
+            const res = await GET(req as any);
+            expect(res.status).toBe(403);
+        });
+
+        it('returns the moderation queue for a teacher', async () => {
+            currentUserMock.mockResolvedValue({ primaryEmailAddress: { emailAddress: 'teacher@test.com' } });
+            (requireTeacher as jest.Mock).mockResolvedValue({ role: 'teacher' });
+            selectResultQueue.push([
+                { doubtId: 1, content: 'spam post', subject: 'Physics', isHidden: true, flagCount: 3 },
+            ]);
+
+            const req = new Request('http://localhost/api/doubts/flag?classroomId=7');
+            const res = await GET(req as any);
+            const json = await res.json();
+
+            expect(res.status).toBe(200);
+            expect(json.data).toHaveLength(1);
+            expect(json.data[0].flagCount).toBe(3);
+        });
+    });
+
+    describe('PATCH /api/doubts/flag', () => {
+        it('rejects an invalid action', async () => {
+            currentUserMock.mockResolvedValue({ primaryEmailAddress: { emailAddress: 'teacher@test.com' } });
+
+            const req = new Request('http://localhost/api/doubts/flag', {
+                method: 'PATCH',
+                body: JSON.stringify({ doubtId: 1, action: 'delete_forever' }),
+            });
+
+            const res = await PATCH(req as any);
+            expect(res.status).toBe(400);
+        });
+
+        it('dismisses open flags without un-hiding the doubt', async () => {
+            currentUserMock.mockResolvedValue({ primaryEmailAddress: { emailAddress: 'teacher@test.com' } });
+            (requireTeacher as jest.Mock).mockResolvedValue({ role: 'teacher' });
+            selectResultQueue.push([{ id: 1, classroomId: 7 }]);
+
+            const req = new Request('http://localhost/api/doubts/flag', {
+                method: 'PATCH',
+                body: JSON.stringify({ doubtId: 1, action: 'dismiss' }),
+            });
+
+            const res = await PATCH(req as any);
+            const json = await res.json();
+
+            expect(res.status).toBe(200);
+            expect(json.action).toBe('dismiss');
+            expect(updateMock).toHaveBeenCalledTimes(1); // only the flags status update
+        });
+
+        it('re-shows a hidden doubt and resolves its flags', async () => {
+            currentUserMock.mockResolvedValue({ primaryEmailAddress: { emailAddress: 'teacher@test.com' } });
+            (requireTeacher as jest.Mock).mockResolvedValue({ role: 'teacher' });
+            selectResultQueue.push([{ id: 1, classroomId: 7 }]);
+
+            const req = new Request('http://localhost/api/doubts/flag', {
+                method: 'PATCH',
+                body: JSON.stringify({ doubtId: 1, action: 'reshow' }),
+            });
+
+            const res = await PATCH(req as any);
+            const json = await res.json();
+
+            expect(res.status).toBe(200);
+            expect(json.action).toBe('reshow');
+            expect(updateMock).toHaveBeenCalledTimes(2); // flags resolved + doubt un-hidden
+        });
+    });
+});

--- a/src/app/api/doubts/flag/route.ts
+++ b/src/app/api/doubts/flag/route.ts
@@ -1,0 +1,167 @@
+import { NextRequest, NextResponse } from "next/server";
+import { db } from "@/configs/db";
+import { contentFlagsTable, doubtsTable } from "@/configs/schema";
+import { and, count, desc, eq, gte } from "drizzle-orm";
+import { currentUser } from "@clerk/nextjs/server";
+import { requireTeacher, parseClassroomId } from "@/lib/auth/membership-guard";
+import { buildErrorResponse } from "@/lib/errors/error-handler";
+
+const AUTO_HIDE_FLAG_THRESHOLD = 3;
+const AUTO_HIDE_WINDOW_MS = 10 * 60 * 1000;
+
+export async function POST(req: NextRequest) {
+    try {
+        const user = await currentUser();
+        if (!user?.primaryEmailAddress?.emailAddress) {
+            return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+        }
+        const reporterEmail = user.primaryEmailAddress.emailAddress;
+
+        const body = await req.json();
+        const { doubtId, reason } = body as { doubtId: number; reason: "spam" | "inappropriate" | "off_topic" };
+
+        if (!doubtId || !Number.isInteger(doubtId) || !reason || !["spam", "inappropriate", "off_topic"].includes(reason)) {
+            return NextResponse.json({ error: "Invalid doubtId or reason" }, { status: 400 });
+        }
+
+        const [doubt] = await db
+            .select({ id: doubtsTable.id })
+            .from(doubtsTable)
+            .where(eq(doubtsTable.id, doubtId));
+
+        if (!doubt) {
+            return NextResponse.json({ error: "Doubt not found" }, { status: 404 });
+        }
+
+        try {
+            await db.insert(contentFlagsTable).values({
+                doubtId,
+                reporterEmail,
+                reason,
+            });
+        } catch (error: unknown) {
+            // Unique constraint on (doubtId, reporterEmail) — same user can't flag twice.
+            const dbError = error as { code?: string };
+            if (dbError?.code === "23505") {
+                return NextResponse.json({ error: "You have already flagged this doubt" }, { status: 409 });
+            }
+            throw error;
+        }
+
+        const windowStart = new Date(Date.now() - AUTO_HIDE_WINDOW_MS);
+        const [{ value: recentFlagCount }] = await db
+            .select({ value: count() })
+            .from(contentFlagsTable)
+            .where(
+                and(
+                    eq(contentFlagsTable.doubtId, doubtId),
+                    eq(contentFlagsTable.status, "open"),
+                    gte(contentFlagsTable.createdAt, windowStart),
+                ),
+            );
+
+        let autoHidden = false;
+        if (recentFlagCount >= AUTO_HIDE_FLAG_THRESHOLD) {
+            await db.update(doubtsTable).set({ isHidden: true }).where(eq(doubtsTable.id, doubtId));
+            autoHidden = true;
+        }
+
+        return NextResponse.json({
+            success: true,
+            message: "Doubt flagged successfully",
+            reason,
+            autoHidden,
+        });
+    } catch (error) {
+        const { status, body } = buildErrorResponse(error);
+        return NextResponse.json(body, { status });
+    }
+}
+
+export async function GET(req: NextRequest) {
+    try {
+        const user = await currentUser();
+        if (!user?.primaryEmailAddress?.emailAddress) {
+            return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+        }
+        const email = user.primaryEmailAddress.emailAddress;
+
+        const { searchParams } = new URL(req.url);
+        const classroomIdParam = searchParams.get("classroomId");
+
+        if (!classroomIdParam) {
+            return NextResponse.json({ error: "classroomId required" }, { status: 400 });
+        }
+
+        const classroomId = parseClassroomId(classroomIdParam);
+        await requireTeacher(email, classroomId);
+
+        const flaggedDoubts = await db
+            .select({
+                doubtId: doubtsTable.id,
+                content: doubtsTable.content,
+                subject: doubtsTable.subject,
+                isHidden: doubtsTable.isHidden,
+                flagCount: count(contentFlagsTable.id),
+            })
+            .from(contentFlagsTable)
+            .innerJoin(doubtsTable, eq(contentFlagsTable.doubtId, doubtsTable.id))
+            .where(and(eq(doubtsTable.classroomId, classroomId), eq(contentFlagsTable.status, "open")))
+            .groupBy(doubtsTable.id, doubtsTable.content, doubtsTable.subject, doubtsTable.isHidden)
+            .orderBy(desc(count(contentFlagsTable.id)));
+
+        return NextResponse.json({
+            success: true,
+            data: flaggedDoubts,
+        });
+    } catch (error) {
+        const { status, body } = buildErrorResponse(error);
+        return NextResponse.json(body, { status });
+    }
+}
+
+// PATCH: teacher moderation actions on a flagged doubt — dismiss the open
+// flags (doubt stays as-is), or re-show a doubt that was auto-hidden or
+// hidden in error, resolving its flags either way so it drops out of the
+// queue.
+export async function PATCH(req: NextRequest) {
+    try {
+        const user = await currentUser();
+        if (!user?.primaryEmailAddress?.emailAddress) {
+            return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+        }
+        const email = user.primaryEmailAddress.emailAddress;
+
+        const body = await req.json();
+        const { doubtId, action } = body as { doubtId: number; action: "dismiss" | "reshow" };
+
+        if (!doubtId || !Number.isInteger(doubtId) || !["dismiss", "reshow"].includes(action)) {
+            return NextResponse.json({ error: "Invalid doubtId or action" }, { status: 400 });
+        }
+
+        const [doubt] = await db
+            .select({ id: doubtsTable.id, classroomId: doubtsTable.classroomId })
+            .from(doubtsTable)
+            .where(eq(doubtsTable.id, doubtId));
+
+        if (!doubt || !doubt.classroomId) {
+            return NextResponse.json({ error: "Doubt not found" }, { status: 404 });
+        }
+
+        await requireTeacher(email, doubt.classroomId);
+
+        await db
+            .update(contentFlagsTable)
+            .set({ status: "resolved" })
+            .where(and(eq(contentFlagsTable.doubtId, doubtId), eq(contentFlagsTable.status, "open")));
+
+        if (action === "reshow") {
+            await db.update(doubtsTable).set({ isHidden: false }).where(eq(doubtsTable.id, doubtId));
+        }
+
+        return NextResponse.json({ success: true, action });
+    } catch (error) {
+        const { status, body } = buildErrorResponse(error);
+        return NextResponse.json(body, { status });
+    }
+}

--- a/src/app/api/doubts/route.ts
+++ b/src/app/api/doubts/route.ts
@@ -96,6 +96,14 @@ export async function GET(req: Request) {
         ? or(not(eq(doubtsTable.type, "teacher")), eq(doubtsTable.userEmail, email))
         : not(eq(doubtsTable.type, "teacher"));
       if (teacherCondition) conditions.push(teacherCondition);
+
+      // Doubts auto-hidden or hidden by moderation stay visible to teachers
+      // for review, but are excluded from the student-facing feed. The
+      // original poster can still see their own hidden doubt.
+      const hiddenCondition = email
+        ? or(eq(doubtsTable.isHidden, false), eq(doubtsTable.userEmail, email))
+        : eq(doubtsTable.isHidden, false);
+      if (hiddenCondition) conditions.push(hiddenCondition);
     }
 
     if (subject && subject !== "All") {

--- a/src/configs/schema.ts
+++ b/src/configs/schema.ts
@@ -119,6 +119,7 @@ export const doubtsTable = pgTable("doubts", {
     solvedReplyId: integer(),
     type: varchar({ length: 20 }).default("community"),
     isPinned: boolean().default(false),
+    isHidden: boolean("isHidden").default(false).notNull(),
     deletedAt: timestamp(),
     createdAt: timestamp().defaultNow().notNull(),
 
@@ -263,6 +264,27 @@ export const moderationLogsTable = pgTable("moderation_logs", {
         columns: [table.userEmail],
         foreignColumns: [usersTable.email],
     }).onDelete("set null"),
+}));
+
+export const contentFlagsTable = pgTable("content_flags", {
+    id: integer().primaryKey().generatedAlwaysAsIdentity(),
+    doubtId: integer("doubt_id").notNull(),
+    reporterEmail: varchar("reporter_email", { length: 255 }).notNull(),
+    reason: varchar({ length: 20 }).notNull(),
+    status: varchar({ length: 20 }).default("open").notNull(),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+}, (table) => ({
+    doubtIdIndex: index("content_flags_doubtId_idx").on(table.doubtId),
+    createdAtIndex: index("content_flags_createdAt_idx").on(table.createdAt),
+    doubtIdFk: foreignKey({
+        columns: [table.doubtId],
+        foreignColumns: [doubtsTable.id],
+    }).onDelete("cascade"),
+    reporterEmailFk: foreignKey({
+        columns: [table.reporterEmail],
+        foreignColumns: [usersTable.email],
+    }).onDelete("cascade"),
+    uniqueFlagPerReporter: unique("content_flags_doubtId_reporterEmail_unique").on(table.doubtId, table.reporterEmail),
 }));
 
 export const auditLogsTable = pgTable("audit_logs", {


### PR DESCRIPTION
## **User description**
Implements issue #735: Moderation queue with auto-hide.

POST /api/doubts/flag flags a doubt with reason (spam/inappropriate/off_topic). GET /api/doubts/flag returns moderation queue for classroom. Auto-hide logic ready: 3+ flags within 10min auto-hides doubt. Teachers can dismiss/re-show flags.

Closes #735

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added content flagging for doubts, including reporting, review, and moderation actions.
  * Introduced hidden-status support so flagged doubts can be temporarily removed from student-facing views.
  * Added organization support in the data model for classrooms.

* **Bug Fixes**
  * Prevented duplicate flags from the same reporter on the same doubt.
  * Improved doubt visibility so hidden items remain available to teachers and their original authors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Add moderation flagging for doubts with auto-hide and teacher review**

### What Changed
- Students can report a doubt as spam, inappropriate, or off-topic, and the same person cannot flag the same doubt twice
- After 3 recent reports, a doubt is automatically hidden from the student feed
- Teachers can open a classroom moderation queue to review flagged doubts, dismiss reports, or show a hidden doubt again
- Hidden doubts stay visible to the original author and teachers for review, but are removed from the student-facing feed

### Impact
`✅ Faster removal of inappropriate doubts`
`✅ Fewer flagged posts in student feeds`
`✅ Clearer moderation review for teachers`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
