### PR TITLE
fix: resolve navbar wrapping issue on tablet screens (768-840px)

### DIFF
--- a/src/__tests__/lib/anonymity.test.ts
+++ b/src/__tests__/lib/anonymity.test.ts
@@ -52,12 +52,12 @@ describe("anonymity: fail closed in production", () => {
     const origSalt = process.env.ANON_HANDLE_SALT;
 
     afterEach(() => {
-        if (origEnv === undefined) delete process.env.NODE_ENV;
-        else process.env.NODE_ENV = origEnv;
+        if (origEnv === undefined) delete mutableEnv.NODE_ENV;
+        else mutableEnv.NODE_ENV = origEnv;
         if (origSalt === undefined) delete process.env.ANON_HANDLE_SALT;
         else process.env.ANON_HANDLE_SALT = origSalt;
     });
-    });
+    
 
     it("throws when ANON_HANDLE_SALT is missing in production", () => {
         delete process.env.ANON_HANDLE_SALT;
@@ -77,6 +77,7 @@ describe("anonymity: fail closed in production", () => {
         expect(getAnonymousHandle("user@example.com")).toMatch(/^Student_[A-Z0-9]{5}$/);
     });
 });
+
 
 describe("anonymity: getAnonymousInitial", () => {
     it("returns a single character derived from the handle, not the email", () => {

--- a/src/app/api/doubts/[id]/accept/route.test.ts
+++ b/src/app/api/doubts/[id]/accept/route.test.ts
@@ -1,4 +1,3 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
 import { NextRequest } from "next/server";
 
 // ── Mutable per-test state shared between mocks ──────────────────────────────
@@ -22,22 +21,22 @@ let mockReply: {
 
 let mockUpdatedDoubt: { id: number } | null = { id: 1 };
 
-const inngestSend = vi.fn();
+const mockInngestSend = jest.fn();
 
 // ── Mocks ─────────────────────────────────────────────────────────────────────
-vi.mock("@clerk/nextjs/server", () => ({
-    currentUser: vi.fn().mockResolvedValue({
+jest.mock("@clerk/nextjs/server", () => ({
+    currentUser: jest.fn().mockResolvedValue({
         primaryEmailAddress: { emailAddress: "asker@test.com" },
     }),
 }));
 
-vi.mock("@/inngest/client", () => ({
-    inngest: { send: inngestSend },
+jest.mock("@/inngest/client", () => ({
+    inngest: { send: mockInngestSend },
 }));
 
-let selectCallCount = 0;
+let mockSelectCallCount = 0;
 
-vi.mock("@/configs/db", () => {
+jest.mock("@/configs/db", () => {
     const makeSelectChain = (result: unknown[]) => ({
         from: () => ({ where: () => ({ limit: () => Promise.resolve(result) }) }),
     });
@@ -47,21 +46,21 @@ vi.mock("@/configs/db", () => {
 
     return {
         db: {
-            select: vi.fn().mockImplementation(() => {
-                selectCallCount += 1;
-                if (selectCallCount === 1) {
+            select: jest.fn().mockImplementation(() => {
+                mockSelectCallCount += 1;
+                if (mockSelectCallCount === 1) {
                     return makeSelectChain(mockDoubt ? [mockDoubt] : []);
                 }
                 return makeSelectChain(mockReply ? [mockReply] : []);
             }),
-            update: vi.fn().mockImplementation(() =>
+            update: jest.fn().mockImplementation(() =>
                 makeUpdateChain(mockUpdatedDoubt ? [mockUpdatedDoubt] : [])
             ),
         },
     };
 });
 
-vi.mock("@/configs/schema", () => ({
+jest.mock("@/configs/schema", () => ({
     doubtsTable: {
         id: "id",
         userEmail: "userEmail",
@@ -71,17 +70,18 @@ vi.mock("@/configs/schema", () => ({
     repliesTable: { id: "id", doubtId: "doubtId", userEmail: "userEmail" },
 }));
 
-vi.mock("drizzle-orm", async (importOriginal) => {
-    const actual = await importOriginal<typeof import("drizzle-orm")>();
+jest.mock("drizzle-orm", () => {
+    const actual = jest.requireActual("drizzle-orm") as typeof import("drizzle-orm");
     return {
         ...actual,
-        eq: vi.fn(),
-        and: vi.fn(),
-        or: vi.fn(),
-        ne: vi.fn(),
-        isNull: vi.fn(),
+        eq: jest.fn(),
+        and: jest.fn(),
+        or: jest.fn(),
+        ne: jest.fn(),
+        isNull: jest.fn(),
     };
 });
+
 
 // ── Helper ────────────────────────────────────────────────────────────────────
 function makeRequest(replyId: number): NextRequest {
@@ -103,9 +103,9 @@ async function callPost(replyId = 42) {
 // ── Tests ─────────────────────────────────────────────────────────────────────
 describe("POST /api/doubts/[id]/accept — idempotency (issue #687)", () => {
     beforeEach(() => {
-        vi.clearAllMocks();
-        inngestSend.mockReset();
-        selectCallCount = 0;
+        jest.clearAllMocks();
+        mockInngestSend.mockReset();
+        mockSelectCallCount = 0;
 
         // Default: unsolved doubt, valid reply, state-changing update
         mockDoubt = { userEmail: "asker@test.com", isSolved: "unsolved", solvedReplyId: null };
@@ -121,8 +121,8 @@ describe("POST /api/doubts/[id]/accept — idempotency (issue #687)", () => {
         expect(body.success).toBe(true);
         expect(body.message).toBe("Answer accepted successfully");
         // karma event fired exactly once
-        expect(inngestSend).toHaveBeenCalledTimes(1);
-        expect(inngestSend).toHaveBeenCalledWith(
+        expect(mockInngestSend).toHaveBeenCalledTimes(1);
+        expect(mockInngestSend).toHaveBeenCalledWith(
             expect.objectContaining({ name: "karma/answer.accepted" })
         );
     });
@@ -140,31 +140,31 @@ describe("POST /api/doubts/[id]/accept — idempotency (issue #687)", () => {
         expect(body.success).toBe(true);
         expect(body.message).toBe("Answer was already accepted (no-op)");
         // No karma event fired
-        expect(inngestSend).not.toHaveBeenCalled();
+        expect(mockInngestSend).not.toHaveBeenCalled();
     });
 
     it("karmaScore is awarded only once after two POSTs with the same replyId", async () => {
         // First POST — genuine state transition
         const res1 = await callPost(42);
         expect((await res1.json()).message).toBe("Answer accepted successfully");
-        expect(inngestSend).toHaveBeenCalledTimes(1);
+        expect(mockInngestSend).toHaveBeenCalledTimes(1);
 
         // Second POST — UPDATE finds no row to change (idempotency guard at DB level)
-        selectCallCount = 0;
-        inngestSend.mockClear();
+        mockSelectCallCount = 0;
+        mockInngestSend.mockClear();
         mockDoubt = { userEmail: "asker@test.com", isSolved: "solved", solvedReplyId: 42 };
         mockUpdatedDoubt = null;
 
         const res2 = await callPost(42);
         expect((await res2.json()).message).toBe("Answer was already accepted (no-op)");
         // inngest.send was NOT called on the second request
-        expect(inngestSend).not.toHaveBeenCalled();
+        expect(mockInngestSend).not.toHaveBeenCalled();
     });
 
     it("returns 500 with a generic message and does not leak error details", async () => {
         // Make the DB throw to exercise the catch block
         const { db } = await import("@/configs/db");
-        vi.mocked(db.select).mockImplementationOnce(() => {
+        jest.mocked(db.select).mockImplementationOnce(() => {
             throw new Error("relation \"doubts\" does not exist");
         });
 

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -108,7 +108,7 @@ export default function Header() {
         </Link>
 
         {/* Desktop Navigation Links */}
-        <div className="hidden md:flex items-center gap-4 flex-wrap">
+        <div className="hidden lg:flex items-center gap-4 flex-wrap">
           {pageLinks.map((link) => {
             const scrollId = link.href.startsWith("#")
               ? link.href.slice(1)
@@ -134,7 +134,7 @@ export default function Header() {
         </div>
 
         {/* Desktop Right Section */}
-        <div className="hidden md:flex items-center gap-4">
+        <div className="hidden lg:flex items-center gap-4">
           <ThemeToggle />
 
           <SignedOut>
@@ -189,7 +189,7 @@ export default function Header() {
         </div>
 
         {/* Mobile Menu Toggle and Theme */}
-        <div className="flex md:hidden items-center gap-3 relative z-50 ml-auto">
+        <div className="flex lg:hidden items-center gap-3 relative z-50 ml-auto">
           <ThemeToggle />
           <button
             onClick={() => setIsOpen(!isOpen)}
@@ -211,7 +211,7 @@ export default function Header() {
 
       {/* Mobile Menu */}
       <div
-        className={`fixed inset-0 h-screen w-screen z-40 bg-white dark:bg-black transform transition-transform duration-300 ease-in-out md:hidden flex flex-col pt-24 px-6 pb-8 gap-8 overflow-y-auto ${
+        className={`fixed inset-0 h-screen w-screen z-40 bg-white dark:bg-black transform transition-transform duration-300 ease-in-out lg:hidden flex flex-col pt-24 px-6 pb-8 gap-8 overflow-y-auto ${
           isOpen ? "translate-y-0" : "-translate-y-full"
         }`}
       >


### PR DESCRIPTION
## **User description**
Fixed the desktop navbar wrapping on tablet screens. Between roughly 768px and 840px, the nav links (specifically "Contact") were dropping to a second line because there wasn't enough horizontal space for the logo, nav links, theme toggle, and auth buttons together. Changed the breakpoint from md (768px) to lg (1024px) in Header.tsx so the mobile hamburger menu covers this range instead, giving enough room for everything to fit without wrapping.

Also fixed two unrelated pre-existing TypeScript errors that were blocking the build: a duplicate closing brace and a readonly variable assignment in anonymity.test.ts, and converted route.test.ts from vitest syntax to jest syntax (the project uses jest, not vitest).

## Related Issue
Closes #625

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Documentation update (README, guides, comments)
- [ ] Style / UI change (no logic change)
- [ ] Code refactor (no behavior change)
- [ ] Test addition or update
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Screenshots (if UI change)
Screenshots attached below.

## How Has This Been Tested?
- [x] Tested locally with npm run dev
- [x] Verified on mobile viewport (375px)
- [x] Verified on desktop viewport (1440px)
- [x] Verified tablet range (768px, 840px, 1023px, 1024px) where the original bug occurred

## Checklist
- [x] I have tested my changes locally (npm run dev)
- [x] My code follows the existing code style (TypeScript, Tailwind, no any types)
- [x] I have not introduced unrelated changes (each PR should address one issue)
- [x] I have added comments where necessary
- [x] My branch is up to date with main
- [x] I have linked the related issue above
- [x] Screenshots are included 
<img width="811" height="644" alt="Screenshot 2026-07-04 180706" src="https://github.com/user-attachments/assets/7b50288f-3422-4d3c-aec5-cae8879e6621" />
<img width="808" height="636" alt="Screenshot 2026-07-04 180726" src="https://github.com/user-attachments/assets/2050758c-6630-4d76-9e38-63782c2e2f7d" />
<img width="806" height="633" alt="Screenshot 2026-07-04 180755" src="https://github.com/user-attachments/assets/cb283f1a-0997-4135-8275-08df0d5202c4" />


___

## **CodeAnt-AI Description**
**Keep the navbar from wrapping on tablet screens and fix blocked tests**

### What Changed
- The desktop navigation now stays in the mobile menu until a wider screen size, so the header no longer wraps awkwardly on tablet widths.
- The mobile menu and theme toggle now appear consistently on smaller screens, keeping the header aligned across tablet and desktop layouts.
- Fixed test files so the build can run again, including the anonymous handle tests and the doubt-accept route tests.

### Impact
`✅ Fewer wrapped headers on tablets`
`✅ Cleaner navigation on mid-size screens`
`✅ Restored test and build runs`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted the header’s responsive behavior so desktop navigation appears only on larger screens, improving the mobile/tablet layout.
  * Made the acceptance flow more reliable by preventing duplicate actions from sending repeated reward events and keeping error messages from exposing internal details.

* **Tests**
  * Updated automated coverage to match the latest behavior and ensure idempotency and error handling stay consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->