### PR TITLE
fix: require teacher role for analytics export without classroomId

### DIFF
--- a/src/app/api/analytics/export/route.ts
+++ b/src/app/api/analytics/export/route.ts
@@ -45,17 +45,22 @@ export async function GET(req: Request) {
 
     classroomFilter = eq(doubtsTable.classroomId, classroomId);
   } else {
-    // Get all classrooms user is a member of
+    // Get all classrooms user is a TEACHER of
     const userMemberships = await db
       .select({ classroomId: membershipsTable.classroomId })
       .from(membershipsTable)
-      .where(eq(membershipsTable.userEmail, email));
+      .where(
+        and(
+          eq(membershipsTable.userEmail, email),
+          inArray(membershipsTable.role, ["teacher", "owner", "admin"]),
+        ),
+      );
 
     const userClassroomIds = userMemberships.map((m: any) => m.classroomId);
 
     if (userClassroomIds.length === 0) {
       return NextResponse.json({
-        message: "Export route working",
+        message: "No classrooms with teacher access",
       });
     }
 


### PR DESCRIPTION
## **User description**
## Description

Fixes an authorization bypass in the analytics export endpoint. When `classroomId` was omitted, the endpoint only checked classroom membership — not teacher role — allowing any student to export analytics CSV.

### Bug

`GET /api/analytics/export` with no `classroomId` parameter fetched all classrooms the user belonged to (via `membershipsTable`) but never verified teacher role. Students could export analytics including weak topics, top contributors, and engagement metrics.

### Fix

Changed the `else` branch to filter memberships by teacher-level roles (`teacher`, `owner`, `admin`) using `inArray`. Now teacher access is required consistently regardless of whether `classroomId` is specified.

Closes #773


___

## **CodeAnt-AI Description**
**Require teacher access for analytics exports**

### What Changed
- Analytics exports now require teacher-level access even when no classroom is selected
- Users who are only members of a classroom can no longer export its analytics
- If the user has no classrooms with teacher access, the export returns a clear “No classrooms with teacher access” message

### Impact
`✅ Fewer unauthorized analytics exports`
`✅ Clearer access errors for non-teachers`
`✅ Consistent export permissions across classroom and all-classroom views`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved analytics export behavior so classroom exports now only include classrooms where the user has teacher-level access.
  * Updated the empty-state message when no eligible classrooms are found to be more accurate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->