### PR TITLE
fix: return 404 when DELETE /api/resume-builder affects no rows (fixe…

### DIFF
--- a/app/api/resume-builder/route.ts
+++ b/app/api/resume-builder/route.ts
@@ -139,9 +139,14 @@ export async function DELETE(req: NextRequest) {
             return NextResponse.json({ error: "ID is required" }, { status: 400 });
         }
 
-        await db
+        const deleted = await db
             .delete(resumesTable)
-            .where(and(eq(resumesTable.id, parseInt(id)), eq(resumesTable.userEmail, userEmail)));
+            .where(and(eq(resumesTable.id, parseInt(id)), eq(resumesTable.userEmail, userEmail)))
+            .returning();
+
+        if (deleted.length === 0) {
+            return NextResponse.json({ error: "Resume not found" }, { status: 404 });
+        }
 
         return NextResponse.json({ success: true });
     } catch (error: any) {

--- a/app/api/resume-builder/route.ts
+++ b/app/api/resume-builder/route.ts
@@ -49,9 +49,9 @@ export async function POST(req: NextRequest) {
 
             return NextResponse.json(inserted[0]);
         }
-    } catch (error: any) {
+    } catch (error: unknown) {
         console.error("Resume Save Error:", error);
-        return NextResponse.json({ error: error.message }, { status: 500 });
+        return NextResponse.json({ error: error instanceof Error ? error.message : "Internal Server Error" }, { status: 500 });
     }
 }
 
@@ -110,9 +110,9 @@ export async function GET(req: NextRequest) {
         });
 
         return NextResponse.json(resumes);
-    } catch (error: any) {
+    } catch (error: unknown) {
         console.error("Resume Fetch Error:", error);
-        return NextResponse.json({ error: error.message }, { status: 500 });
+        return NextResponse.json({ error: error instanceof Error ? error.message : "Internal Server Error" }, { status: 500 });
     }
 }
 
@@ -133,24 +133,32 @@ export async function DELETE(req: NextRequest) {
         if (isBlocked) return errorResponse;
 
         const { searchParams } = new URL(req.url);
-        const id = searchParams.get("id");
+        const idParam = searchParams.get("id");
 
-        if (!id) {
+        if (!idParam) {
             return NextResponse.json({ error: "ID is required" }, { status: 400 });
         }
 
+        // Reject anything that isn't a clean integer (e.g. "123abc")
+        if (!/^\d+$/.test(idParam)) {
+            return NextResponse.json({ error: "Invalid ID" }, { status: 400 });
+        }
+
+        const id = parseInt(idParam, 10);
+
+        // Only return the id column — no need to pull the full row (resumeData) just to check existence
         const deleted = await db
             .delete(resumesTable)
-            .where(and(eq(resumesTable.id, parseInt(id)), eq(resumesTable.userEmail, userEmail)))
-            .returning();
+            .where(and(eq(resumesTable.id, id), eq(resumesTable.userEmail, userEmail)))
+            .returning({ id: resumesTable.id });
 
         if (deleted.length === 0) {
             return NextResponse.json({ error: "Resume not found" }, { status: 404 });
         }
 
         return NextResponse.json({ success: true });
-    } catch (error: any) {
+    } catch (error: unknown) {
         console.error("Resume Delete Error:", error);
-        return NextResponse.json({ error: error.message }, { status: 500 });
+        return NextResponse.json({ error: error instanceof Error ? error.message : "Internal Server Error" }, { status: 500 });
     }
 }


### PR DESCRIPTION
## **User description**
## Description
<!-- What does this PR do? Keep it brief but specific. -->
Fixes the DELETE /api/resume-builder endpoint so it correctly reports failure when no resume is deleted. Previously, the delete query filtered by both resume ID and the logged-in user's email but never checked whether a row was actually affected, so the endpoint always returned { success: true } — even for a non-existent resume ID or one belonging to another user.The fix adds .returning() to the delete query (matching the pattern already used in the POST update branch in this file) and checks the result length. If no row was deleted, the endpoint now returns 404 { error: "Resume not found" } instead of a false success.

## Related Issue
<!-- Link the issue this PR addresses. Use "Closes #<number>" to auto-close the issue on merge. -->
Closes #729 

## Type of Change
<!-- Check the relevant option. -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Documentation update (README, guides, comments)
- [ ] Style / UI change (no logic change)
- [ ] Code refactor (no behavior change)
- [ ] Test addition or update
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Screenshots (if UI change)
<!-- Add before/after screenshots for any UI changes. Delete this section if not applicable. -->
N/A

| Before | After |
| :---: | :---: |
| (screenshot) | (screenshot) |

## How Has This Been Tested?
<!-- Describe the tests you ran to verify your changes. -->
- [x] Tested locally with `npm run dev`
- [ ] Verified on mobile viewport (375px)
- [ ] Verified on desktop viewport (1440px)

## Checklist
- [x] I have tested my changes locally (`npm run dev`)
- [x] My code follows the existing code style (TypeScript, Tailwind, no `any` types)
- [x] I have not introduced unrelated changes (each PR should address one issue)
- [x] I have added comments where necessary
- [x] My branch is up to date with `main`
- [x] I have linked the related issue above
- [ ] Screenshots are included (if this is a UI change)


___

## **CodeAnt-AI Description**
**Return a 404 when a resume delete request does not match any resume**

### What Changed
- Deleting a resume now returns `404 Resume not found` when the resume ID does not exist or does not belong to the signed-in user
- Successful deletes still return `{ success: true }`
- The API no longer reports a delete as successful when nothing was removed

### Impact
`✅ Clearer delete errors`
`✅ Fewer false success responses`
`✅ Safer resume deletion`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The resume deletion endpoint now correctly returns a “Resume not found” response when no matching resume exists.
  * Deletion responses now reflect whether a resume was actually removed, instead of always reporting success.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->