### PR TITLE
fix: prevent comment edit from posting new solution in DoubtRepliesModal

### DIFF
--- a/src/components/DoubtRepliesModal.tsx
+++ b/src/components/DoubtRepliesModal.tsx
@@ -225,9 +225,8 @@ export default function DoubtRepliesModal({ doubt, isOpen, onClose, onReplyChang
 
     const handlePostOrUpdate = () => {
         if (editingId && replies.find(r => r.id === editingId)?.type === 'solution') {
-            // Update mode for solution
             updateSolution();
-        } else {
+        } else if (!editingId) {
             handlePost('solution');
         }
     };


### PR DESCRIPTION
## **User description**
## Description

Fixes a logic bug in `handlePostOrUpdate` where editing a comment would post a new solution instead of updating the comment.

### Bug

`handlePostOrUpdate` checked `editingId` and whether the reply type was `'solution'`. When editing a comment (`type === 'comment'`), the condition failed, falling through to `handlePost('solution')` which posted a new solution — leaving the original comment unchanged.

### Fix

Restructured `handlePostOrUpdate` to only handle solution edits (when `editingId` refers to a solution) and new solution posts (when `editingId` is null). Comment edits are handled inline by `ReplyBubble` and are no longer intercepted.

Closes #774


___

## **CodeAnt-AI Description**
**Prevent comment edits from creating a new solution**

### What Changed
- Editing a comment no longer sends it through the solution-posting path
- Solution edits still update the existing solution as expected
- New solution posts only happen when creating a reply, not while editing an existing comment

### Impact
`✅ Fewer duplicate solutions`
`✅ Safer comment edits`
`✅ Clearer reply updates`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
