### PR TITLE
[Performance]: Parallelize three sequential count queries in notifications GET

### DIFF
--- a/src/app/api/admin/overview/route.ts
+++ b/src/app/api/admin/overview/route.ts
@@ -33,112 +33,135 @@ export async function GET(request: Request) {
         const limit = Math.min(parsePositiveInt(limitStr, 50), 100);
         const offset = parsePositiveInt(offsetStr, 0);
 
-        // 2. Platform-level KPIs
-        const totalUsersResult = await db.select({ value: count() }).from(usersTable);
-        const totalUsers = totalUsersResult[0]?.value || 0;
-
-        const totalClassroomsResult = await db.select({ value: count() }).from(classroomsTable);
-        const totalClassrooms = totalClassroomsResult[0]?.value || 0;
-
-        const totalDoubtsResult = await db.select({ value: count() }).from(doubtsTable).where(isNull(doubtsTable.deletedAt));
-        const totalDoubts = totalDoubtsResult[0]?.value || 0;
-
-        const totalAiCallsResult = await db.select({ value: count() }).from(doubtsTable).where(
-            and(eq(doubtsTable.type, "ai"), isNull(doubtsTable.deletedAt))
-        );
-        const totalAiCalls = totalAiCallsResult[0]?.value || 0;
-
-        const activeConfusionAlertsResult = await db.select({ value: count() }).from(confusionAlertsTable).where(eq(confusionAlertsTable.status, "active"));
-        const activeConfusionAlerts = activeConfusionAlertsResult[0]?.value || 0;
-
-        // 3. User roles breakdown
-        const rolesBreakdown = await db.select({
-            role: usersTable.role,
-            count: count(),
-        })
-        .from(usersTable)
-        .groupBy(usersTable.role);
-
-        // 4. Active classrooms count (classroom with at least 1 doubt in the last 30 days)
+        // 2. Run all independent queries in parallel
         const thirtyDaysAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
-        const activeClassroomsResult = await db.selectDistinct({ id: doubtsTable.classroomId })
+
+        const [
+            totalUsersResult,
+            totalClassroomsResult,
+            totalDoubtsResult,
+            totalAiCallsResult,
+            activeConfusionAlertsResult,
+            rolesBreakdown,
+            activeClassroomsResult,
+            subjectVolume,
+            classrooms,
+            studentCounts,
+            doubtStats,
+            pedagogyStats,
+            activeAlertsPerClassroom,
+            resolutionTimes,
+            confusionAlerts,
+            pendingFlagsResult,
+            totalFlagsResult,
+        ] = await Promise.all([
+            db.select({ value: count() }).from(usersTable),
+            db.select({ value: count() }).from(classroomsTable),
+            db.select({ value: count() }).from(doubtsTable).where(isNull(doubtsTable.deletedAt)),
+            db.select({ value: count() }).from(doubtsTable).where(
+                and(eq(doubtsTable.type, "ai"), isNull(doubtsTable.deletedAt))
+            ),
+            db.select({ value: count() }).from(confusionAlertsTable).where(eq(confusionAlertsTable.status, "active")),
+            db.select({
+                role: usersTable.role,
+                count: count(),
+            })
+            .from(usersTable)
+            .groupBy(usersTable.role),
+            db.selectDistinct({ id: doubtsTable.classroomId })
+                .from(doubtsTable)
+                .where(
+                    and(
+                        isNotNull(doubtsTable.classroomId),
+                        gte(doubtsTable.createdAt, thirtyDaysAgo),
+                        isNull(doubtsTable.deletedAt)
+                    )
+                ),
+            db.select({
+                subject: doubtsTable.subject,
+                count: count(),
+            })
             .from(doubtsTable)
-            .where(
-                and(
-                    isNotNull(doubtsTable.classroomId),
-                    gte(doubtsTable.createdAt, thirtyDaysAgo),
-                    isNull(doubtsTable.deletedAt)
-                )
-            );
+            .where(isNull(doubtsTable.deletedAt))
+            .groupBy(doubtsTable.subject),
+            db.select({
+                id: classroomsTable.id,
+                name: classroomsTable.name,
+                university: classroomsTable.university,
+                year: classroomsTable.year,
+                teacherEmail: classroomsTable.teacherEmail,
+                teacherName: usersTable.name,
+            })
+            .from(classroomsTable)
+            .leftJoin(usersTable, eq(classroomsTable.teacherEmail, usersTable.email))
+            .limit(limit)
+            .offset(offset),
+            db.select({
+                classroomId: membershipsTable.classroomId,
+                count: count(),
+            })
+            .from(membershipsTable)
+            .where(eq(membershipsTable.role, "student"))
+            .groupBy(membershipsTable.classroomId),
+            db.select({
+                classroomId: doubtsTable.classroomId,
+                total: count(),
+                solved: sql<number>`sum(case when ${doubtsTable.isSolved} = 'solved' then 1 else 0 end)::int`,
+            })
+            .from(doubtsTable)
+            .where(isNull(doubtsTable.deletedAt))
+            .groupBy(doubtsTable.classroomId),
+            db.select({
+                classroomId: doubtsTable.classroomId,
+                totalReplies: count(repliesTable.id),
+                driftedReplies: sql<number>`sum(case when ${repliesTable.pedagogyDrifted} = true then 1 else 0 end)::int`,
+            })
+            .from(repliesTable)
+            .innerJoin(doubtsTable, eq(repliesTable.doubtId, doubtsTable.id))
+            .groupBy(doubtsTable.classroomId),
+            db.select({
+                classroomId: confusionAlertsTable.classroomId,
+                count: count(),
+            })
+            .from(confusionAlertsTable)
+            .where(eq(confusionAlertsTable.status, "active"))
+            .groupBy(confusionAlertsTable.classroomId),
+            db.select({
+                classroomId: doubtsTable.classroomId,
+                avgTimeMins: sql<number>`avg(extract(epoch from (${repliesTable.createdAt} - ${doubtsTable.createdAt})) / 60)::int`,
+            })
+            .from(doubtsTable)
+            .innerJoin(repliesTable, eq(doubtsTable.solvedReplyId, repliesTable.id))
+            .where(isNull(doubtsTable.deletedAt))
+            .groupBy(doubtsTable.classroomId),
+            db.select({
+                id: confusionAlertsTable.id,
+                classroomId: confusionAlertsTable.classroomId,
+                classroomName: classroomsTable.name,
+                topic: confusionAlertsTable.topic,
+                summary: confusionAlertsTable.summary,
+                suggestedAction: confusionAlertsTable.suggestedAction,
+                confidence: confusionAlertsTable.confidence,
+                doubtCount: confusionAlertsTable.doubtCount,
+                createdAt: confusionAlertsTable.createdAt,
+            })
+            .from(confusionAlertsTable)
+            .innerJoin(classroomsTable, eq(confusionAlertsTable.classroomId, classroomsTable.id))
+            .where(eq(confusionAlertsTable.status, "active"))
+            .orderBy(desc(confusionAlertsTable.createdAt)),
+            db.select({ value: count() }).from(moderationLogsTable).where(eq(moderationLogsTable.status, "pending")),
+            db.select({ value: count() }).from(moderationLogsTable),
+        ]);
+
+        const totalUsers = totalUsersResult[0]?.value || 0;
+        const totalClassrooms = totalClassroomsResult[0]?.value || 0;
+        const totalDoubts = totalDoubtsResult[0]?.value || 0;
+        const totalAiCalls = totalAiCallsResult[0]?.value || 0;
+        const activeConfusionAlerts = activeConfusionAlertsResult[0]?.value || 0;
         const activeClassrooms = activeClassroomsResult.length;
         const inactiveClassrooms = Math.max(0, totalClassrooms - activeClassrooms);
-
-        // 5. Subject popularity breakdown
-        const subjectVolume = await db.select({
-            subject: doubtsTable.subject,
-            count: count(),
-        })
-        .from(doubtsTable)
-        .where(isNull(doubtsTable.deletedAt))
-        .groupBy(doubtsTable.subject);
-
-        // 6. Detailed classroom health stats
-        const classrooms = await db.select({
-            id: classroomsTable.id,
-            name: classroomsTable.name,
-            university: classroomsTable.university,
-            year: classroomsTable.year,
-            teacherEmail: classroomsTable.teacherEmail,
-            teacherName: usersTable.name,
-        })
-        .from(classroomsTable)
-        .leftJoin(usersTable, eq(classroomsTable.teacherEmail, usersTable.email))
-        .limit(limit)
-        .offset(offset);
-
-        // Sub-queries/Aggregates mapped in JS to stay highly optimized
-        const studentCounts = await db.select({
-            classroomId: membershipsTable.classroomId,
-            count: count(),
-        })
-        .from(membershipsTable)
-        .where(eq(membershipsTable.role, "student"))
-        .groupBy(membershipsTable.classroomId);
-
-        const doubtStats = await db.select({
-            classroomId: doubtsTable.classroomId,
-            total: count(),
-            solved: sql<number>`sum(case when ${doubtsTable.isSolved} = 'solved' then 1 else 0 end)::int`,
-        })
-        .from(doubtsTable)
-        .where(isNull(doubtsTable.deletedAt))
-        .groupBy(doubtsTable.classroomId);
-
-        const pedagogyStats = await db.select({
-            classroomId: doubtsTable.classroomId,
-            totalReplies: count(repliesTable.id),
-            driftedReplies: sql<number>`sum(case when ${repliesTable.pedagogyDrifted} = true then 1 else 0 end)::int`,
-        })
-        .from(repliesTable)
-        .innerJoin(doubtsTable, eq(repliesTable.doubtId, doubtsTable.id))
-        .groupBy(doubtsTable.classroomId);
-
-        const activeAlertsPerClassroom = await db.select({
-            classroomId: confusionAlertsTable.classroomId,
-            count: count(),
-        })
-        .from(confusionAlertsTable)
-        .where(eq(confusionAlertsTable.status, "active"))
-        .groupBy(confusionAlertsTable.classroomId);
-
-        const resolutionTimes = await db.select({
-            classroomId: doubtsTable.classroomId,
-            avgTimeMins: sql<number>`avg(extract(epoch from (${repliesTable.createdAt} - ${doubtsTable.createdAt})) / 60)::int`,
-        })
-        .from(doubtsTable)
-        .innerJoin(repliesTable, eq(doubtsTable.solvedReplyId, repliesTable.id))
-        .where(isNull(doubtsTable.deletedAt))
-        .groupBy(doubtsTable.classroomId);
+        const pendingFlags = pendingFlagsResult[0]?.value || 0;
+        const totalFlags = totalFlagsResult[0]?.value || 0;
 
         // Build mapping helpers
         const studentCountMap = new Map(studentCounts.map((c: any) => [c.classroomId, c.count]));
@@ -179,30 +202,6 @@ export async function GET(request: Request) {
                 alertsCount
             };
         });
-
-        // 7. Active confusion alerts details
-        const confusionAlerts = await db.select({
-            id: confusionAlertsTable.id,
-            classroomId: confusionAlertsTable.classroomId,
-            classroomName: classroomsTable.name,
-            topic: confusionAlertsTable.topic,
-            summary: confusionAlertsTable.summary,
-            suggestedAction: confusionAlertsTable.suggestedAction,
-            confidence: confusionAlertsTable.confidence,
-            doubtCount: confusionAlertsTable.doubtCount,
-            createdAt: confusionAlertsTable.createdAt,
-        })
-        .from(confusionAlertsTable)
-        .innerJoin(classroomsTable, eq(confusionAlertsTable.classroomId, classroomsTable.id))
-        .where(eq(confusionAlertsTable.status, "active"))
-        .orderBy(desc(confusionAlertsTable.createdAt));
-
-        // 8. Moderation overview
-        const pendingFlagsResult = await db.select({ value: count() }).from(moderationLogsTable).where(eq(moderationLogsTable.status, "pending"));
-        const pendingFlags = pendingFlagsResult[0]?.value || 0;
-
-        const totalFlagsResult = await db.select({ value: count() }).from(moderationLogsTable);
-        const totalFlags = totalFlagsResult[0]?.value || 0;
 
         // return compiled JSON response
         return successResponse({

--- a/src/app/api/admin/overview/route.ts
+++ b/src/app/api/admin/overview/route.ts
@@ -33,135 +33,112 @@ export async function GET(request: Request) {
         const limit = Math.min(parsePositiveInt(limitStr, 50), 100);
         const offset = parsePositiveInt(offsetStr, 0);
 
-        // 2. Run all independent queries in parallel
-        const thirtyDaysAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
-
-        const [
-            totalUsersResult,
-            totalClassroomsResult,
-            totalDoubtsResult,
-            totalAiCallsResult,
-            activeConfusionAlertsResult,
-            rolesBreakdown,
-            activeClassroomsResult,
-            subjectVolume,
-            classrooms,
-            studentCounts,
-            doubtStats,
-            pedagogyStats,
-            activeAlertsPerClassroom,
-            resolutionTimes,
-            confusionAlerts,
-            pendingFlagsResult,
-            totalFlagsResult,
-        ] = await Promise.all([
-            db.select({ value: count() }).from(usersTable),
-            db.select({ value: count() }).from(classroomsTable),
-            db.select({ value: count() }).from(doubtsTable).where(isNull(doubtsTable.deletedAt)),
-            db.select({ value: count() }).from(doubtsTable).where(
-                and(eq(doubtsTable.type, "ai"), isNull(doubtsTable.deletedAt))
-            ),
-            db.select({ value: count() }).from(confusionAlertsTable).where(eq(confusionAlertsTable.status, "active")),
-            db.select({
-                role: usersTable.role,
-                count: count(),
-            })
-            .from(usersTable)
-            .groupBy(usersTable.role),
-            db.selectDistinct({ id: doubtsTable.classroomId })
-                .from(doubtsTable)
-                .where(
-                    and(
-                        isNotNull(doubtsTable.classroomId),
-                        gte(doubtsTable.createdAt, thirtyDaysAgo),
-                        isNull(doubtsTable.deletedAt)
-                    )
-                ),
-            db.select({
-                subject: doubtsTable.subject,
-                count: count(),
-            })
-            .from(doubtsTable)
-            .where(isNull(doubtsTable.deletedAt))
-            .groupBy(doubtsTable.subject),
-            db.select({
-                id: classroomsTable.id,
-                name: classroomsTable.name,
-                university: classroomsTable.university,
-                year: classroomsTable.year,
-                teacherEmail: classroomsTable.teacherEmail,
-                teacherName: usersTable.name,
-            })
-            .from(classroomsTable)
-            .leftJoin(usersTable, eq(classroomsTable.teacherEmail, usersTable.email))
-            .limit(limit)
-            .offset(offset),
-            db.select({
-                classroomId: membershipsTable.classroomId,
-                count: count(),
-            })
-            .from(membershipsTable)
-            .where(eq(membershipsTable.role, "student"))
-            .groupBy(membershipsTable.classroomId),
-            db.select({
-                classroomId: doubtsTable.classroomId,
-                total: count(),
-                solved: sql<number>`sum(case when ${doubtsTable.isSolved} = 'solved' then 1 else 0 end)::int`,
-            })
-            .from(doubtsTable)
-            .where(isNull(doubtsTable.deletedAt))
-            .groupBy(doubtsTable.classroomId),
-            db.select({
-                classroomId: doubtsTable.classroomId,
-                totalReplies: count(repliesTable.id),
-                driftedReplies: sql<number>`sum(case when ${repliesTable.pedagogyDrifted} = true then 1 else 0 end)::int`,
-            })
-            .from(repliesTable)
-            .innerJoin(doubtsTable, eq(repliesTable.doubtId, doubtsTable.id))
-            .groupBy(doubtsTable.classroomId),
-            db.select({
-                classroomId: confusionAlertsTable.classroomId,
-                count: count(),
-            })
-            .from(confusionAlertsTable)
-            .where(eq(confusionAlertsTable.status, "active"))
-            .groupBy(confusionAlertsTable.classroomId),
-            db.select({
-                classroomId: doubtsTable.classroomId,
-                avgTimeMins: sql<number>`avg(extract(epoch from (${repliesTable.createdAt} - ${doubtsTable.createdAt})) / 60)::int`,
-            })
-            .from(doubtsTable)
-            .innerJoin(repliesTable, eq(doubtsTable.solvedReplyId, repliesTable.id))
-            .where(isNull(doubtsTable.deletedAt))
-            .groupBy(doubtsTable.classroomId),
-            db.select({
-                id: confusionAlertsTable.id,
-                classroomId: confusionAlertsTable.classroomId,
-                classroomName: classroomsTable.name,
-                topic: confusionAlertsTable.topic,
-                summary: confusionAlertsTable.summary,
-                suggestedAction: confusionAlertsTable.suggestedAction,
-                confidence: confusionAlertsTable.confidence,
-                doubtCount: confusionAlertsTable.doubtCount,
-                createdAt: confusionAlertsTable.createdAt,
-            })
-            .from(confusionAlertsTable)
-            .innerJoin(classroomsTable, eq(confusionAlertsTable.classroomId, classroomsTable.id))
-            .where(eq(confusionAlertsTable.status, "active"))
-            .orderBy(desc(confusionAlertsTable.createdAt)),
-            db.select({ value: count() }).from(moderationLogsTable).where(eq(moderationLogsTable.status, "pending")),
-            db.select({ value: count() }).from(moderationLogsTable),
-        ]);
-
+        // 2. Platform-level KPIs
+        const totalUsersResult = await db.select({ value: count() }).from(usersTable);
         const totalUsers = totalUsersResult[0]?.value || 0;
+
+        const totalClassroomsResult = await db.select({ value: count() }).from(classroomsTable);
         const totalClassrooms = totalClassroomsResult[0]?.value || 0;
+
+        const totalDoubtsResult = await db.select({ value: count() }).from(doubtsTable).where(isNull(doubtsTable.deletedAt));
         const totalDoubts = totalDoubtsResult[0]?.value || 0;
+
+        const totalAiCallsResult = await db.select({ value: count() }).from(doubtsTable).where(
+            and(eq(doubtsTable.type, "ai"), isNull(doubtsTable.deletedAt))
+        );
         const totalAiCalls = totalAiCallsResult[0]?.value || 0;
+
+        const activeConfusionAlertsResult = await db.select({ value: count() }).from(confusionAlertsTable).where(eq(confusionAlertsTable.status, "active"));
         const activeConfusionAlerts = activeConfusionAlertsResult[0]?.value || 0;
+
+        // 3. User roles breakdown
+        const rolesBreakdown = await db.select({
+            role: usersTable.role,
+            count: count(),
+        })
+        .from(usersTable)
+        .groupBy(usersTable.role);
+
+        // 4. Active classrooms count (classroom with at least 1 doubt in the last 30 days)
+        const thirtyDaysAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+        const activeClassroomsResult = await db.selectDistinct({ id: doubtsTable.classroomId })
+            .from(doubtsTable)
+            .where(
+                and(
+                    isNotNull(doubtsTable.classroomId),
+                    gte(doubtsTable.createdAt, thirtyDaysAgo),
+                    isNull(doubtsTable.deletedAt)
+                )
+            );
         const activeClassrooms = activeClassroomsResult.length;
         const inactiveClassrooms = Math.max(0, totalClassrooms - activeClassrooms);
-        const pendingFlags = pendingFlagsResult[0]?.value || 0;
-        const totalFlags = totalFlagsResult[0]?.value || 0;
+
+        // 5. Subject popularity breakdown
+        const subjectVolume = await db.select({
+            subject: doubtsTable.subject,
+            count: count(),
+        })
+        .from(doubtsTable)
+        .where(isNull(doubtsTable.deletedAt))
+        .groupBy(doubtsTable.subject);
+
+        // 6. Detailed classroom health stats
+        const classrooms = await db.select({
+            id: classroomsTable.id,
+            name: classroomsTable.name,
+            university: classroomsTable.university,
+            year: classroomsTable.year,
+            teacherEmail: classroomsTable.teacherEmail,
+            teacherName: usersTable.name,
+        })
+        .from(classroomsTable)
+        .leftJoin(usersTable, eq(classroomsTable.teacherEmail, usersTable.email))
+        .limit(limit)
+        .offset(offset);
+
+        // Sub-queries/Aggregates mapped in JS to stay highly optimized
+        const studentCounts = await db.select({
+            classroomId: membershipsTable.classroomId,
+            count: count(),
+        })
+        .from(membershipsTable)
+        .where(eq(membershipsTable.role, "student"))
+        .groupBy(membershipsTable.classroomId);
+
+        const doubtStats = await db.select({
+            classroomId: doubtsTable.classroomId,
+            total: count(),
+            solved: sql<number>`sum(case when ${doubtsTable.isSolved} = 'solved' then 1 else 0 end)::int`,
+        })
+        .from(doubtsTable)
+        .where(isNull(doubtsTable.deletedAt))
+        .groupBy(doubtsTable.classroomId);
+
+        const pedagogyStats = await db.select({
+            classroomId: doubtsTable.classroomId,
+            totalReplies: count(repliesTable.id),
+            driftedReplies: sql<number>`sum(case when ${repliesTable.pedagogyDrifted} = true then 1 else 0 end)::int`,
+        })
+        .from(repliesTable)
+        .innerJoin(doubtsTable, eq(repliesTable.doubtId, doubtsTable.id))
+        .groupBy(doubtsTable.classroomId);
+
+        const activeAlertsPerClassroom = await db.select({
+            classroomId: confusionAlertsTable.classroomId,
+            count: count(),
+        })
+        .from(confusionAlertsTable)
+        .where(eq(confusionAlertsTable.status, "active"))
+        .groupBy(confusionAlertsTable.classroomId);
+
+        const resolutionTimes = await db.select({
+            classroomId: doubtsTable.classroomId,
+            avgTimeMins: sql<number>`avg(extract(epoch from (${repliesTable.createdAt} - ${doubtsTable.createdAt})) / 60)::int`,
+        })
+        .from(doubtsTable)
+        .innerJoin(repliesTable, eq(doubtsTable.solvedReplyId, repliesTable.id))
+        .where(isNull(doubtsTable.deletedAt))
+        .groupBy(doubtsTable.classroomId);
 
         // Build mapping helpers
         const studentCountMap = new Map(studentCounts.map((c: any) => [c.classroomId, c.count]));
@@ -202,6 +179,30 @@ export async function GET(request: Request) {
                 alertsCount
             };
         });
+
+        // 7. Active confusion alerts details
+        const confusionAlerts = await db.select({
+            id: confusionAlertsTable.id,
+            classroomId: confusionAlertsTable.classroomId,
+            classroomName: classroomsTable.name,
+            topic: confusionAlertsTable.topic,
+            summary: confusionAlertsTable.summary,
+            suggestedAction: confusionAlertsTable.suggestedAction,
+            confidence: confusionAlertsTable.confidence,
+            doubtCount: confusionAlertsTable.doubtCount,
+            createdAt: confusionAlertsTable.createdAt,
+        })
+        .from(confusionAlertsTable)
+        .innerJoin(classroomsTable, eq(confusionAlertsTable.classroomId, classroomsTable.id))
+        .where(eq(confusionAlertsTable.status, "active"))
+        .orderBy(desc(confusionAlertsTable.createdAt));
+
+        // 8. Moderation overview
+        const pendingFlagsResult = await db.select({ value: count() }).from(moderationLogsTable).where(eq(moderationLogsTable.status, "pending"));
+        const pendingFlags = pendingFlagsResult[0]?.value || 0;
+
+        const totalFlagsResult = await db.select({ value: count() }).from(moderationLogsTable);
+        const totalFlags = totalFlagsResult[0]?.value || 0;
 
         // return compiled JSON response
         return successResponse({

--- a/src/app/api/notifications/route.ts
+++ b/src/app/api/notifications/route.ts
@@ -25,33 +25,29 @@ export async function GET(req: Request) {
             : (pageStr ? (parsePositiveInt(pageStr, 1) - 1) * limit : 0);
         const page = Math.floor(offset / limit) + 1;
 
-        // Calculate total count globally
-        const [totalCountRow] = await db
-            .select({ count: sql<number>`count(*)::int` })
-            .from(notificationsTable)
-            .where(eq(notificationsTable.userEmail, userEmail));
+        // Run all independent queries in parallel
+        const [[totalCountRow], [unreadCountRow], notifications] = await Promise.all([
+            db.select({ count: sql<number>`count(*)::int` })
+                .from(notificationsTable)
+                .where(eq(notificationsTable.userEmail, userEmail)),
+            db.select({ count: sql<number>`count(*)::int` })
+                .from(notificationsTable)
+                .where(and(
+                    eq(notificationsTable.userEmail, userEmail),
+                    eq(notificationsTable.isRead, false)
+                )),
+            db.select()
+                .from(notificationsTable)
+                .where(eq(notificationsTable.userEmail, userEmail))
+                .orderBy(
+                    desc(notificationsTable.createdAt),
+                    desc(notificationsTable.id)
+                )
+                .limit(limit)
+                .offset(offset),
+        ]);
         const totalCount = totalCountRow?.count ?? 0;
-
-        // Calculate unread count globally
-        const [unreadCountRow] = await db
-            .select({ count: sql<number>`count(*)::int` })
-            .from(notificationsTable)
-            .where(and(
-                eq(notificationsTable.userEmail, userEmail),
-                eq(notificationsTable.isRead, false)
-            ));
         const unreadCount = unreadCountRow?.count ?? 0;
-
-        // Fetch user's notifications, ordered by most recent first
-        const notifications = await db.select()
-            .from(notificationsTable)
-            .where(eq(notificationsTable.userEmail, userEmail))
-            .orderBy(
-                desc(notificationsTable.createdAt),
-                desc(notificationsTable.id)
-            )
-            .limit(limit)
-            .offset(offset);
 
         const hasMore = offset + notifications.length < totalCount;
 


### PR DESCRIPTION
## **User description**
## Description
Reduced the notifications GET endpoint from 3 sequential DB round trips to 1
parallelized `Promise.all()` call. The `totalCount`, `unreadCount`, and
`notifications` queries are independent and now execute concurrently, cutting
response latency from the sum of their durations to roughly the slowest
single query.

## Related Issue
<!-- Link the issue this PR addresses. Use "Closes #<number>" to auto-close the issue on merge. -->
Closes #806 

## Type of Change
<!-- Check the relevant option. -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Documentation update (README, guides, comments)
- [ ] Style / UI change (no logic change)
- [ ] Code refactor (no behavior change)
- [ ] Test addition or update
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## How Has This Been Tested?
<!-- Describe the tests you ran to verify your changes. -->
- [x] Tested locally with `npm run dev`
- [ ] Verified on mobile viewport (375px)
- [ ] Verified on desktop viewport (1440px)

## Checklist
- [x] I have tested my changes locally (`npm run dev`)
- [x] My code follows the existing code style (TypeScript, Tailwind, no `any` types)
- [x] I have not introduced unrelated changes (each PR should address one issue)
- [x] I have added comments where necessary
- [x] My branch is up to date with `main`
- [x] I have linked the related issue above
- [ ] Screenshots are included (if this is a UI change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Admin overview data now loads faster by fetching multiple metrics at the same time.
  * Notifications refresh more quickly with parallel data loading, improving response time while keeping the same results and layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Notifications load faster by fetching counts and items at the same time**

### What Changed
- The notifications page now gets the total count, unread count, and current page of notifications in parallel instead of waiting for each one in sequence
- This reduces the time it takes to open the notifications list, especially when the account has many notifications
- The returned data and pagination behavior stay the same

### Impact
`✅ Faster notifications loading`
`✅ Fewer waits on busy accounts`
`✅ Smoother pagination`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
