### PR TITLE
fix(backend): scope replies GET user-upvotes to this doubt's reply IDs

### DIFF
--- a/src/__tests__/api/replies.test.ts
+++ b/src/__tests__/api/replies.test.ts
@@ -1,0 +1,117 @@
+import { inArray } from 'drizzle-orm';
+
+const currentUserMock = jest.fn();
+const selectQueue: any[] = [];
+
+// Spy on inArray so we can assert the reply-likes query is scoped to the
+// doubt's reply IDs and not over-fetched across the whole app.
+jest.mock('drizzle-orm', () => {
+    const actual = jest.requireActual('drizzle-orm');
+    return {
+        ...actual,
+        inArray: jest.fn(actual.inArray),
+    };
+});
+
+jest.mock('@clerk/nextjs/server', () => ({
+    currentUser: () => currentUserMock(),
+}));
+
+jest.mock('@/configs/schema', () => ({
+    repliesTable: { doubtId: 'replies.doubtId', id: 'replies.id', userEmail: 'replies.userEmail' },
+    doubtsTable: { id: 'doubts.id', deletedAt: 'doubts.deletedAt' },
+    replyLikesTable: { userEmail: 'replyLikes.userEmail', replyId: 'replyLikes.replyId' },
+    usersTable: { email: 'users.email', blockedUntil: 'users.blockedUntil' },
+    membershipsTable: { userEmail: 'memberships.userEmail', classroomId: 'memberships.classroomId', role: 'memberships.role' },
+}));
+
+const buildQuery = (data: any) => {
+    const q: any = {};
+    q.from = () => q;
+    q.where = () => q;
+    q.orderBy = () => q;
+    q.limit = () => q;
+    q.then = (resolve: any) => Promise.resolve(resolve(data));
+    return q;
+};
+
+jest.mock('@/configs/db', () => {
+    const returning = jest.fn(() => Promise.resolve([]));
+    const insertValues = jest.fn(() => ({ returning }));
+    const updateSet = jest.fn(() => ({ where: jest.fn(() => ({ returning })) }));
+    const delWhere = jest.fn(() => Promise.resolve({}));
+    return {
+        db: {
+            select: jest.fn(() => buildQuery(selectQueue.shift() ?? [])),
+            insert: jest.fn(() => ({ values: insertValues })),
+            update: jest.fn(() => ({ set: updateSet })),
+            delete: jest.fn(() => ({ where: delWhere })),
+        },
+    };
+});
+
+import { GET } from '@/app/api/replies/route';
+
+describe('Replies GET endpoint', () => {
+    beforeEach(() => {
+        currentUserMock.mockReset();
+        selectQueue.length = 0;
+        (inArray as jest.Mock).mockClear();
+        jest.clearAllMocks();
+    });
+
+    it('scopes the user upvotes query to this doubt\'s reply IDs', async () => {
+        currentUserMock.mockResolvedValue({
+            id: 'clerk_1',
+            primaryEmailAddress: { emailAddress: 'student@example.com' },
+        });
+
+        const replies = [
+            { id: 7, doubtId: 1, userEmail: 'owner@example.com' },
+            { id: 8, doubtId: 1, userEmail: 'other@example.com' },
+        ];
+
+        // Queue order matches GET execution:
+        // 1) user block check, 2) doubt lookup, 3) replies, 4) reply likes.
+        selectQueue.push(
+            [], // no block
+            [{ id: 1, classroomId: null, type: 'community', userEmail: 'owner@example.com' }],
+            replies,
+            [{ replyId: 7, userEmail: 'student@example.com' }],
+        );
+
+        const res = await GET(new Request('http://localhost/api/replies?doubtId=1'));
+        const json = await res.json();
+
+        // The GET must scope the like lookup with inArray(replyLikesTable.replyId, [...]).
+        const scopedCall = (inArray as jest.Mock).mock.calls.find(
+            (call) => call[0] === 'replyLikes.replyId',
+        );
+        expect(scopedCall).toBeDefined();
+        expect(scopedCall![1]).toEqual(expect.arrayContaining([7, 8]));
+        expect(scopedCall![1]).toHaveLength(2);
+
+        // hasUpvoted reflects only this doubt's replies.
+        const byId = Object.fromEntries(json.map((r: any) => [r.id, r.hasUpvoted]));
+        expect(byId[7]).toBe(true);
+        expect(byId[8]).toBe(false);
+    });
+
+    it('does not query reply likes when the user is anonymous', async () => {
+        currentUserMock.mockResolvedValue(null);
+
+        // Anonymous users skip the user-block select (it only runs when email
+        // is present), so the queue starts directly with the doubt lookup.
+        selectQueue.push(
+            [{ id: 1, classroomId: null, type: 'community', userEmail: 'owner@example.com' }],
+            [{ id: 9, doubtId: 1, userEmail: 'owner@example.com' }],
+        );
+
+        const res = await GET(new Request('http://localhost/api/replies?doubtId=1'));
+        const json = await res.json();
+
+        expect(res.status).toBe(200);
+        expect((inArray as jest.Mock).mock.calls.length).toBe(0);
+        expect(json[0].hasUpvoted).toBeFalsy();
+    });
+});

--- a/src/app/api/replies/route.ts
+++ b/src/app/api/replies/route.ts
@@ -1,6 +1,6 @@
 import { db } from "@/configs/db";
 import { repliesTable, doubtsTable, replyLikesTable, usersTable, membershipsTable } from "@/configs/schema";
-import { eq, asc, and, isNull } from "drizzle-orm";
+import { eq, asc, and, isNull, inArray } from "drizzle-orm";
 import { NextResponse } from "next/server";
 import { currentUser } from "@clerk/nextjs/server";
 import { moderateContent, handleModerationViolation } from "@/lib/moderation/moderation";
@@ -88,10 +88,20 @@ export async function GET(req: Request) {
 
     let repliesWithVotes = data;
     if (email) {
-      const userUpvotes = await db
-        .select()
-        .from(replyLikesTable)
-        .where(eq(replyLikesTable.userEmail, email));
+      // Only fetch the current user's likes for this doubt's replies, not
+      // every like they have ever made across the entire app.
+      const replyIds = data.map((r: any) => r.id);
+      const userUpvotes = replyIds.length > 0
+        ? await db
+            .select()
+            .from(replyLikesTable)
+            .where(
+              and(
+                eq(replyLikesTable.userEmail, email),
+                inArray(replyLikesTable.replyId, replyIds),
+              ),
+            )
+        : [];
       const upvotedReplyIds = new Set(userUpvotes.map((v: any) => v.replyId));
       repliesWithVotes = data.map((reply: any) => ({
         ...reply,


### PR DESCRIPTION
## **User description**
## Summary
Fixes #793 — the replies GET endpoint over-fetched the current user's likes.

- The `replyLikes` query now scopes to this doubt's replies via `and(eq(replyLikesTable.userEmail, email), inArray(replyLikesTable.replyId, replyIds))`, where `replyIds` are the IDs returned for the requested doubt. When there are no replies, the query is skipped entirely with an empty array.
- For anonymous requests (`email` is undefined) the like lookup is still skipped, as before.

## Test plan
- Added `src/__tests__/api/replies.test.ts` with two cases:
  - authenticated GET asserts the `inArray(replyLikesTable.replyId, [...])` condition is applied with exactly this doubt's reply IDs, and that `hasUpvoted` is correctly reflected only for this doubt's replies.
  - anonymous GET asserts no `inArray` like query is issued and the response is unaffected.
- All replies suites pass (15 tests) and `tsc --noEmit` + ESLint pass via lint-staged.

🤖 Generated with [Kilo](https://github.com/Kilo-Org/kilo)


___

## **CodeAnt-AI Description**
**Limit reply upvotes to the current doubt**

### What Changed
- Reply lists now only mark a reply as upvoted if the current user liked one of this doubt’s replies
- Requests from signed-out users no longer run the upvote lookup
- Added coverage for both signed-in and anonymous reply loading cases

### Impact
`✅ Correct reply like status`
`✅ Fewer unrelated upvote lookups`
`✅ No upvote queries for anonymous users`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
