### PR TITLE
fix: block self-accept karma exploit (#816)

### DIFF
--- a/src/app/api/doubts/[id]/accept/route.test.ts
+++ b/src/app/api/doubts/[id]/accept/route.test.ts
@@ -161,6 +161,20 @@ describe("POST /api/doubts/[id]/accept — idempotency (issue #687)", () => {
         expect(mockInngestSend).not.toHaveBeenCalled();
     });
 
+    it("returns 403 and does NOT emit karma when the reply author is the doubt owner (self-accept, issue #816)", async () => {
+        // Both doubt and reply are owned by the caller — the self-accept guard
+        // must reject the request before any state transition or event emit.
+        mockDoubt = { userEmail: "asker@test.com", isSolved: "unsolved", solvedReplyId: null };
+        mockReply = { userEmail: "asker@test.com", doubtId: 1 };
+
+        const res = await callPost(42);
+        const body = await res.json();
+
+        expect(res.status).toBe(403);
+        expect(body.error).toBe("Forbidden! You cannot accept your own reply.");
+        expect(mockInngestSend).not.toHaveBeenCalled();
+    });
+
     it("returns 500 with a generic message and does not leak error details", async () => {
         // Make the DB throw to exercise the catch block
         const { db } = await import("@/configs/db");

--- a/src/app/api/doubts/[id]/accept/route.ts
+++ b/src/app/api/doubts/[id]/accept/route.ts
@@ -74,6 +74,13 @@ export async function POST(
             );
         }
 
+        if (reply.userEmail === loggedInUserEmail) {
+            return NextResponse.json(
+                { error: "Forbidden! You cannot accept your own reply." },
+                { status: 403 }
+            );
+        }
+
         // ── 4. ATOMIC IDEMPOTENT UPDATE ───────────────────────────────────────
         const [updatedDoubt] = await db
             .update(doubtsTable)

--- a/src/inngest/karma.ts
+++ b/src/inngest/karma.ts
@@ -1,7 +1,7 @@
 // inngest/karma.ts
 import { inngest } from "./client"; 
 import { db } from "@/configs/db";
-import { usersTable, karmaTransactionsTable, doubtsTable } from "@/configs/schema";
+import { usersTable, karmaTransactionsTable, doubtsTable, repliesTable } from "@/configs/schema";
 import { eq, sql, isNotNull, and } from "drizzle-orm"; 
 import { checkAndAwardBadges } from "@/lib/karma/karma-utils";
 
@@ -112,31 +112,60 @@ export const onAnswerAccepted = inngest.createFunction(
             doubtId: number;
         };
 
-        // Defense in depth: even if the accept route's self-accept guard is
-        // bypassed (dev tooling, older client, direct event emit), refuse to
-        // credit karma when the reply author is also the doubt owner.
+        // Defense in depth: don't trust event payload fields at face value.
+        // Re-derive the reply's author and its parent doubt from the DB so a
+        // forged event that pairs a valid replyId with an unrelated doubtId
+        // (or lies about replyAuthorEmail) can't sneak past the self-accept
+        // guard. Same reasoning as the route handler — we never award karma
+        // without a DB-authoritative match.
+        const [reply] = await db
+            .select({
+                userEmail: repliesTable.userEmail,
+                doubtId: repliesTable.doubtId,
+            })
+            .from(repliesTable)
+            .where(eq(repliesTable.id, replyId))
+            .limit(1);
+
+        if (!reply || reply.doubtId !== doubtId) {
+            console.warn(
+                `[karma-answer-accepted] Rejecting karma event: reply ${replyId} does not belong to doubt ${doubtId}`
+            );
+            return { success: false, skipped: "reply_doubt_mismatch", userEmail: replyAuthorEmail };
+        }
+
         const [doubt] = await db
             .select({ userEmail: doubtsTable.userEmail })
             .from(doubtsTable)
             .where(eq(doubtsTable.id, doubtId))
             .limit(1);
 
-        if (doubt?.userEmail && doubt.userEmail === replyAuthorEmail) {
+        if (!doubt) {
             console.warn(
-                `[karma-answer-accepted] Refusing self-accept karma award for ${replyAuthorEmail} on doubt ${doubtId}`
+                `[karma-answer-accepted] Rejecting karma event: doubt ${doubtId} not found`
             );
-            return { success: false, skipped: "self_accept", userEmail: replyAuthorEmail };
+            return { success: false, skipped: "doubt_not_found", userEmail: replyAuthorEmail };
         }
 
+        if (reply.userEmail && doubt.userEmail && reply.userEmail === doubt.userEmail) {
+            console.warn(
+                `[karma-answer-accepted] Refusing self-accept karma award for ${reply.userEmail} on doubt ${doubtId}`
+            );
+            return { success: false, skipped: "self_accept", userEmail: reply.userEmail };
+        }
+
+        // Attribute the ledger row to the DB-derived author, not the event payload.
+        const authoritativeAuthor = reply.userEmail || replyAuthorEmail;
+
         await executeKarmaTransaction({
-            userEmail: replyAuthorEmail,
+            userEmail: authoritativeAuthor,
             eventType: "answer_accepted",
             replyId,
             doubtId,
             note: "Answer marked as accepted solution",
         });
 
-        return { success: true, userEmail: replyAuthorEmail };
+        return { success: true, userEmail: authoritativeAuthor };
     }
 );
 

--- a/src/inngest/karma.ts
+++ b/src/inngest/karma.ts
@@ -1,7 +1,7 @@
 // inngest/karma.ts
 import { inngest } from "./client"; 
 import { db } from "@/configs/db";
-import { usersTable, karmaTransactionsTable } from "@/configs/schema";
+import { usersTable, karmaTransactionsTable, doubtsTable } from "@/configs/schema";
 import { eq, sql, isNotNull, and } from "drizzle-orm"; 
 import { checkAndAwardBadges } from "@/lib/karma/karma-utils";
 
@@ -111,6 +111,22 @@ export const onAnswerAccepted = inngest.createFunction(
             replyId: number;
             doubtId: number;
         };
+
+        // Defense in depth: even if the accept route's self-accept guard is
+        // bypassed (dev tooling, older client, direct event emit), refuse to
+        // credit karma when the reply author is also the doubt owner.
+        const [doubt] = await db
+            .select({ userEmail: doubtsTable.userEmail })
+            .from(doubtsTable)
+            .where(eq(doubtsTable.id, doubtId))
+            .limit(1);
+
+        if (doubt?.userEmail && doubt.userEmail === replyAuthorEmail) {
+            console.warn(
+                `[karma-answer-accepted] Refusing self-accept karma award for ${replyAuthorEmail} on doubt ${doubtId}`
+            );
+            return { success: false, skipped: "self_accept", userEmail: replyAuthorEmail };
+        }
 
         await executeKarmaTransaction({
             userEmail: replyAuthorEmail,


### PR DESCRIPTION
## **User description**
fixes #816

## what was wrong

user could accept their own reply on their own doubt and net +25 karma per doubt. `src/app/api/doubts/[id]/accept/route.ts` only checked doubt ownership and reply→doubt linkage — not whether the reply author is the doubt owner. so the abuse loop was: post doubt → post reply on own doubt → accept own reply → +25 karma, repeat for every new doubt.

the reply upvote route already blocks the analogous self-vote (`src/app/api/replies/vote/route.ts:48-55`) but accept had no equivalent guard, even though accept is worth more karma (+25 vs +10).

## fix

- `src/app/api/doubts/[id]/accept/route.ts`: after we resolve the reply, added a 403 short-circuit if `reply.userEmail === loggedInUserEmail`. same pattern the upvote route uses. matches the fix suggested in the issue.
- `src/inngest/karma.ts` `onAnswerAccepted`: defense in depth — look up the doubt owner inside the worker and refuse to run the karma transaction if `replyAuthorEmail === doubt.userEmail`. logs a warning so any abuse attempt shows up in the logs. protects against any future path that emits `karma/answer.accepted` directly (dev tools, older client, cron backfill).

didn't do the backfill script this PR — that's a one-off ops task and better done separately once maintainer confirms the approach. happy to do it in a follow-up.

## test plan

- [x] type-check passes (`npx tsc --noEmit`)
- [x] existing self-upvote guard pattern used verbatim so behavior stays consistent
- [ ] manual: post doubt as user A, post reply as user A, hit accept endpoint → expect 403 "You cannot accept your own reply."
- [ ] manual: post doubt as user A, post reply as user B, user A accepts → still works, +25 karma to B


___

## **CodeAnt-AI Description**
Stop users from accepting their own reply and earning karma

### What Changed
- The accept-reply flow now blocks when the reply was written by the same user who asked the doubt, and shows a clear forbidden message
- Karma is also withheld if a self-accept event is sent another way, so the award cannot be granted through older clients or direct event calls

### Impact
`✅ Prevents self-accept karma abuse`
`✅ Keeps accepted-answer rewards tied to other users`
`✅ Fewer moderation issues from replayed or direct accept events`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented users from accepting their own reply on a doubt thread; the accept action is now rejected with a clear 403 error.
  * Added validation to ensure the accepted reply belongs to the correct thread, and blocked self-accept cases from triggering karma awarding.
* **Tests**
  * Added coverage for the “self-accept” rejection behavior, including confirmation that the karma event is not emitted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->