### PR TITLE
fix(backend): scope doubts GET likes/bookmarks to current page's doubt IDs

### DIFF
--- a/src/__tests__/api/doubts-scoped-likes.test.ts
+++ b/src/__tests__/api/doubts-scoped-likes.test.ts
@@ -1,0 +1,141 @@
+import { inArray } from 'drizzle-orm';
+
+const currentUserMock = jest.fn();
+const selectQueue: any[] = [];
+
+// Spy on inArray so we can assert the likes/bookmarks queries are scoped to
+// this page's doubt IDs instead of over-fetching globally.
+jest.mock('drizzle-orm', () => {
+    const actual = jest.requireActual('drizzle-orm');
+    return {
+        ...actual,
+        inArray: jest.fn(actual.inArray),
+    };
+});
+
+jest.mock('@clerk/nextjs/server', () => ({
+    currentUser: () => currentUserMock(),
+}));
+
+jest.mock('@/configs/schema', () => ({
+    doubtsTable: { id: 'doubts.id', deletedAt: 'doubts.deletedAt', classroomId: 'doubts.classroomId', type: 'doubts.type', subject: 'doubts.subject', content: 'doubts.content', userEmail: 'doubts.userEmail', isSolved: 'doubts.isSolved', isPinned: 'doubts.isPinned', likes: 'doubts.likes', createdAt: 'doubts.createdAt' },
+    repliesTable: { doubtId: 'replies.doubtId' },
+    likesTable: { doubtId: 'likes.doubtId', userEmail: 'likes.userEmail' },
+    bookmarksTable: { doubtId: 'bookmarks.doubtId', userEmail: 'bookmarks.userEmail' },
+    doubtTagsTable: { doubtId: 'doubtTags.doubtId', tagId: 'doubtTags.tagId' },
+    tagsTable: { id: 'tags.id', normalizedName: 'tags.normalizedName' },
+    membershipsTable: { userEmail: 'memberships.userEmail', classroomId: 'memberships.classroomId', role: 'memberships.role' },
+}));
+
+const makeChain = (fields: any) => {
+    let table: any;
+    const chain: any = {};
+    chain.from = (t: any) => { table = t; return chain; };
+    chain.where = () => chain;
+    chain.orderBy = () => chain;
+    chain.limit = () => chain;
+    chain.offset = () => chain;
+    chain.groupBy = () => chain;
+    chain.innerJoin = () => chain;
+    chain.leftJoin = () => chain;
+    chain.then = (resolve: any) => Promise.resolve(resolve(selectQueue.shift() ?? []));
+    return chain;
+};
+
+jest.mock('@/configs/db', () => ({
+    db: {
+        select: jest.fn((fields: any) => makeChain(fields)),
+        insert: jest.fn(() => ({ values: jest.fn(() => ({ returning: jest.fn(() => Promise.resolve([])), onConflictDoNothing: jest.fn(() => Promise.resolve({})) })) })),
+        update: jest.fn(() => ({ set: jest.fn(() => ({ where: jest.fn(() => Promise.resolve([])) })) })),
+        delete: jest.fn(() => ({ where: jest.fn(() => Promise.resolve({})) })),
+    },
+}));
+
+jest.mock('@/lib/search/search', () => ({ buildRankOrder: jest.fn(() => null), buildSearchCondition: jest.fn(() => null) }));
+jest.mock('@/lib/moderation/moderation', () => ({ moderateContent: jest.fn().mockResolvedValue({ isAllowed: true }), handleModerationViolation: jest.fn().mockResolvedValue(null) }));
+jest.mock('@/lib/ai/categorizer', () => ({ categorizeDoubt: jest.fn().mockResolvedValue('General') }));
+jest.mock('@/lib/ai/embeddings', () => ({ safeGenerateEmbedding: jest.fn().mockResolvedValue([]) }));
+jest.mock('@/lib/errors/error-handler', () => ({ buildErrorResponse: jest.fn().mockReturnValue({ status: 500, body: { error: 'Internal Server Error' } }), errorResponse: jest.fn(), ApiError: class extends Error {} }));
+jest.mock('@/lib/validations/validate', () => ({ parseAndValidateRequest: jest.fn().mockImplementation(async (req: Request) => ({ errorResponse: null, data: await req.json().catch(() => ({})) })) }));
+jest.mock('@/lib/validations/doubt', () => ({ createDoubtSchema: {} }));
+jest.mock('@/lib/notifications/service', () => ({ createClassroomDoubtNotifications: jest.fn() }));
+jest.mock('@/inngest/client', () => ({ inngest: { send: jest.fn().mockResolvedValue(undefined) } }));
+jest.mock('@/lib/ratelimit/api-rate-limit', () => ({ enforceApiRateLimit: jest.fn().mockResolvedValue(null) }));
+jest.mock('@/lib/ratelimit/ratelimit', () => ({ generalLimiter: {} }));
+jest.mock('@/lib/auth/auth-utils', () => ({ checkUserBlock: jest.fn().mockResolvedValue({ isBlocked: false, errorResponse: null }) }));
+jest.mock('@/lib/auth/membership-guard', () => ({ canTeach: jest.fn(() => false) }));
+jest.mock('@/lib/anonymity/anonymity', () => ({ toPublicDoubt: (d: any) => ({ ...d, author: 'Student_X', isOwnPost: false }) }));
+
+import { GET } from '@/app/api/doubts/route';
+
+const pageOfDoubts = [
+    { id: 1, subject: 'Physics', content: 'What is speed of light?', createdAt: '2026-01-01T00:00:00.000Z', likes: 4, isSolved: 'unsolved', isPinned: false, classroomId: null, type: 'community', userEmail: 'student@example.com' },
+    { id: 2, subject: 'Chemistry', content: 'What is pH?', createdAt: '2026-01-02T00:00:00.000Z', likes: 10, isSolved: 'solved', isPinned: false, classroomId: null, type: 'community', userEmail: 'other@example.com' },
+];
+
+describe('Doubts GET endpoint — scoped likes/bookmarks', () => {
+    beforeEach(() => {
+        currentUserMock.mockReset();
+        selectQueue.length = 0;
+        (inArray as jest.Mock).mockClear();
+        jest.clearAllMocks();
+        currentUserMock.mockResolvedValue({
+            primaryEmailAddress: { emailAddress: 'student@example.com' },
+            fullName: 'Test Student',
+        });
+    });
+
+    it('scopes the user likes and bookmarks queries to this page\'s doubt IDs', async () => {
+        // Queue order for an authenticated GET: count, doubts, reply counts,
+        // likes, bookmarks, tags.
+        selectQueue.push(
+            [{ count: 2 }],
+            pageOfDoubts,
+            [{ doubtId: 1, count: 2 }, { doubtId: 2, count: 1 }],
+            [{ doubtId: 1 }],          // user liked doubt 1 only
+            [{ doubtId: 2 }],          // user bookmarked doubt 2 only
+            [],
+        );
+
+        const res = await GET(new Request('http://localhost/api/doubts?subject=Physics'));
+        const json = await res.json();
+
+        // Both like and bookmark lookups must be scoped with inArray(..., [1, 2]).
+        const likeCall = (inArray as jest.Mock).mock.calls.find((c) => c[0] === 'likes.doubtId');
+        const bookmarkCall = (inArray as jest.Mock).mock.calls.find((c) => c[0] === 'bookmarks.doubtId');
+
+        expect(res.status).toBe(200);
+        expect(likeCall).toBeDefined();
+        expect(likeCall![1]).toEqual([1, 2]);
+        expect(bookmarkCall).toBeDefined();
+        expect(bookmarkCall![1]).toEqual([1, 2]);
+
+        // hasLiked / hasBookmarked reflect only this page's doubts.
+        const byId = Object.fromEntries(json.doubts.map((d: any) => [d.id, d]));
+        expect(byId[1].hasLiked).toBe(true);
+        expect(byId[1].hasBookmarked).toBe(false);
+        expect(byId[2].hasLiked).toBe(false);
+        expect(byId[2].hasBookmarked).toBe(true);
+    });
+
+    it('does not query likes/bookmarks for anonymous users', async () => {
+        currentUserMock.mockResolvedValue(null);
+
+        selectQueue.push(
+            [{ count: 2 }],
+            pageOfDoubts,
+            [{ doubtId: 1, count: 2 }, { doubtId: 2, count: 1 }],
+            [],
+        );
+
+        const res = await GET(new Request('http://localhost/api/doubts?subject=Physics'));
+        const json = await res.json();
+
+        expect(res.status).toBe(200);
+        // No like/bookmark scoping queries should be issued for anonymous users.
+        expect((inArray as jest.Mock).mock.calls.some((c) => c[0] === 'likes.doubtId')).toBe(false);
+        expect((inArray as jest.Mock).mock.calls.some((c) => c[0] === 'bookmarks.doubtId')).toBe(false);
+        expect(json.doubts[0].hasLiked).toBeFalsy();
+        expect(json.doubts[0].hasBookmarked).toBeFalsy();
+    });
+});

--- a/src/app/api/doubts/route.ts
+++ b/src/app/api/doubts/route.ts
@@ -216,11 +216,23 @@ export async function GET(req: Request) {
       }));
     }
 
+    // Only fetch the current user's likes/bookmarks for this page's doubts,
+    // not every like/bookmark they have ever made across the entire app.
+    const pageDoubtIds = doubts.map((d: any) => d.id);
+
     if (email && doubts.length > 0) {
-      const userLikes = await db
-        .select({ doubtId: likesTable.doubtId })
-        .from(likesTable)
-        .where(eq(likesTable.userEmail, email));
+      const userLikes =
+        pageDoubtIds.length > 0
+          ? await db
+              .select({ doubtId: likesTable.doubtId })
+              .from(likesTable)
+              .where(
+                and(
+                  eq(likesTable.userEmail, email),
+                  inArray(likesTable.doubtId, pageDoubtIds),
+                ),
+              )
+          : [];
 
       const likedIds = new Set(userLikes.map((l: any) => l.doubtId));
       doubts = doubts.map((doubt: any) => ({
@@ -230,10 +242,18 @@ export async function GET(req: Request) {
     }
 
     if (doubts.length > 0 && email) {
-      const userBookmarks = await db
-        .select({ doubtId: bookmarksTable.doubtId })
-        .from(bookmarksTable)
-        .where(eq(bookmarksTable.userEmail, email));
+      const userBookmarks =
+        pageDoubtIds.length > 0
+          ? await db
+              .select({ doubtId: bookmarksTable.doubtId })
+              .from(bookmarksTable)
+              .where(
+                and(
+                  eq(bookmarksTable.userEmail, email),
+                  inArray(bookmarksTable.doubtId, pageDoubtIds),
+                ),
+              )
+          : [];
 
       const bookmarkedIds = new Set(userBookmarks.map((b: any) => b.doubtId));
       doubts = doubts.map((doubt: any) => ({


### PR DESCRIPTION
## **User description**
## Summary
Fixes #794 — the doubts GET endpoint over-fetched the current user's likes and bookmarks.

- Both the `likes` and `bookmarks` lookups in the GET handler were filtered only by `userEmail`, pulling **every** like/bookmark the user has ever made across the whole app.
- They are now scoped to the doubts actually returned on the current page via `and(eq(<table>.userEmail, email), inArray(<table>.doubtId, pageDoubtIds))`, where `pageDoubtIds = doubts.map(d => d.id)`. When the page is empty the queries are skipped entirely — matching the existing `replyCount`/`tags` batch-fetch pattern already used in this handler.
- For anonymous requests (`email` is null) the like/bookmark lookups are still skipped, as before.

## Test plan
- Added `src/__tests__/api/doubts-scoped-likes.test.ts`:
  - authenticated GET asserts `inArray(likesTable.doubtId, [1, 2])` and `inArray(bookmarksTable.doubtId, [1, 2])` are applied with exactly this page's doubt IDs, and that `hasLiked`/`hasBookmarked` are correctly reflected only for this page's doubts.
  - anonymous GET asserts no like/bookmark scoping queries are issued and the response is unaffected.
- Existing `doubts.test.ts` (10 tests) still passes; `tsc --noEmit` and ESLint pass via lint-staged.

🤖 Generated with [Kilo](https://github.com/Kilo-Org/kilo)


___

## **CodeAnt-AI Description**
**Limit likes and bookmarks to the doubts shown on the current page**

### What Changed
- The doubts list now checks the current user's likes and bookmarks only against the doubts returned on that page.
- This stops unrelated likes and bookmarks from affecting the page, so each doubt shows the correct saved/liked state.
- Anonymous users still skip likes and bookmarks lookups, as before.
- Added coverage to verify the lookups stay scoped to the page and are not run for anonymous requests.

### Impact
`✅ Correct like and bookmark states on doubts pages`
`✅ Fewer unrelated saves shown in the list`
`✅ No likes/bookmarks lookup for anonymous visitors`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Likes and bookmarks on doubt listings now reflect only the doubts shown on the current page.
  * Anonymous viewers no longer receive like/bookmark state for other content, keeping the page response accurate.
* **Tests**
  * Added coverage for authenticated and anonymous cases to verify page-scoped like and bookmark behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->