### PR TITLE
fix: add sign-out button to DashboardLayout header

### DIFF
--- a/src/components/DashboardLayout.tsx
+++ b/src/components/DashboardLayout.tsx
@@ -102,6 +102,13 @@ export default function DashboardLayout({
               <SignedIn>
                 <div className="flex items-center gap-3">
                   <NotificationBell />
+                  <button
+                    onClick={() => setShowSignOutDialog(true)}
+                    className="p-2 rounded-xl text-slate-500 dark:text-zinc-400 hover:bg-slate-50 dark:hover:bg-zinc-900 transition-all duration-300"
+                    aria-label="Sign out"
+                  >
+                    <LogOut className="w-5 h-5" />
+                  </button>
                 </div>
               </SignedIn>
             </div>


### PR DESCRIPTION
## **User description**
## Description

Adds a sign-out button to the DashboardLayout header. The AlertDialog and `handleSignOut` function already existed but had no trigger — users on dashboard pages could not sign out.

### Bug

`DashboardLayout` defines `showSignOutDialog` state, an `AlertDialog` with confirmation UI, and an async `handleSignOut` function. However, no button or element called `setShowSignOutDialog(true)`, making the sign-out flow unreachable from any dashboard page.

### Fix

Added a `LogOut` icon button next to the NotificationBell that calls `setShowSignOutDialog(true)` when clicked, opening the existing confirmation dialog. The `LogOut` import was already present but unused.

Closes #772


___

## **CodeAnt-AI Description**
**Add a sign-out button to the dashboard header**

### What Changed
- Added a sign-out button next to the notification icon on dashboard pages
- Clicking it opens the existing sign-out confirmation dialog, making sign-out available from the dashboard header

### Impact
`✅ Easier sign-out from dashboard pages`
`✅ Fewer dead-end dashboard sessions`
`✅ Clearer access to account logout`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
