### PR TITLE
fix: add file type validation to Tesseract OCR processing

### DIFF
--- a/src/lib/video/pipeline.ts
+++ b/src/lib/video/pipeline.ts
@@ -35,6 +35,24 @@ export interface VideoProgress {
 
 export type ProgressReporter = (update: VideoProgress) => Promise<void> | void;
 
+const ALLOWED_IMAGE_TYPES = ["image/jpeg", "image/png", "image/gif", "image/webp", "image/bmp", "image/svg+xml", "image/tiff"];
+
+async function validateImageUrl(url: string): Promise<void> {
+  try {
+    const response = await axios.head(url, { timeout: 5000 });
+    const contentType = String(response.headers["content-type"] || "").toLowerCase();
+
+    if (!ALLOWED_IMAGE_TYPES.some(type => contentType.includes(type))) {
+      throw new Error(`Invalid file type: ${contentType || "unknown"}. Only image files are allowed.`);
+    }
+  } catch (error) {
+    if (error instanceof Error && error.message.startsWith("Invalid file type")) {
+      throw error;
+    }
+    throw new Error("Failed to validate image file: unable to fetch file headers");
+  }
+}
+
 export async function cleanupVideoArtifacts(tempDir: string, outputLocation: string): Promise<void> {
   await Promise.all([
     fs.promises.unlink(outputLocation).catch(() => {}),
@@ -109,6 +127,7 @@ export async function runVideoPipeline(
   // 1. OCR if an image is provided and no text content was supplied.
   if (imageUrl && !content) {
     await onProgress({ progress: 10, step: "Reading image (OCR)…" });
+    await validateImageUrl(imageUrl);
     const {
       data: { text },
     } = await Tesseract.recognize(imageUrl, "eng");


### PR DESCRIPTION
## **User description**
Prevents Tesseract OCR from processing non-image files.

- Validate image MIME type before passing to Tesseract.recognize()
- Only allow common image formats (JPEG, PNG, GIF, WebP, BMP, SVG, TIFF)
- Prevent processing of non-image files or malicious file types

Closes #757

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added image URL validation before OCR processing.
  * Unsupported image formats or inaccessible image headers are now rejected earlier.
  * Image validation requests time out after 5 seconds to improve processing reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Tighten form security, limit invite-code brute forcing, and return usable video links**

### What Changed
- Unsubscribe requests now require a matching one-time form token and cookie, and the token is cleared after use
- Joining a classroom by invite code is now rate-limited to reduce repeated guessing attempts
- Completed videos are now returned with time-limited signed links, and temporary video/audio files are cleaned up after processing
- Doubt and reply vote status is now checked only against items on the current page, avoiding unnecessary lookups

### Impact
`✅ Fewer fake unsubscribe submissions`
`✅ Slower invite-code guessing`
`✅ More reliable video playback links`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
