### PR TITLE
fix: reset violationCount and clear block state on expiry in checkUserBlock

### DIFF
--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -86,7 +86,7 @@ jest.mock("react-hotkeys-hook", () => ({
     useHotkeys: () => {}
 }));
 
-jest.mock("@/lib/ratelimit", () => {
+jest.mock("@/lib/ratelimit/ratelimit", () => {
     const createLimiter = () => ({
         limit: jest.fn().mockResolvedValue({
             success: true,

--- a/src/__tests__/lib/auth-utils.test.ts
+++ b/src/__tests__/lib/auth-utils.test.ts
@@ -1,0 +1,131 @@
+import { checkUserBlock } from "@/lib/auth-utils";
+
+jest.mock("@/configs/db", () => {
+    const mockReturning = jest.fn();
+    const mockWhere = jest.fn().mockReturnValue({ returning: mockReturning });
+    const mockSet = jest.fn().mockReturnValue({ where: mockWhere });
+    const mockUpdate = jest.fn().mockReturnValue({ set: mockSet });
+
+    const mockSelectWhere = jest.fn();
+    const mockFrom = jest.fn().mockReturnValue({ where: mockSelectWhere });
+    const mockSelect = jest.fn().mockReturnValue({ from: mockFrom });
+
+    return {
+        db: {
+            select: mockSelect,
+            update: mockUpdate,
+        },
+        _mocks: {
+            mockSelect,
+            mockSelectWhere,
+            mockUpdate,
+            mockSet,
+            mockWhere,
+            mockReturning,
+        }
+    };
+});
+
+jest.mock("drizzle-orm", () => ({
+    eq: jest.fn((col, val) => ({ type: "eq", col, val })),
+    and: jest.fn((...args) => ({ type: "and", args })),
+}));
+
+const {
+    mockSelectWhere,
+    mockUpdate,
+    mockWhere,
+    mockReturning,
+} = require("@/configs/db")._mocks;
+
+describe("checkUserBlock", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it("should return isBlocked: false if user does not exist", async () => {
+        mockSelectWhere.mockResolvedValueOnce([]);
+
+        const result = await checkUserBlock("test@example.com");
+
+        expect(result).toEqual({
+            isBlocked: false,
+            errorResponse: undefined,
+            dbUser: undefined,
+        });
+    });
+
+    it("should return isBlocked: false if user is not blocked", async () => {
+        const user = { email: "test@example.com", isBlocked: false, blockedUntil: null };
+        mockSelectWhere.mockResolvedValueOnce([user]);
+
+        const result = await checkUserBlock("test@example.com");
+
+        expect(result).toEqual({
+            isBlocked: false,
+            errorResponse: undefined,
+            dbUser: user,
+        });
+    });
+
+    it("should return isBlocked: true if user is actively blocked", async () => {
+        const futureDate = new Date();
+        futureDate.setDate(futureDate.getDate() + 1);
+        const user = { email: "test@example.com", isBlocked: true, blockedUntil: futureDate };
+        mockSelectWhere.mockResolvedValueOnce([user]);
+
+        const result = await checkUserBlock("test@example.com");
+
+        expect(result.isBlocked).toBe(true);
+        expect(result.errorResponse).toBeDefined();
+        expect(result.dbUser).toEqual(user);
+    });
+
+    it("should atomically clear block state if block has expired and update succeeds", async () => {
+        const pastDate = new Date();
+        pastDate.setDate(pastDate.getDate() - 1);
+        const user = { email: "test@example.com", isBlocked: true, blockedUntil: pastDate };
+        const clearedUser = { email: "test@example.com", isBlocked: false, blockedUntil: null, violationCount: 0 };
+        
+        mockSelectWhere.mockResolvedValueOnce([user]);
+        mockReturning.mockResolvedValueOnce([clearedUser]);
+
+        const result = await checkUserBlock("test@example.com");
+
+        expect(result).toEqual({
+            isBlocked: false,
+            errorResponse: undefined,
+            dbUser: clearedUser,
+        });
+
+        expect(mockUpdate).toHaveBeenCalled();
+        expect(mockWhere).toHaveBeenCalled();
+    });
+
+    it("should retry if concurrent update causes conditional update to fail", async () => {
+        const pastDate = new Date();
+        pastDate.setDate(pastDate.getDate() - 1);
+        const expiredUser = { email: "test@example.com", isBlocked: true, blockedUntil: pastDate };
+        
+        const futureDate = new Date();
+        futureDate.setDate(futureDate.getDate() + 2);
+        const newlyBlockedUser = { email: "test@example.com", isBlocked: true, blockedUntil: futureDate };
+
+        // Attempt 1: Select returns expiredUser. Update returns [] (failed to match condition because of race).
+        mockSelectWhere.mockResolvedValueOnce([expiredUser]);
+        mockReturning.mockResolvedValueOnce([]);
+
+        // Attempt 2: Select returns newlyBlockedUser (actively blocked).
+        mockSelectWhere.mockResolvedValueOnce([newlyBlockedUser]);
+
+        const result = await checkUserBlock("test@example.com");
+
+        // The second attempt should detect they are actively blocked and block them
+        expect(result.isBlocked).toBe(true);
+        expect(result.errorResponse).toBeDefined();
+        expect(result.dbUser).toEqual(newlyBlockedUser);
+
+        expect(mockSelectWhere).toHaveBeenCalledTimes(2);
+        expect(mockUpdate).toHaveBeenCalledTimes(1);
+    });
+});

--- a/src/__tests__/lib/auth-utils.test.ts
+++ b/src/__tests__/lib/auth-utils.test.ts
@@ -1,4 +1,4 @@
-import { checkUserBlock } from "@/lib/auth-utils";
+import { checkUserBlock } from "@/lib/auth/auth-utils";
 
 jest.mock("@/configs/db", () => {
     const mockReturning = jest.fn();
@@ -127,5 +127,33 @@ describe("checkUserBlock", () => {
 
         expect(mockSelectWhere).toHaveBeenCalledTimes(2);
         expect(mockUpdate).toHaveBeenCalledTimes(1);
+    });
+
+    it("fallback after 3 retries should return errorResponse when user is still actively blocked", async () => {
+        const pastDate = new Date();
+        pastDate.setDate(pastDate.getDate() - 1);
+        const expiredUser = { email: "test@example.com", isBlocked: true, blockedUntil: pastDate };
+
+        const futureDate = new Date();
+        futureDate.setDate(futureDate.getDate() + 3);
+        const activelyBlockedUser = { email: "test@example.com", isBlocked: true, blockedUntil: futureDate };
+
+        // All 3 attempts: select expired user, update returns [] (race every time)
+        mockSelectWhere.mockResolvedValueOnce([expiredUser]);
+        mockReturning.mockResolvedValueOnce([]);
+        mockSelectWhere.mockResolvedValueOnce([expiredUser]);
+        mockReturning.mockResolvedValueOnce([]);
+        mockSelectWhere.mockResolvedValueOnce([expiredUser]);
+        mockReturning.mockResolvedValueOnce([]);
+
+        // Fallback read: user is now actively blocked again
+        mockSelectWhere.mockResolvedValueOnce([activelyBlockedUser]);
+
+        const result = await checkUserBlock("test@example.com");
+
+        // Fallback must NOT silently return errorResponse: undefined for a blocked user
+        expect(result.isBlocked).toBe(true);
+        expect(result.errorResponse).toBeDefined();
+        expect(result.dbUser).toEqual(activelyBlockedUser);
     });
 });

--- a/src/lib/auth/auth-utils.ts
+++ b/src/lib/auth/auth-utils.ts
@@ -89,8 +89,21 @@ export async function checkUserBlock(email: string) {
             };
         }
 
-        // Fallback for extreme database contention
+        // Fallback for extreme database contention.
+        // Re-run the same active-block check so callers always receive a consistent
+        // errorResponse whenever the user is still within a block window.
         const [finalUser] = await db.select().from(usersTable).where(eq(usersTable.email, email));
+        if (finalUser?.isBlocked && finalUser.blockedUntil && new Date(finalUser.blockedUntil) > new Date()) {
+            const unlockDate = new Date(finalUser.blockedUntil).toDateString();
+            const { status, body } = buildErrorResponse(
+                new Error(`Your account is temporarily blocked due to safety violations. Access will be restored on ${unlockDate}.`)
+            );
+            return {
+                isBlocked: true,
+                errorResponse: NextResponse.json(body, { status }),
+                dbUser: finalUser,
+            };
+        }
         return {
             isBlocked: finalUser?.isBlocked ?? false,
             errorResponse: undefined,

--- a/src/lib/auth/auth-utils.ts
+++ b/src/lib/auth/auth-utils.ts
@@ -1,6 +1,6 @@
 import { db } from "@/configs/db";
 import { usersTable } from "@/configs/schema";
-import { eq } from "drizzle-orm";
+import { eq, and } from "drizzle-orm";
 import { NextResponse } from "next/server";
 import { buildErrorResponse } from "@/lib/errors/error-handler";
 
@@ -18,46 +18,83 @@ import { buildErrorResponse } from "@/lib/errors/error-handler";
  */
 export async function checkUserBlock(email: string) {
     try {
-        const [user] = await db.select().from(usersTable).where(eq(usersTable.email, email));
+        let attempts = 0;
+        while (attempts < 3) {
+            attempts++;
+            const [user] = await db.select().from(usersTable).where(eq(usersTable.email, email));
 
-        // User is actively within a block window → deny access.
-        if (user?.blockedUntil && new Date(user.blockedUntil) > new Date()) {
-            const unlockDate = new Date(user.blockedUntil).toDateString();
-            const { status, body } = buildErrorResponse(
-                new Error(`Your account is temporarily blocked due to safety violations. Access will be restored on ${unlockDate}.`)
-            );
+            if (!user) {
+                return {
+                    isBlocked: false,
+                    errorResponse: undefined,
+                    dbUser: undefined,
+                };
+            }
+
+            // User is actively within a block window → deny access.
+            if (user.blockedUntil && new Date(user.blockedUntil) > new Date()) {
+                const unlockDate = new Date(user.blockedUntil).toDateString();
+                const { status, body } = buildErrorResponse(
+                    new Error(`Your account is temporarily blocked due to safety violations. Access will be restored on ${unlockDate}.`)
+                );
+                return {
+                    isBlocked: true,
+                    errorResponse: NextResponse.json(body, { status }),
+                    dbUser: user,
+                };
+            }
+
+            // Block has expired: atomically clear the strike record so the user starts fresh.
+            // Without this reset, the stale violationCount means the very next flag re-triggers
+            // a block instantly, creating a permanent punishment loop (issue #344).
+            //
+            // Fix (race condition):
+            // We verify that isBlocked is still true and blockedUntil matches the value we read.
+            // If another concurrent request re-blocked the user in the meantime, the update will
+            // not match any rows (clearedUser is undefined). We then retry the read to get the latest state.
+            if (user.isBlocked && user.blockedUntil && new Date(user.blockedUntil) <= new Date()) {
+                const [clearedUser] = await db
+                    .update(usersTable)
+                    .set({
+                        isBlocked: false,
+                        blockedUntil: null,
+                        violationCount: 0,
+                    })
+                    .where(
+                        and(
+                            eq(usersTable.email, email),
+                            eq(usersTable.isBlocked, true),
+                            eq(usersTable.blockedUntil, user.blockedUntil)
+                        )
+                    )
+                    .returning();
+
+                if (clearedUser) {
+                    return {
+                        isBlocked: false,
+                        errorResponse: undefined,
+                        dbUser: clearedUser,
+                    };
+                }
+
+                // Stale read detected -> retry
+                continue;
+            }
+
+            // User is not blocked or block is already cleared
             return {
-                isBlocked: true,
-                errorResponse: NextResponse.json(body, { status }),
+                isBlocked: false,
+                errorResponse: undefined,
                 dbUser: user,
             };
         }
 
-        // Block has expired: atomically clear the strike record so the user starts fresh.
-        // Without this reset, the stale violationCount means the very next flag re-triggers
-        // a block instantly, creating a permanent punishment loop (issue #344).
-        if (user?.isBlocked && user.blockedUntil && new Date(user.blockedUntil) <= new Date()) {
-            const [clearedUser] = await db
-                .update(usersTable)
-                .set({
-                    isBlocked: false,
-                    blockedUntil: null,
-                    violationCount: 0,
-                })
-                .where(eq(usersTable.email, email))
-                .returning();
-
-            return {
-                isBlocked: false,
-                errorResponse: undefined,
-                dbUser: clearedUser,
-            };
-        }
-
+        // Fallback for extreme database contention
+        const [finalUser] = await db.select().from(usersTable).where(eq(usersTable.email, email));
         return {
-            isBlocked: false,
+            isBlocked: finalUser?.isBlocked ?? false,
             errorResponse: undefined,
-            dbUser: user,
+            dbUser: finalUser,
         };
     } catch (err) {
         const { status, body } = buildErrorResponse(err);

--- a/src/lib/auth/auth-utils.ts
+++ b/src/lib/auth/auth-utils.ts
@@ -9,11 +9,18 @@ import { buildErrorResponse } from "@/lib/errors/error-handler";
  * Returns an object containing the block status, an error response if blocked, and the database user object.
  *
  * In production, error responses are sanitised so that no internal details are leaked to the client.
+ *
+ * Block expiry handling:
+ * When a user's block period has elapsed (blockedUntil is in the past), their strike record is
+ * atomically cleared (violationCount → 0, isBlocked → false, blockedUntil → null) so that they
+ * start fresh. Without this reset the old violationCount persists indefinitely, causing the next
+ * moderation flag to immediately re-trigger a block — a permanent punishment loop.
  */
 export async function checkUserBlock(email: string) {
     try {
         const [user] = await db.select().from(usersTable).where(eq(usersTable.email, email));
 
+        // User is actively within a block window → deny access.
         if (user?.blockedUntil && new Date(user.blockedUntil) > new Date()) {
             const unlockDate = new Date(user.blockedUntil).toDateString();
             const { status, body } = buildErrorResponse(
@@ -23,6 +30,27 @@ export async function checkUserBlock(email: string) {
                 isBlocked: true,
                 errorResponse: NextResponse.json(body, { status }),
                 dbUser: user,
+            };
+        }
+
+        // Block has expired: atomically clear the strike record so the user starts fresh.
+        // Without this reset, the stale violationCount means the very next flag re-triggers
+        // a block instantly, creating a permanent punishment loop (issue #344).
+        if (user?.isBlocked && user.blockedUntil && new Date(user.blockedUntil) <= new Date()) {
+            const [clearedUser] = await db
+                .update(usersTable)
+                .set({
+                    isBlocked: false,
+                    blockedUntil: null,
+                    violationCount: 0,
+                })
+                .where(eq(usersTable.email, email))
+                .returning();
+
+            return {
+                isBlocked: false,
+                errorResponse: undefined,
+                dbUser: clearedUser,
             };
         }
 


### PR DESCRIPTION
## **User description**
Summary
Fixes #344

Root Cause
When a user's block period elapsed (blockedUntil was in the past), the block fields were never cleared. violationCount remained at >= 3, so the very next moderation flag would add another strike on top of the already-maxed count and instantly re-trigger a block — creating a permanent punishment loop with no recovery path.

Fix
Added a second conditional in checkUserBlock (src/lib/auth-utils.ts) that runs after the active-block check. When the block window has elapsed, a single UPDATE … RETURNING atomically resets:

isBlocked → false
blockedUntil → null
violationCount → 0
The caller always receives a fresh user row, and the active-block path (blockedUntil > now) is unaffected.

Additionally, resolved a critical race condition by introducing optimistic concurrency control on the update query and wrapping the check in a retry loop. A comprehensive test suite has also been added in `src/__tests__/lib/auth-utils.test.ts`.

Before / After
Scenario	Before	After
Block expires, user returns	Still blocked on next flag	Strike count cleared, fresh start
Block still active	Correctly blocked	Unchanged
User never blocked	No change	No change

GSSoC'26
Contributing under GSSoC 2026.


___

## **CodeAnt-AI Description**
**Reset expired blocks so users can start fresh**

### What Changed
- When a block period has ended, the user’s block status, expiry date, and strike count are cleared
- Users who are still within an active block window are still denied access with the same block message
- If the block state changes at the same time as the check, the app retries and returns the latest result instead of using stale data
- Added tests for missing users, active blocks, expired blocks, and retry handling

### Impact
`✅ Fewer permanent block loops`
`✅ Shorter recovery after serving a block`
`✅ Clearer block handling during concurrent moderation updates`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved account block handling so expired blocks are cleared automatically and users can regain access as expected.
  * Added safer handling for concurrent updates, reducing cases where a block status could be reported incorrectly.
  * Active blocks still return a clear error response with the unlock date when applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->