### PR TITLE
fix: stop middleware from bucketing non-AI /api/doubts POSTs as AI (#817)

### DIFF
--- a/src/app/api/doubts/route.ts
+++ b/src/app/api/doubts/route.ts
@@ -33,7 +33,7 @@ import { createDoubtSchema } from "@/lib/validations/doubt";
 import { createClassroomDoubtNotifications } from "@/lib/notifications/service";
 import { inngest } from "@/inngest/client";
 import { enforceApiRateLimit } from "@/lib/ratelimit/api-rate-limit";
-import { generalLimiter } from "@/lib/ratelimit/ratelimit";
+import { aiLimiter, generalLimiter } from "@/lib/ratelimit/ratelimit";
 import { buildRankOrder } from "@/lib/search/search";
 import { canTeach } from "@/lib/auth/membership-guard";
 import { currentUser } from "@clerk/nextjs/server";
@@ -361,6 +361,9 @@ export async function POST(req: Request) {
         return errorResponse(violationError, 400);
       }
     }
+
+    const aiRateLimitResponse = await enforceApiRateLimit(aiLimiter, email, "ai");
+    if (aiRateLimitResponse) return aiRateLimitResponse;
 
     const subTopic = await categorizeDoubt(content || "", subject, imageUrl);
 

--- a/src/middleware.tsx
+++ b/src/middleware.tsx
@@ -80,7 +80,8 @@ export default clerkMiddleware(async (auth, req) => {
             path.startsWith('/api/ai-career-chat-agent') ||
             path.startsWith('/api/doubts/check-similarity') ||
             path.startsWith('/api/roadmap') ||
-            (path.startsWith('/api/doubts') && (req.method === 'POST' || path.includes('/practice')));
+            path.startsWith('/api/doubts/practice') ||
+            path.includes('/practice');
         const isVideoRoute = path.startsWith('/api/video/generate');
         const limiter = isVideoRoute ? videoLimiter : (isAiRoute ? aiLimiter : generalLimiter);
 
@@ -94,7 +95,7 @@ export default clerkMiddleware(async (auth, req) => {
                         message: isVideoRoute
                             ? "Video generation limit reached (max 3 per hour)."
                             : (isAiRoute
-                                ? "AI Solver is currently rate limited to protect resources."
+                                ? "AI request limit reached. Please try again later."
                                 : "You've reached the rate limit for this action.")
                     }),
                     {


### PR DESCRIPTION
## **User description**
fixes #817

## what was wrong

`src/middleware.tsx:83` had `(path.startsWith('/api/doubts') && (POST || /practice))` — this collapsed every POST under `/api/doubts/*` into the AI bucket. that includes upvote, accept, pin, restore, and action. all of them non-AI, but subject to the strict 10/min AI limiter instead of the 30/min general limiter. so a student browsing a busy classroom and upvoting the top ten answers hit 429 with the misleading \"AI Solver is currently rate limited\" message.

`POST /api/doubts` itself is already bypassed via `ROUTE_LEVEL_LIMITED_POSTS` and route-level general limit, but the AI classification call (`categorizeDoubt`) inside the route was only protected by that general limit — nothing was AI-limiting it.

## fix

- `src/middleware.tsx`: narrow the `/api/doubts` AI clause to `path.startsWith('/api/doubts/practice')` + a general `path.includes('/practice')` catch. dropped the POST wildcard. actual AI-backed subroutes (`/api/doubts/check-similarity`, `/api/solve`, `/api/ask-ai`, `/api/roadmap`, ...) stay explicit in the list.
- `src/app/api/doubts/route.ts`: added an explicit `enforceApiRateLimit(aiLimiter, email, \"ai\")` just before the `categorizeDoubt(...)` call, so creation still gets the AI-cost budget applied even though middleware skips this path.
- `src/middleware.tsx`: replaced the misleading \"AI Solver is currently rate limited to protect resources.\" copy with \"AI request limit reached. Please try again later.\" — matches the string route-level `RATE_LIMIT_MESSAGES.ai` already returns, so users get a consistent message regardless of where the limit fires.

## test plan

- [x] `npx tsc --noEmit` clean
- [ ] manual: POST `/api/doubts/[id]/upvote` 15 times in a minute → does not 429, hits general 30/min bucket
- [ ] manual: POST `/api/doubts` 11 times in a minute → 11th one 429s with the AI copy (from the route-level enforcer)
- [ ] manual: GET/POST any `/practice` path → still uses AI bucket


___

## **CodeAnt-AI Description**
Fix AI rate limiting for doubt creation and show the right limit message

### What Changed
- Non-AI `/api/doubts` actions like upvote, accept, pin, restore, and similar requests now use the normal request limit instead of the stricter AI limit
- Creating a doubt still counts against the AI request limit, but that check now happens at the point where AI tagging runs
- When the AI limit is reached, users now see a clear, consistent message instead of an AI Solver-specific warning

### Impact
`✅ Fewer false AI rate-limit errors`
`✅ More reliable upvotes and classroom actions`
`✅ Clearer rate-limit messages for students`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
