### PR TITLE
fix(security): add CSRF protection to unsubscribe route

### DIFF
--- a/src/__tests__/api/unsubscribe.test.ts
+++ b/src/__tests__/api/unsubscribe.test.ts
@@ -54,11 +54,64 @@ function makeUnsignedRequest(method: string, ip: string) {
     });
 }
 
+/** In the test (non-production) env the CSRF cookie drops the `__Host-` prefix. */
+const CSRF_COOKIE = 'csrf_unsub';
+
+/**
+ * Perform the GET that renders the unsubscribe form, then return the nonce the
+ * server set (via the Set-Cookie on the GET response) so a follow-up POST can
+ * replay a legitimate, same-origin submission.
+ */
+async function fetchCsrfNonce(email = 'Student@College.edu'): Promise<string> {
+    const res = await GET(makeSignedRequest('GET', email));
+    const nonce = res.cookies.get(CSRF_COOKIE)?.value;
+    if (!nonce) throw new Error('GET did not set a CSRF nonce cookie');
+    return nonce;
+}
+
+/**
+ * Build a POST that mimics the legitimate browser flow: the nonce hidden in the
+ * form body matches the nonce stored in the HttpOnly cookie. Without both
+ * values present and equal, the route refuses the submission.
+ */
+async function makeSignedPostRequest(email = 'Student@College.edu') {
+    const nonce = await fetchCsrfNonce(email);
+    const expires = Date.now() + 60_000;
+    const token = generateUnsubscribeToken(email, expires);
+    const url = `http://localhost/api/unsubscribe?email=${encodeURIComponent(email)}&expires=${expires}&token=${token}`;
+
+    return new NextRequest(url, {
+        method: 'POST',
+        headers: {
+            'x-forwarded-for': '127.0.0.1',
+            'content-type': 'application/x-www-form-urlencoded',
+            cookie: `${CSRF_COOKIE}=${nonce}`,
+        },
+        body: `csrf_nonce=${nonce}`,
+    });
+}
+
 describe('Unsubscribe API Endpoint', () => {
     beforeEach(() => {
         process.env.UNSUBSCRIBE_SECRET = 'test-unsubscribe-secret';
         jest.clearAllMocks();
         currentUserMock.mockResolvedValue(null);
+    });
+
+    it('emits a CSRF nonce cookie and embeds the same nonce in the form', async () => {
+        const res = await GET(makeSignedRequest('GET'));
+
+        expect(res.status).toBe(200);
+        expect(res.headers.get('content-type')).toContain('text/html');
+        expect(res.headers.get('cache-control')).toBe('no-store');
+
+        const nonce = res.cookies.get(CSRF_COOKIE)?.value;
+        expect(nonce).toBeTruthy();
+        expect(res.cookies.get(CSRF_COOKIE)?.httpOnly).toBe(true);
+        expect(res.cookies.get(CSRF_COOKIE)?.sameSite).toBe('strict');
+        // The form body must contain the same nonce so the POST can verify it.
+        expect(await res.text()).toContain(`name="csrf_nonce" value="${nonce}"`);
+        expect(mockUpdate).not.toHaveBeenCalled();
     });
 
     it('does not change notification preferences on GET', async () => {
@@ -67,6 +120,35 @@ describe('Unsubscribe API Endpoint', () => {
         expect(res.status).toBe(200);
         expect(res.headers.get('content-type')).toContain('text/html');
         expect(res.headers.get('cache-control')).toBe('no-store');
+        expect(mockUpdate).not.toHaveBeenCalled();
+    });
+
+    it('blocks a POST that is missing the CSRF nonce (cross-site style)', async () => {
+        const res = await POST(makeSignedRequest('POST'));
+
+        expect(res.status).toBe(307);
+        expect(res.headers.get('location')).toContain('Invalid%20form%20submission');
+        expect(mockUpdate).not.toHaveBeenCalled();
+    });
+
+    it('blocks a POST whose form nonce does not match the cookie nonce', async () => {
+        const nonce = await fetchCsrfNonce();
+        const expires = Date.now() + 60_000;
+        const token = generateUnsubscribeToken('Student@College.edu', expires);
+        const url = `http://localhost/api/unsubscribe?email=${encodeURIComponent('Student@College.edu')}&expires=${expires}&token=${token}`;
+
+        const res = await POST(new NextRequest(url, {
+            method: 'POST',
+            headers: {
+                'x-forwarded-for': '127.0.0.1',
+                'content-type': 'application/x-www-form-urlencoded',
+                cookie: `${CSRF_COOKIE}=${nonce}`,
+            },
+            body: 'csrf_nonce=deadbeefdeadbeefdeadbeefdeadbeef',
+        }));
+
+        expect(res.status).toBe(307);
+        expect(res.headers.get('location')).toContain('Invalid%20form%20submission');
         expect(mockUpdate).not.toHaveBeenCalled();
     });
 
@@ -104,8 +186,8 @@ describe('Unsubscribe API Endpoint', () => {
         expect(mockUpdate).not.toHaveBeenCalled();
     });
 
-    it('updates notification preferences only for a valid signed POST', async () => {
-        const res = await POST(makeSignedRequest('POST'));
+    it('updates notification preferences only for a valid signed POST with matching CSRF nonce', async () => {
+        const res = await POST(await makeSignedPostRequest());
 
         expect(res.status).toBe(307);
         expect(res.headers.get('location')).toBe('http://localhost/profile?unsubscribed=true');
@@ -115,6 +197,8 @@ describe('Unsubscribe API Endpoint', () => {
             notificationPreference: 'none',
         });
         expect(mockWhere).toHaveBeenCalledWith({ field: 'email', value: 'student@college.edu' });
+        // Cookie is cleared after a successful, one-time use.
+        expect(res.cookies.get(CSRF_COOKIE)?.maxAge).toBe(0);
     });
 
     it('refuses to unsubscribe when the signed-in user does not match the token email', async () => {
@@ -122,7 +206,7 @@ describe('Unsubscribe API Endpoint', () => {
             primaryEmailAddress: { emailAddress: 'attacker@example.com' },
         });
 
-        const res = await POST(makeSignedRequest('POST'));
+        const res = await POST(await makeSignedPostRequest());
 
         expect(res.status).toBe(307);
         expect(res.headers.get('location')).toContain('Signed-in%20user%20does%20not%20match');

--- a/src/app/api/unsubscribe/route.ts
+++ b/src/app/api/unsubscribe/route.ts
@@ -4,15 +4,32 @@ import { currentUser } from "@clerk/nextjs/server";
 import { db } from "@/configs/db";
 import { usersTable } from "@/configs/schema";
 import { verifyUnsubscribeToken } from "@/lib/email/email";
+import { randomBytes } from "crypto";
 
 const RATE_LIMIT_WINDOW_MS = 60 * 1000;
 const RATE_LIMIT_MAX_REQUESTS = 10;
 const unsubscribeAttempts = new Map<string, { count: number; resetAt: number }>();
 
+/**
+ * CSRF protection cookie name.
+ *
+ * The `__Host-` prefix is a browser security feature: it forces the browser
+ * to only send this cookie to the exact origin that set it, with Path=/,
+ * and only over HTTPS. This prevents subdomain-injection attacks.
+ * In development (HTTP) the prefix is dropped gracefully.
+ */
+const CSRF_COOKIE =
+    process.env.NODE_ENV === "production" ? "__Host-csrf_unsub" : "csrf_unsub";
+
+/** CSRF nonce TTL — must be consumed within 15 minutes of the GET. */
+const CSRF_COOKIE_MAX_AGE_SECONDS = 15 * 60;
+
 function getClientIp(req: NextRequest) {
-    return req.headers.get("x-forwarded-for")?.split(",")[0]?.trim()
-        || req.headers.get("x-real-ip")
-        || "unknown";
+    return (
+        req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
+        req.headers.get("x-real-ip") ||
+        "unknown"
+    );
 }
 
 function isRateLimited(ip: string) {
@@ -55,6 +72,11 @@ function escapeHtml(value: string) {
         .replace(/'/g, "&#039;");
 }
 
+/** Generate a cryptographically random hex nonce. */
+function generateNonce(): string {
+    return randomBytes(32).toString("hex");
+}
+
 export async function GET(req: NextRequest) {
     const { email, expires, token } = getParams(req);
 
@@ -62,10 +84,15 @@ export async function GET(req: NextRequest) {
         return redirectWithError(req, "Invalid or expired unsubscribe link");
     }
 
+    // Generate a one-time CSRF nonce and embed it in both the form (hidden
+    // field) and a short-lived HttpOnly cookie. The POST handler verifies that
+    // both values match — a cross-site form cannot read the HttpOnly cookie, so
+    // it cannot supply the correct nonce even if it knows the unsubscribe URL.
+    const nonce = generateNonce();
+
     const unsubscribeAction = `/api/unsubscribe?email=${encodeURIComponent(email!)}&expires=${encodeURIComponent(expires!)}&token=${encodeURIComponent(token!)}`;
 
-    return new NextResponse(
-        `<!DOCTYPE html>
+    const html = `<!DOCTYPE html>
         <html lang="en">
             <head>
                 <meta charset="UTF-8" />
@@ -77,19 +104,34 @@ export async function GET(req: NextRequest) {
                     <h1 style="font-size:24px;margin:0 0 12px;">Unsubscribe from email notifications?</h1>
                     <p style="line-height:1.5;color:#cbd5e1;">This will turn off DoubtDesk email notifications for ${escapeHtml(email!)}.</p>
                     <form method="POST" action="${unsubscribeAction}">
+                        <input type="hidden" name="csrf_nonce" value="${escapeHtml(nonce)}" />
                         <button type="submit" style="border:0;border-radius:8px;background:#4f46e5;color:white;font-weight:700;padding:12px 18px;cursor:pointer;" >Unsubscribe</button>
                     </form>
                 </main>
             </body>
-        </html>`,
-        {
-            status: 200,
-            headers: {
-                "Content-Type": "text/html; charset=utf-8",
-                "Cache-Control": "no-store",
-            },
-        }
-    );
+        </html>`;
+
+    const res = new NextResponse(html, {
+        status: 200,
+        headers: {
+            "Content-Type": "text/html; charset=utf-8",
+            "Cache-Control": "no-store",
+        },
+    });
+
+    // Store the nonce in a short-lived, HttpOnly, SameSite=Strict cookie.
+    // A cross-site attacker cannot read HttpOnly cookies via JS, and
+    // SameSite=Strict prevents the browser from sending the cookie on
+    // cross-site form POSTs — providing defence-in-depth.
+    res.cookies.set(CSRF_COOKIE, nonce, {
+        httpOnly: true,
+        secure: process.env.NODE_ENV === "production",
+        sameSite: "strict",
+        maxAge: CSRF_COOKIE_MAX_AGE_SECONDS,
+        path: "/",
+    });
+
+    return res;
 }
 
 export async function POST(req: NextRequest) {
@@ -103,6 +145,34 @@ export async function POST(req: NextRequest) {
         if (!email || !isValidRequest(email, expires, token)) {
             return redirectWithError(req, "Invalid or expired unsubscribe link");
         }
+
+        // ── CSRF nonce verification ───────────────────────────────────────────
+        // Read the nonce from both the submitted form body and the cookie set
+        // during the GET. If they don't match (or either is absent), the
+        // submission is either cross-site or the form has been tampered with.
+        const contentType = req.headers.get("content-type") ?? "";
+        let formNonce: string | null = null;
+        if (contentType.includes("application/x-www-form-urlencoded")) {
+            const body = await req.text();
+            const params = new URLSearchParams(body);
+            formNonce = params.get("csrf_nonce");
+        } else if (contentType.includes("multipart/form-data")) {
+            const formData = await req.formData();
+            formNonce = formData.get("csrf_nonce") as string | null;
+        }
+
+        const cookieNonce = req.cookies.get(CSRF_COOKIE)?.value ?? null;
+
+        if (
+            !formNonce ||
+            !cookieNonce ||
+            formNonce.length !== cookieNonce.length ||
+            !timingSafeEqual(formNonce, cookieNonce)
+        ) {
+            console.warn("[unsubscribe] CSRF nonce mismatch", { ip, email });
+            return redirectWithError(req, "Invalid form submission. Please try the unsubscribe link again.");
+        }
+        // ─────────────────────────────────────────────────────────────────────
 
         const normalizedEmail = email.trim().toLowerCase();
 
@@ -145,9 +215,27 @@ export async function POST(req: NextRequest) {
             timestamp: new Date().toISOString(),
         }));
 
-        return NextResponse.redirect(new URL("/profile?unsubscribed=true", req.url));
+        // Clear the CSRF cookie after successful consumption so it cannot be reused.
+        const res = NextResponse.redirect(new URL("/profile?unsubscribed=true", req.url));
+        res.cookies.set(CSRF_COOKIE, "", { maxAge: 0, path: "/" });
+        return res;
     } catch (error: unknown) {
         console.error("Unsubscribe API Error:", error);
         return redirectWithError(req, "Internal Server Error");
     }
+}
+
+/**
+ * Constant-time string comparison to prevent timing attacks on the nonce.
+ * Both strings must be the same length (checked before calling).
+ */
+function timingSafeEqual(a: string, b: string): boolean {
+    const bufA = Buffer.from(a, "utf8");
+    const bufB = Buffer.from(b, "utf8");
+    if (bufA.length !== bufB.length) return false;
+    let diff = 0;
+    for (let i = 0; i < bufA.length; i++) {
+        diff |= bufA[i] ^ bufB[i];
+    }
+    return diff === 0;
 }


### PR DESCRIPTION
## **User description**
## Summary
Fixes #786 — CSRF vulnerability in the unsubscribe route.

- The GET handler now generates a cryptographically random one-time nonce (`crypto.randomBytes(32)`) and embeds it both as a hidden form field **and** in a short-lived, `HttpOnly`, `SameSite=Strict` cookie.
- The POST handler requires the form nonce and the cookie nonce to be present and equal (constant-time compare). A cross-site form cannot read the `HttpOnly` cookie, so it cannot supply the matching nonce even if it knows the unsubscribe URL.
- In production the cookie uses the `__Host-` prefix to prevent subdomain injection; it is dropped to `csrf_unsub` in development/HTTP.
- The cookie is cleared (`maxAge: 0`) after a successful, single use so the nonce cannot be replayed.
- Added defence-in-depth via `SameSite=Strict`, which also blocks the browser from sending the cookie on cross-site POSTs.

## Test plan
- Updated `src/__tests__/api/unsubscribe.test.ts` to exercise the full GET→POST flow with the nonce.
- Added tests that prove a missing/mismatched nonce is rejected, and that the legitimate signed POST still succeeds and clears the cookie.
- `npm test` (unsubscribe suite): 9 passing. `tsc --noEmit` and ESLint pass via lint-staged.

🤖 Generated with [Kilo](https://github.com/Kilo-Org/kilo)


___

## **CodeAnt-AI Description**
**Protect unsubscribe requests from cross-site form submissions**

### What Changed
- The unsubscribe page now includes a one-time verification code in the form and checks it again when the form is submitted
- Requests without the code, or with a code that does not match, are rejected with an invalid form message
- The verification code expires after 15 minutes and is cleared after a successful unsubscribe so it cannot be reused
- Added coverage for the full unsubscribe flow, including blocked submissions and a successful unsubscribe with a matching code

### Impact
`✅ Fewer unwanted unsubscribe requests`
`✅ Safer email preference changes`
`✅ Clearer invalid form errors`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
