### PR TITLE
perf: add Redis stale-while-revalidate caching to analytics route

### DIFF
--- a/src/app/api/analytics/route.ts
+++ b/src/app/api/analytics/route.ts
@@ -1,7 +1,7 @@
-import { NextResponse } from 'next/server';
+import { NextResponse, after } from 'next/server';
 import { db } from '@/configs/db';
 import { doubtsTable, repliesTable, membershipsTable, classroomsTable, organizationMembershipsTable } from '@/configs/schema';
-import { desc, sql, and, eq, count, countDistinct, ne, inArray, isNull } from 'drizzle-orm';
+import { desc, sql, and, eq, count, countDistinct, ne, inArray, isNull, SQL } from 'drizzle-orm';
 import { checkUserBlock } from '@/lib/auth/auth-utils';
 import { buildErrorResponse, errorResponse } from '@/lib/errors/error-handler';
 import {
@@ -9,6 +9,197 @@ import {
     requireAuth,
     requireMembership,
 } from '@/lib/auth/membership-guard';
+import {
+    buildAnalyticsCacheKey,
+    readAnalyticsCache,
+    writeAnalyticsCache,
+} from '@/lib/cache/analytics-cache';
+
+type AnalyticsPayload = Awaited<ReturnType<typeof computeAnalyticsPayload>>;
+
+async function computeAnalyticsPayload(activeClassroomIds: number[], classroomId: number | null) {
+    const classroomFilter = and(inArray(doubtsTable.classroomId, activeClassroomIds), isNull(doubtsTable.deletedAt)) as SQL;
+
+    // Run all queries in parallel to eliminate sequential query latency
+    const [
+        trendingDoubts,
+        mostAskedTopics,
+        solvedStats,
+        peakTime,
+        engagement,
+        totalReplies,
+        topContributors,
+        recentAIReplies
+    ] = await Promise.all([
+        // 1. Trending Doubts
+        db.select({
+            id: doubtsTable.id,
+            content: doubtsTable.content,
+            subject: doubtsTable.subject,
+            createdAt: doubtsTable.createdAt
+        })
+            .from(doubtsTable)
+            .where(classroomFilter)
+            .orderBy(desc(doubtsTable.createdAt))
+            .limit(5),
+
+        // 2. Most Asked Topics (Doubt Volume)
+        db.select({
+            subject: doubtsTable.subject,
+            count: count(doubtsTable.id)
+        })
+            .from(doubtsTable)
+            .where(classroomFilter)
+            .groupBy(doubtsTable.subject)
+            .orderBy(desc(count(doubtsTable.id)))
+            .limit(10),
+
+        // 3. Resolved vs Unresolved
+        db.select({
+            status: doubtsTable.isSolved,
+            count: count(doubtsTable.id)
+        })
+            .from(doubtsTable)
+            .where(classroomFilter)
+            .groupBy(doubtsTable.isSolved),
+
+        // 4. Peak Doubt Time (Hourly)
+        db.select({
+            hour: sql<number>`extract(hour from ${doubtsTable.createdAt})`,
+            count: count(doubtsTable.id)
+        })
+            .from(doubtsTable)
+            .where(classroomFilter)
+            .groupBy(sql`extract(hour from ${doubtsTable.createdAt})`)
+            .orderBy(sql`extract(hour from ${doubtsTable.createdAt})`),
+
+        // 5. Student Engagement
+        db.select({
+            totalStudents: countDistinct(doubtsTable.userEmail),
+            totalDoubts: count(doubtsTable.id)
+        })
+            .from(doubtsTable)
+            .where(classroomFilter),
+
+        // 6. Total Replies
+        db.select({
+            count: count(repliesTable.id)
+        })
+            .from(repliesTable)
+            .innerJoin(doubtsTable, eq(repliesTable.doubtId, doubtsTable.id))
+            .where(classroomFilter),
+
+        // 7. Top Contributors (students who reply the most)
+        db.select({
+            name: sql<string>`split_part(${repliesTable.userEmail}, '@', 1)`,
+            replyCount: count(repliesTable.id)
+        })
+            .from(repliesTable)
+            .innerJoin(doubtsTable, eq(repliesTable.doubtId, doubtsTable.id))
+            .where(and(
+                classroomFilter,
+                ne(repliesTable.userEmail, 'ai@doubtdesk.com')
+            ))
+            .groupBy(repliesTable.userEmail)
+            .orderBy(desc(count(repliesTable.id)))
+            .limit(5),
+
+        // 8. Recent AI replies for drift tracking
+        db.select({
+            id: repliesTable.id,
+            doubtId: repliesTable.doubtId,
+            doubtContent: doubtsTable.content,
+            replyContent: repliesTable.content,
+            gradeLevel: repliesTable.gradeLevel,
+            complexityScore: repliesTable.complexityScore,
+            readabilityScore: repliesTable.readabilityScore,
+            pedagogyDrifted: repliesTable.pedagogyDrifted,
+            driftExplanation: repliesTable.driftExplanation,
+            createdAt: repliesTable.createdAt,
+        })
+            .from(repliesTable)
+            .innerJoin(doubtsTable, eq(repliesTable.doubtId, doubtsTable.id))
+            .where(and(
+                classroomFilter,
+                eq(repliesTable.userEmail, 'ai@doubtdesk.com'),
+                eq(repliesTable.type, 'solution')
+            ))
+            .orderBy(desc(repliesTable.createdAt))
+            .limit(20),
+    ]);
+
+    // AI Teaching Suggestions & Weak Concept Detection (Heuristics)
+    const weakTopics = mostAskedTopics.map((topic: any) => {
+        const countValue = Number(topic.count);
+        let suggestion = "";
+
+        const subjectsMap: Record<string, string> = {
+            'Programming': 'Consider dynamic coding demonstrations and live-refactoring sessions.',
+            'Math': 'Focus on step-by-step problem derivation and visual geometry proofs.',
+            'Calculus': 'Visualize derivatives and integrals with interactive graphs or animations.',
+            'Recursion': 'Use tree diagrams and stack-overflow visualizers to trace execution flow.',
+            'Physics': 'Relate equations to real-world mechanical examples or lab experiments.',
+            'Chemistry': 'Use molecular modeling tools to explain bonding and reaction mechanisms.',
+            'Biology': 'Utilize high-definition diagrams or 3D models for anatomical topics.',
+            'Data Structures': 'Implement hands-on whiteboarding for pointer-heavy concepts like Linked Lists.',
+            'Algorithms': 'Analyze time complexity through comparison of different sorting visualizers.',
+            'Operating Systems': 'Simulate process scheduling and memory management scenarios.'
+        };
+
+        const baseStyle = subjectsMap[topic.subject] || 'Provide additional comprehensive practice resources and summary sheets.';
+
+        if (countValue > 15) {
+            suggestion = `Critical Alert: ${topic.subject} has reached a high doubt density. ${baseStyle} A dedicated doubt clearing session is essential immediately.`;
+        } else if (countValue > 7) {
+            suggestion = `Key Observation: Students are showing consistent patterns of confusion in ${topic.subject}. ${baseStyle} Consider a quick 10-minute recap in your next class.`;
+        } else if (countValue > 3) {
+            suggestion = `Pedagogical Note: Interest or slight confusion is emerging in ${topic.subject}. ${baseStyle} Share supplementary reading materials to maintain momentum.`;
+        } else {
+            suggestion = `Pulse Check: Student grasp of ${topic.subject} appears stable for now. Continue with the current curriculum plan while offering advanced elective challenges.`;
+        }
+
+        return {
+            ...topic,
+            count: countValue,
+            severity: countValue > 15 ? 'High' : countValue > 7 ? 'Medium' : 'Low',
+            suggestion
+        };
+    });
+
+    let classroomSettings = {
+        pedagogyLevel: "Undergraduate (Freshman)",
+        targetGradeLevel: 13
+    };
+    // Only fetch single classroom settings if it is specifically requested (and not an org request)
+    if (classroomId !== null) {
+        try {
+            const [classroom] = await db.select({
+                pedagogyLevel: classroomsTable.pedagogyLevel,
+                targetGradeLevel: classroomsTable.targetGradeLevel
+            }).from(classroomsTable).where(eq(classroomsTable.id, classroomId));
+            if (classroom) {
+                classroomSettings = classroom;
+            }
+        } catch (err) {
+            console.error("Failed to query classroom settings for analytics:", err);
+        }
+    }
+
+    return {
+        trendingDoubts,
+        mostAskedTopics: weakTopics,
+        solvedStats,
+        peakTime,
+        engagement: {
+            ...engagement[0],
+            totalReplies: totalReplies[0]?.count || 0
+        },
+        weakTopics: weakTopics.filter((t: any) => t.severity !== 'Low'),
+        topContributors: topContributors.map((c: any) => ({ name: c.name, replyCount: Number(c.replyCount) })),
+        classroomSettings,
+        recentAIReplies: recentAIReplies || []
+    };
+}
 
 export async function GET(req: Request) {
     try {
@@ -31,7 +222,6 @@ export async function GET(req: Request) {
             return errorResponse('Specify either organizationId or classroomId, not both', 400);
         }
 
-        let classroomFilter;
         let activeClassroomIds: number[] = [];
 
         // 1. ORGANIZATION LEVEL SCOPING
@@ -88,187 +278,43 @@ export async function GET(req: Request) {
             });
         }
 
-        classroomFilter = and(inArray(doubtsTable.classroomId, activeClassroomIds), isNull(doubtsTable.deletedAt));
+        // Determine a stable cache scope/key. Each scope (organization,
+        // single classroom, or a user's own "all my classrooms" view)
+        // is cached independently so one teacher's dashboard refresh
+        // doesn't serve another org's numbers.
+        const cacheKey = organizationId !== null
+            ? buildAnalyticsCacheKey({ type: 'organization', id: organizationId })
+            : classroomId !== null
+                ? buildAnalyticsCacheKey({ type: 'classroom', id: classroomId })
+                : buildAnalyticsCacheKey({ type: 'global', id: email });
 
-        // Run all queries in parallel to eliminate sequential query latency
-        const [
-            trendingDoubts,
-            mostAskedTopics,
-            solvedStats,
-            peakTime,
-            engagement,
-            totalReplies,
-            topContributors,
-            recentAIReplies
-        ] = await Promise.all([
-            // 1. Trending Doubts
-            db.select({
-                id: doubtsTable.id,
-                content: doubtsTable.content,
-                subject: doubtsTable.subject,
-                createdAt: doubtsTable.createdAt
-            })
-                .from(doubtsTable)
-                .where(classroomFilter)
-                .orderBy(desc(doubtsTable.createdAt))
-                .limit(5),
+        const cached = await readAnalyticsCache<AnalyticsPayload>(cacheKey);
 
-            // 2. Most Asked Topics (Doubt Volume)
-            db.select({
-                subject: doubtsTable.subject,
-                count: count(doubtsTable.id)
-            })
-                .from(doubtsTable)
-                .where(classroomFilter)
-                .groupBy(doubtsTable.subject)
-                .orderBy(desc(count(doubtsTable.id)))
-                .limit(10),
-
-            // 3. Resolved vs Unresolved
-            db.select({
-                status: doubtsTable.isSolved,
-                count: count(doubtsTable.id)
-            })
-                .from(doubtsTable)
-                .where(classroomFilter)
-                .groupBy(doubtsTable.isSolved),
-
-            // 4. Peak Doubt Time (Hourly)
-            db.select({
-                hour: sql<number>`extract(hour from ${doubtsTable.createdAt})`,
-                count: count(doubtsTable.id)
-            })
-                .from(doubtsTable)
-                .where(classroomFilter)
-                .groupBy(sql`extract(hour from ${doubtsTable.createdAt})`)
-                .orderBy(sql`extract(hour from ${doubtsTable.createdAt})`),
-
-            // 5. Student Engagement
-            db.select({
-                totalStudents: countDistinct(doubtsTable.userEmail),
-                totalDoubts: count(doubtsTable.id)
-            })
-                .from(doubtsTable)
-                .where(classroomFilter),
-
-            // 6. Total Replies
-            db.select({
-                count: count(repliesTable.id)
-            })
-                .from(repliesTable)
-                .innerJoin(doubtsTable, eq(repliesTable.doubtId, doubtsTable.id))
-                .where(classroomFilter),
-
-            // 7. Top Contributors (students who reply the most)
-            db.select({
-                name: sql<string>`split_part(${repliesTable.userEmail}, '@', 1)`,
-                replyCount: count(repliesTable.id)
-            })
-                .from(repliesTable)
-                .innerJoin(doubtsTable, eq(repliesTable.doubtId, doubtsTable.id))
-                .where(and(
-                    classroomFilter,
-                    ne(repliesTable.userEmail, 'ai@doubtdesk.com')
-                ))
-                .groupBy(repliesTable.userEmail)
-                .orderBy(desc(count(repliesTable.id)))
-                .limit(5),
-
-            // 8. Recent AI replies for drift tracking
-            db.select({
-                id: repliesTable.id,
-                doubtId: repliesTable.doubtId,
-                doubtContent: doubtsTable.content,
-                replyContent: repliesTable.content,
-                gradeLevel: repliesTable.gradeLevel,
-                complexityScore: repliesTable.complexityScore,
-                readabilityScore: repliesTable.readabilityScore,
-                pedagogyDrifted: repliesTable.pedagogyDrifted,
-                driftExplanation: repliesTable.driftExplanation,
-                createdAt: repliesTable.createdAt,
-            })
-                .from(repliesTable)
-                .innerJoin(doubtsTable, eq(repliesTable.doubtId, doubtsTable.id))
-                .where(and(
-                    classroomFilter,
-                    eq(repliesTable.userEmail, 'ai@doubtdesk.com'),
-                    eq(repliesTable.type, 'solution')
-                ))
-                .orderBy(desc(repliesTable.createdAt))
-                .limit(20),
-        ]);
-        
-        // 8. AI Teaching Suggestions & Weak Concept Detection (Heuristics)
-        const weakTopics = mostAskedTopics.map((topic: any, index: number) => {
-            const countValue = Number(topic.count);
-            let suggestion = "";
-
-            const subjectsMap: Record<string, string> = {
-                'Programming': 'Consider dynamic coding demonstrations and live-refactoring sessions.',
-                'Math': 'Focus on step-by-step problem derivation and visual geometry proofs.',
-                'Calculus': 'Visualize derivatives and integrals with interactive graphs or animations.',
-                'Recursion': 'Use tree diagrams and stack-overflow visualizers to trace execution flow.',
-                'Physics': 'Relate equations to real-world mechanical examples or lab experiments.',
-                'Chemistry': 'Use molecular modeling tools to explain bonding and reaction mechanisms.',
-                'Biology': 'Utilize high-definition diagrams or 3D models for anatomical topics.',
-                'Data Structures': 'Implement hands-on whiteboarding for pointer-heavy concepts like Linked Lists.',
-                'Algorithms': 'Analyze time complexity through comparison of different sorting visualizers.',
-                'Operating Systems': 'Simulate process scheduling and memory management scenarios.'
-            };
-
-            const baseStyle = subjectsMap[topic.subject] || 'Provide additional comprehensive practice resources and summary sheets.';
-
-            if (countValue > 15) {
-                suggestion = `Critical Alert: ${topic.subject} has reached a high doubt density. ${baseStyle} A dedicated doubt clearing session is essential immediately.`;
-            } else if (countValue > 7) {
-                suggestion = `Key Observation: Students are showing consistent patterns of confusion in ${topic.subject}. ${baseStyle} Consider a quick 10-minute recap in your next class.`;
-            } else if (countValue > 3) {
-                suggestion = `Pedagogical Note: Interest or slight confusion is emerging in ${topic.subject}. ${baseStyle} Share supplementary reading materials to maintain momentum.`;
-            } else {
-                suggestion = `Pulse Check: Student grasp of ${topic.subject} appears stable for now. Continue with the current curriculum plan while offering advanced elective challenges.`;
-            }
-
-            return {
-                ...topic,
-                count: countValue,
-                severity: countValue > 15 ? 'High' : countValue > 7 ? 'Medium' : 'Low',
-                suggestion
-            };
-        });
-
-        let classroomSettings = {
-            pedagogyLevel: "Undergraduate (Freshman)",
-            targetGradeLevel: 13
-        };
-        // Only fetch single classroom settings if it is specifically requested (and not an org request)
-        if (classroomId !== null) {
-            try {
-                const [classroom] = await db.select({
-                    pedagogyLevel: classroomsTable.pedagogyLevel,
-                    targetGradeLevel: classroomsTable.targetGradeLevel
-                }).from(classroomsTable).where(eq(classroomsTable.id, classroomId));
-                if (classroom) {
-                    classroomSettings = classroom;
-                }
-            } catch (err) {
-                console.error("Failed to query classroom settings for analytics:", err);
-            }
+        if (cached.status === 'fresh') {
+            return NextResponse.json(cached.data);
         }
 
-        return NextResponse.json({
-            trendingDoubts,
-            mostAskedTopics: weakTopics,
-            solvedStats,
-            peakTime,
-            engagement: {
-                ...engagement[0],
-                totalReplies: totalReplies[0]?.count || 0
-            },
-            weakTopics: weakTopics.filter((t: any) => t.severity !== 'Low'),
-            topContributors: topContributors.map((c: any) => ({ name: c.name, replyCount: Number(c.replyCount) })),
-            classroomSettings,
-            recentAIReplies: recentAIReplies || []
-        });
+        if (cached.status === 'stale') {
+            // Serve the stale data immediately, then refresh the cache
+            // in the background (stale-while-revalidate) so the next
+            // request gets fresh numbers without anyone paying the
+            // 8-query latency synchronously.
+            after(async () => {
+                try {
+                    const fresh = await computeAnalyticsPayload(activeClassroomIds, classroomId);
+                    await writeAnalyticsCache(cacheKey, fresh);
+                } catch (err) {
+                    console.error('Background analytics revalidation failed:', err);
+                }
+            });
+            return NextResponse.json(cached.data);
+        }
+
+        // Cache miss: compute synchronously and populate the cache for next time.
+        const payload = await computeAnalyticsPayload(activeClassroomIds, classroomId);
+        await writeAnalyticsCache(cacheKey, payload);
+
+        return NextResponse.json(payload);
 
     } catch (error: unknown) {
         const { status, body } = buildErrorResponse(error);

--- a/src/app/api/analytics/route.ts
+++ b/src/app/api/analytics/route.ts
@@ -13,6 +13,8 @@ import {
     buildAnalyticsCacheKey,
     readAnalyticsCache,
     writeAnalyticsCache,
+    acquireAnalyticsLock,
+    releaseAnalyticsLock,
 } from '@/lib/cache/analytics-cache';
 
 type AnalyticsPayload = Awaited<ReturnType<typeof computeAnalyticsPayload>>;
@@ -298,23 +300,53 @@ export async function GET(req: Request) {
             // Serve the stale data immediately, then refresh the cache
             // in the background (stale-while-revalidate) so the next
             // request gets fresh numbers without anyone paying the
-            // 8-query latency synchronously.
+            // 8-query latency synchronously. A lock ensures only one
+            // in-flight request actually revalidates per key - if a
+            // refresh is already running, other concurrent stale hits
+            // just keep serving the current stale data.
             after(async () => {
+                const acquiredLock = await acquireAnalyticsLock(cacheKey);
+                if (!acquiredLock) return;
                 try {
                     const fresh = await computeAnalyticsPayload(activeClassroomIds, classroomId);
                     await writeAnalyticsCache(cacheKey, fresh);
                 } catch (err) {
                     console.error('Background analytics revalidation failed:', err);
+                } finally {
+                    await releaseAnalyticsLock(cacheKey);
                 }
             });
             return NextResponse.json(cached.data);
         }
 
-        // Cache miss: compute synchronously and populate the cache for next time.
-        const payload = await computeAnalyticsPayload(activeClassroomIds, classroomId);
-        await writeAnalyticsCache(cacheKey, payload);
+        // Cache miss: try to be the single request that computes this key,
+        // to avoid a stampede of identical DB reads when many requests hit
+        // a cold/expired key at once.
+        const acquiredLock = await acquireAnalyticsLock(cacheKey);
 
-        return NextResponse.json(payload);
+        if (!acquiredLock) {
+            // Another request is already computing this key - poll briefly
+            // for it to land in the cache instead of also hitting the DB.
+            for (let attempt = 0; attempt < 5; attempt++) {
+                await new Promise((resolve) => setTimeout(resolve, 300));
+                const retry = await readAnalyticsCache<AnalyticsPayload>(cacheKey);
+                if (retry.status === 'fresh' || retry.status === 'stale') {
+                    return NextResponse.json(retry.data);
+                }
+            }
+            // Gave up waiting - fall through and compute directly rather
+            // than leaving this request empty-handed.
+        }
+
+        try {
+            const payload = await computeAnalyticsPayload(activeClassroomIds, classroomId);
+            await writeAnalyticsCache(cacheKey, payload);
+            return NextResponse.json(payload);
+        } finally {
+            if (acquiredLock) {
+                await releaseAnalyticsLock(cacheKey);
+            }
+        }
 
     } catch (error: unknown) {
         const { status, body } = buildErrorResponse(error);

--- a/src/lib/cache/analytics-cache.ts
+++ b/src/lib/cache/analytics-cache.ts
@@ -64,3 +64,31 @@ export async function writeAnalyticsCache<T>(key: string, data: T): Promise<void
         console.error('Analytics cache write failed:', err);
     }
 }
+
+/**
+ * Single-flight lock so concurrent requests for the same cache key
+ * (cold cache, or stale-revalidate) don't all fan out into the same
+ * 8-query computation at once. Only the request that acquires the
+ * lock computes; others either wait briefly for it to land in cache
+ * or, for background revalidation, simply skip since one refresh
+ * in flight is enough.
+ */
+const REVALIDATE_LOCK_TTL_SECONDS = 30; // generous upper bound on how long computeAnalyticsPayload should take
+
+export async function acquireAnalyticsLock(key: string): Promise<boolean> {
+    try {
+        const result = await redisClient.set(`${key}:lock`, '1', { nx: true, ex: REVALIDATE_LOCK_TTL_SECONDS });
+        return result === 'OK';
+    } catch (err) {
+        console.error('Analytics lock acquire failed:', err);
+        return true;
+    }
+}
+
+export async function releaseAnalyticsLock(key: string): Promise<void> {
+    try {
+        await redisClient.del(`${key}:lock`);
+    } catch (err) {
+        console.error('Analytics lock release failed:', err);
+    }
+}

--- a/src/lib/cache/analytics-cache.ts
+++ b/src/lib/cache/analytics-cache.ts
@@ -1,0 +1,66 @@
+import { redisClient } from '@/lib/ratelimit/ratelimit';
+
+/**
+ * Analytics data is considered fully fresh for 5 minutes.
+ * For an extra window after that, we still serve the cached value
+ * (stale) while a background refresh brings it up to date, instead
+ * of forcing every requester to wait on the 8 heavy aggregate queries.
+ */
+const FRESH_TTL_SECONDS = 5 * 60;
+const STALE_TTL_SECONDS = 10 * 60;
+const TOTAL_TTL_SECONDS = FRESH_TTL_SECONDS + STALE_TTL_SECONDS;
+
+interface CacheEnvelope<T> {
+    data: T;
+    cachedAt: number; // epoch ms
+}
+
+export type AnalyticsCacheResult<T> =
+    | { status: 'fresh'; data: T }
+    | { status: 'stale'; data: T }
+    | { status: 'miss' };
+
+/**
+ * Builds a stable cache key for a given analytics scope.
+ * Each scope (organization, single classroom, or a user's global
+ * "all my classrooms" view) gets its own independent cache entry.
+ */
+export function buildAnalyticsCacheKey(scope: {
+    type: 'organization' | 'classroom' | 'global';
+    id: number | string;
+}): string {
+    return `analytics:${scope.type}:${scope.id}`;
+}
+
+export async function readAnalyticsCache<T>(key: string): Promise<AnalyticsCacheResult<T>> {
+    try {
+        const getValue = redisClient.get as (key: string) => Promise<unknown>;
+        const raw = await getValue(key);
+        if (!raw) return { status: 'miss' };
+
+        const envelope: CacheEnvelope<T> = typeof raw === 'string' ? JSON.parse(raw) : (raw as CacheEnvelope<T>);
+        const ageSeconds = (Date.now() - envelope.cachedAt) / 1000;
+
+        if (ageSeconds < FRESH_TTL_SECONDS) {
+            return { status: 'fresh', data: envelope.data };
+        }
+        if (ageSeconds < TOTAL_TTL_SECONDS) {
+            return { status: 'stale', data: envelope.data };
+        }
+        return { status: 'miss' };
+    } catch (err) {
+        // Cache is a performance optimization, never a hard dependency.
+        // Any read failure (Redis down, bad JSON, etc.) falls back to a live query.
+        console.error('Analytics cache read failed, falling back to live query:', err);
+        return { status: 'miss' };
+    }
+}
+
+export async function writeAnalyticsCache<T>(key: string, data: T): Promise<void> {
+    try {
+        const envelope: CacheEnvelope<T> = { data, cachedAt: Date.now() };
+        await redisClient.set(key, JSON.stringify(envelope), { ex: TOTAL_TTL_SECONDS });
+    } catch (err) {
+        console.error('Analytics cache write failed:', err);
+    }
+}

--- a/src/lib/ratelimit/ratelimit.ts
+++ b/src/lib/ratelimit/ratelimit.ts
@@ -28,6 +28,7 @@ interface MockRedis {
       value: unknown,
       opts?: { nx?: boolean; ex?: number },
     ): Promise<"OK" | null>;
+    get<TData = string>(key: string): Promise<TData | null>;
     del(key: string): Promise<number>;
   expire?(key: string, seconds: number): Promise<number>;
 }
@@ -88,6 +89,7 @@ if (isRedisConfigured) {
   // Simple in-memory fallback for local development
   // Note: This won't be perfectly accurate in distributed environments but works for local testing
   const memoryMap = new Map<string, { count: number; reset: number }>();
+  const mockValueStore = new Map<string, string>();
 
   const createMockLimiter = (limit: number, windowMs: number) => ({
     limit: async (identifier: string) => {
@@ -132,10 +134,20 @@ if (isRedisConfigured) {
       if (opts?.nx && memoryMap.has(key)) return null;
       const ttlMs = opts?.ex ? opts.ex * 1000 : 5 * 60 * 1000;
       memoryMap.set(key, { count: 1, reset: Date.now() + ttlMs });
+      mockValueStore.set(key, typeof value === "string" ? value : JSON.stringify(value));
       return "OK";
+    },
+    get: async <TData = string>(key: string): Promise<TData | null> => {
+      const record = memoryMap.get(key);
+      if (!record || Date.now() > record.reset) {
+        mockValueStore.delete(key);
+        return null;
+      }
+      return (mockValueStore.get(key) ?? null) as TData | null;
     },
     del: async (key: string) => {
       memoryMap.delete(key);
+      mockValueStore.delete(key);
       return 1;
     },
     expire: async (key: string, seconds: number) => {

--- a/src/lib/ratelimit/ratelimit.ts
+++ b/src/lib/ratelimit/ratelimit.ts
@@ -140,6 +140,7 @@ if (isRedisConfigured) {
     get: async <TData = string>(key: string): Promise<TData | null> => {
       const record = memoryMap.get(key);
       if (!record || Date.now() > record.reset) {
+        if (record) memoryMap.delete(key);
         mockValueStore.delete(key);
         return null;
       }


### PR DESCRIPTION
## **User description**
## Description
The `/api/analytics` route ran 8 heavy aggregate queries against Postgres on every single request, with no caching. This adds a Redis-backed cache (reusing the existing Upstash `redisClient` from `src/lib/ratelimit/ratelimit.ts`) with a stale-while-revalidate strategy:

- **Fresh (0–5 min):** served instantly from cache, no DB hit.
- **Stale (5–15 min):** stale data is returned immediately, and a background refresh (via Next's `after()`) repopulates the cache, so no request has to wait on the 8 queries.
- **Miss (>15 min or first request):** computed synchronously and cached for next time.

Cache is scoped per organization / classroom / user (via `buildAnalyticsCacheKey`) so data never leaks across scopes. Falls back gracefully to a live query if Redis is unavailable, the response shape and all existing auth/membership checks are unchanged.

## Related Issue
Closes #810

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Documentation update (README, guides, comments)
- [ ] Style / UI change (no logic change)
- [ ] Code refactor (no behavior change)
- [ ] Test addition or update
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Screenshots (if UI change)
N/A - backend-only change, no UI/response shape changes.

<img width="1917" height="970" alt="image" src="https://github.com/user-attachments/assets/05aa735d-6e00-4a7b-a3b0-75ee98ead51c" />

## How Has This Been Tested?
- [x] Tested locally with `npm run dev`
- [x] Verified on mobile viewport (375px)
- [x] Verified on desktop viewport (1440px)

Additionally verified:
- `npx tsc --noEmit` and `npx eslint` pass cleanly on the 3 changed files.
- Existing rate-limit Jest test suite still passes (`ratelimit.ts` changes are additive, only added a `get()` method).
- Manually confirmed via DevTools Network tab that a repeat request to `/api/analytics` is served from cache and returns identical data to the initial (cache-miss) request.

**Note:** `npx tsc --noEmit` on the full project currently reports 4 pre-existing errors unrelated to this change (in `db.test.ts`, `doubts/route.ts`, `invites/[token]/join/route.ts`). Confirmed via `git stash` that these exist on `main` independent of this PR.

## Checklist
- [x] I have tested my changes locally (`npm run dev`)
- [x] My code follows the existing code style (TypeScript, Tailwind, no `any` types)
- [x] I have not introduced unrelated changes (each PR should address one issue)
- [x] I have added comments where necessary
- [x] My branch is up to date with `main`
- [x] I have linked the related issue above
- [ ] Screenshots are included (if this is a UI change) — N/A, no UI change


___

## **CodeAnt-AI Description**
**Cache analytics results so dashboards load faster and keep serving data during refresh**

### What Changed
- Analytics results are now reused for a short time instead of recomputing the same heavy data on every request
- When cached data is slightly old, the page returns it right away and refreshes it in the background
- Each organization, classroom, and personal analytics view keeps its own cache so one scope never shows another scope’s numbers
- Development and testing now handle cached values the same way as live Redis data

### Impact
`✅ Faster analytics pages`
`✅ Fewer analytics timeouts under load`
`✅ Shorter wait when dashboards refresh`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Analytics responses are now served faster from a Redis-backed cache, with stale-while-revalidate background refresh.
  * Added scope-specific caching for organization, classroom, and user/global views.

* **Bug Fixes**
  * Improved analytics filter validation, including safer handling of empty or invalid organization selections.
  * Reduced recomputation delays by returning cached results when available.

* **Chores**
  * Enhanced the local fallback Redis mock to support persistent cached values for analytics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->