### PR TITLE
fix: reset violationCount and clear block state on expiry in checkUserBlock

### DIFF
--- a/src/lib/auth-utils.ts
+++ b/src/lib/auth-utils.ts
@@ -9,11 +9,18 @@ import { buildErrorResponse } from "@/lib/error-handler";
  * Returns an object containing the block status, an error response if blocked, and the database user object.
  *
  * In production, error responses are sanitised so that no internal details are leaked to the client.
+ *
+ * Block expiry handling:
+ * When a user's block period has elapsed (blockedUntil is in the past), their strike record is
+ * atomically cleared (violationCount → 0, isBlocked → false, blockedUntil → null) so that they
+ * start fresh. Without this reset the old violationCount persists indefinitely, causing the next
+ * moderation flag to immediately re-trigger a block — a permanent punishment loop.
  */
 export async function checkUserBlock(email: string) {
     try {
         const [user] = await db.select().from(usersTable).where(eq(usersTable.email, email));
 
+        // User is actively within a block window → deny access.
         if (user?.blockedUntil && new Date(user.blockedUntil) > new Date()) {
             const unlockDate = new Date(user.blockedUntil).toDateString();
             const { status, body } = buildErrorResponse(
@@ -23,6 +30,27 @@ export async function checkUserBlock(email: string) {
                 isBlocked: true,
                 errorResponse: NextResponse.json(body, { status }),
                 dbUser: user,
+            };
+        }
+
+        // Block has expired: atomically clear the strike record so the user starts fresh.
+        // Without this reset, the stale violationCount means the very next flag re-triggers
+        // a block instantly, creating a permanent punishment loop (issue #344).
+        if (user?.isBlocked && user.blockedUntil && new Date(user.blockedUntil) <= new Date()) {
+            const [clearedUser] = await db
+                .update(usersTable)
+                .set({
+                    isBlocked: false,
+                    blockedUntil: null,
+                    violationCount: 0,
+                })
+                .where(eq(usersTable.email, email))
+                .returning();
+
+            return {
+                isBlocked: false,
+                errorResponse: undefined,
+                dbUser: clearedUser,
             };
         }
 


### PR DESCRIPTION
## **User description**
## Summary

Fixes #344

## Root Cause

When a user's block period elapsed (`blockedUntil` was in the past), the block fields were never cleared. `violationCount` remained at `>= 3`, so the very next moderation flag would add another strike on top of the already-maxed count and instantly re-trigger a block — creating a permanent punishment loop with no recovery path.

## Fix

Added a second conditional in `checkUserBlock` (`src/lib/auth-utils.ts`) that runs **after** the active-block check. When the block window has elapsed, a single `UPDATE … RETURNING` atomically resets:

- `isBlocked → false`
- `blockedUntil → null`
- `violationCount → 0`

The caller always receives a fresh user row, and the active-block path (`blockedUntil > now`) is unaffected.

## Before / After

| Scenario | Before | After |
|---|---|---|
| Block expires, user returns | Still blocked on next flag | Strike count cleared, fresh start |
| Block still active | Correctly blocked | Unchanged |
| User never blocked | No change | No change |

## Files Changed

- `src/lib/auth-utils.ts` — added expired-block reset logic with inline comments

## GSSoC'26

Contributing under GSSoC 2026.


___

## **CodeAnt-AI Description**
**Reset expired block records so users can recover normally**

### What Changed
- When a block has fully expired, the user's block status, expiry time, and strike count are cleared
- Users who are still within the block window are still denied access with the same temporary block message
- This prevents an expired block from immediately triggering a new block on the next moderation flag

### Impact
`✅ Fewer permanent block loops`
`✅ Clearer recovery after serving a temporary block`
`✅ More predictable moderation enforcement`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Expired moderation blocks now clear automatically once the block period has passed.
  * Users are restored to an unblocked state after expiry, including resetting prior strike counts.
  * Access checks now avoid leaving accounts stuck in repeated block cycles after the penalty window ends.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->