### PR TITLE
Fix/resume delete no row check v2

### DIFF
--- a/src/app/api/resume-builder/route.ts
+++ b/src/app/api/resume-builder/route.ts
@@ -133,15 +133,28 @@ export async function DELETE(req: NextRequest) {
         if (isBlocked) return errorResponse;
 
         const { searchParams } = new URL(req.url);
-        const id = searchParams.get("id");
+        const idParam = searchParams.get("id");
 
-        if (!id) {
+        if (!idParam) {
             return NextResponse.json({ error: "ID is required" }, { status: 400 });
         }
 
-        await db
+        // Reject anything that isn't a clean integer (e.g. "123abc")
+        if (!/^\d+$/.test(idParam)) {
+            return NextResponse.json({ error: "Invalid ID" }, { status: 400 });
+        }
+
+        const id = parseInt(idParam, 10);
+
+        // Only return the id column — no need to pull the full row (resumeData) just to check existence
+        const deleted = await db
             .delete(resumesTable)
-            .where(and(eq(resumesTable.id, parseInt(id)), eq(resumesTable.userEmail, userEmail)));
+            .where(and(eq(resumesTable.id, id), eq(resumesTable.userEmail, userEmail)))
+            .returning({ id: resumesTable.id });
+
+        if (deleted.length === 0) {
+            return NextResponse.json({ error: "Resume not found" }, { status: 404 });
+        }
 
         return NextResponse.json({ success: true });
     } catch (error: unknown) {

--- a/src/app/api/resume-builder/route.ts
+++ b/src/app/api/resume-builder/route.ts
@@ -5,6 +5,9 @@ import { eq, and } from "drizzle-orm";
 import { currentUser } from "@clerk/nextjs/server";
 import { checkUserBlock } from "@/lib/auth-utils";
 
+// Postgres 4-byte signed integer max limit
+const MAX_PG_INT = 2147483647;
+
 export async function POST(req: NextRequest) {
     try {
         const user = await currentUser();
@@ -24,6 +27,12 @@ export async function POST(req: NextRequest) {
         const { id, resumeName, resumeData } = await req.json();
 
         if (id) {
+            // Validate incoming ID to prevent database integer overflows
+            const parsedId = parseInt(id, 10);
+            if (isNaN(parsedId) || parsedId < 1 || parsedId > MAX_PG_INT) {
+                return NextResponse.json({ error: "Invalid ID" }, { status: 400 });
+            }
+
             // Update existing
             const updated = await db
                 .update(resumesTable)
@@ -32,8 +41,12 @@ export async function POST(req: NextRequest) {
                     resumeData: JSON.stringify(resumeData),
                     updatedAt: new Date(),
                 })
-                .where(and(eq(resumesTable.id, id), eq(resumesTable.userEmail, userEmail)))
+                .where(and(eq(resumesTable.id, parsedId), eq(resumesTable.userEmail, userEmail)))
                 .returning();
+
+            if (updated.length === 0) {
+                return NextResponse.json({ error: "Resume not found" }, { status: 404 });
+            }
 
             return NextResponse.json(updated[0]);
         } else {
@@ -72,13 +85,23 @@ export async function GET(req: NextRequest) {
         if (isBlocked) return errorResponse;
 
         const { searchParams } = new URL(req.url);
-        const id = searchParams.get("id");
+        const idParam = searchParams.get("id");
 
-        if (id) {
+        if (idParam) {
+            // Validate GET ID parameter
+            if (!/^\d+$/.test(idParam)) {
+                return NextResponse.json({ error: "Invalid ID" }, { status: 400 });
+            }
+
+            const id = parseInt(idParam, 10);
+            if (id > MAX_PG_INT) {
+                return NextResponse.json({ error: "Invalid ID" }, { status: 400 });
+            }
+
             const result = await db
                 .select()
                 .from(resumesTable)
-                .where(and(eq(resumesTable.id, parseInt(id)), eq(resumesTable.userEmail, userEmail)));
+                .where(and(eq(resumesTable.id, id), eq(resumesTable.userEmail, userEmail)));
 
             if (result.length === 0) {
                 return NextResponse.json({ error: "Resume not found" }, { status: 404 });
@@ -139,12 +162,15 @@ export async function DELETE(req: NextRequest) {
             return NextResponse.json({ error: "ID is required" }, { status: 400 });
         }
 
-        // Reject anything that isn't a clean integer (e.g. "123abc")
+        // Clean, structured integer check
         if (!/^\d+$/.test(idParam)) {
             return NextResponse.json({ error: "Invalid ID" }, { status: 400 });
         }
 
         const id = parseInt(idParam, 10);
+        if (id > MAX_PG_INT) {
+             return NextResponse.json({ error: "Invalid ID" }, { status: 400 });
+        }
 
         // Only return the id column — no need to pull the full row (resumeData) just to check existence
         const deleted = await db


### PR DESCRIPTION
## **User description**
## Description
Fixes the DELETE /api/resume-builder endpoint so it correctly reports failure when no resume is deleted. Previously, the delete query filtered by both resume ID and the logged-in user's email but never checked whether a row was actually affected, so the endpoint always returned { success: true } — even for a non-existent resume ID or one belonging to another user.The fix adds .returning() to the delete query (matching the pattern already used in the POST update branch in this file) and checks the result length. If no row was deleted, the endpoint now returns 404 { error: "Resume not found" } instead of a false success.

## Related Issue
<!-- Link the issue this PR addresses. Use "Closes #<number>" to auto-close the issue on merge. -->
Closes #729 

## Type of Change
<!-- Check the relevant option. -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Documentation update (README, guides, comments)
- [ ] Style / UI change (no logic change)
- [ ] Code refactor (no behavior change)
- [ ] Test addition or update
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Screenshots (if UI change)
<!-- Add before/after screenshots for any UI changes. Delete this section if not applicable. -->
N/A
| Before | After |
| :---: | :---: |
| (screenshot) | (screenshot) |

## How Has This Been Tested?
<!-- Describe the tests you ran to verify your changes. -->
- [x] Tested locally with `npm run dev`
- [ ] Verified on mobile viewport (375px)
- [ ] Verified on desktop viewport (1440px)

## Checklist
- [x] I have tested my changes locally (`npm run dev`)
- [x] My code follows the existing code style (TypeScript, Tailwind, no `any` types)
- [x] I have not introduced unrelated changes (each PR should address one issue)
- [x] I have added comments where necessary
- [x] My branch is up to date with `main`
- [x] I have linked the related issue above
- [ ] Screenshots are included (if this is a UI change)


___

## **CodeAnt-AI Description**
**Reject invalid resume IDs and report when delete finds nothing**

### What Changed
- Delete requests now reject missing or malformed resume IDs instead of trying to process them
- If the requested resume does not exist or does not belong to the signed-in user, the API now returns a 404 instead of a false success
- Successful deletes still return success as before

### Impact
`✅ Fewer false delete confirmations`
`✅ Clearer delete errors for missing resumes`
`✅ Safer resume deletion requests`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
