### PR TITLE
perf: back off video status SSE polling and add heartbeat (#818)

### DIFF
--- a/src/app/api/video/status/route.ts
+++ b/src/app/api/video/status/route.ts
@@ -7,7 +7,11 @@ import { getVideoSignedUrl } from "@/lib/video/storage";
 // Always run dynamically; an SSE stream must never be cached.
 export const dynamic = "force-dynamic";
 
-const POLL_INTERVAL_MS = 1500;
+const INITIAL_POLL_INTERVAL_MS = 1500;
+const MAX_POLL_INTERVAL_MS = 15_000;
+// Send a comment frame periodically so idle intermediaries don't drop the
+// stream while the job is stuck at a single progress value.
+const HEARTBEAT_INTERVAL_MS = 20_000;
 // Cap the stream so it can't outlive the serverless function budget. Clients
 // should reconnect (EventSource does so automatically) if they hit this.
 const MAX_STREAM_MS = 4 * 60 * 1000;
@@ -65,11 +69,14 @@ export async function GET(req: Request) {
     async start(controller) {
       let closed = false;
       let lastSerialized = "";
-      let interval: ReturnType<typeof setInterval> | null = null;
+      let pollTimer: ReturnType<typeof setTimeout> | null = null;
+      let heartbeatTimer: ReturnType<typeof setInterval> | null = null;
       let timeout: ReturnType<typeof setTimeout> | null = null;
+      let currentPollInterval = INITIAL_POLL_INTERVAL_MS;
 
       const cleanup = () => {
-        if (interval) clearInterval(interval);
+        if (pollTimer) clearTimeout(pollTimer);
+        if (heartbeatTimer) clearInterval(heartbeatTimer);
         if (timeout) clearTimeout(timeout);
         if (!closed) {
           closed = true;
@@ -84,6 +91,15 @@ export async function GET(req: Request) {
       const send = (event: object) => {
         if (closed) return;
         controller.enqueue(encoder.encode(`data: ${JSON.stringify(event)}\n\n`));
+      };
+
+      const sendHeartbeat = () => {
+        if (closed) return;
+        try {
+          controller.enqueue(encoder.encode(`: heartbeat\n\n`));
+        } catch {
+          cleanup();
+        }
       };
 
       // Returns true once a terminal state has been emitted and the stream closed.
@@ -122,6 +138,17 @@ export async function GET(req: Request) {
         if (serialized !== lastSerialized) {
           send(snapshot);
           lastSerialized = serialized;
+          // Row changed — reset the backoff so we stay responsive during
+          // rapid transitions (queued → OCR → script → TTS → render).
+          currentPollInterval = INITIAL_POLL_INTERVAL_MS;
+        } else {
+          // Nothing changed — back off exponentially up to the ceiling. In
+          // steady state this cuts Neon query load ~10x vs the old fixed
+          // 1.5s cadence.
+          currentPollInterval = Math.min(
+            currentPollInterval * 2,
+            MAX_POLL_INTERVAL_MS,
+          );
         }
 
         if (row.status === "completed" || row.status === "failed") {
@@ -131,18 +158,28 @@ export async function GET(req: Request) {
         return false;
       };
 
+      const schedulePoll = () => {
+        if (closed) return;
+        pollTimer = setTimeout(async () => {
+          try {
+            const terminal = await poll();
+            if (!terminal) schedulePoll();
+          } catch {
+            send({ status: "failed", error: "Status stream error" });
+            cleanup();
+          }
+        }, currentPollInterval);
+      };
+
       // Close the stream if the client disconnects.
       req.signal?.addEventListener?.("abort", cleanup);
 
       // Emit the current state immediately; stop if it's already terminal.
       if (await poll()) return;
 
-      interval = setInterval(() => {
-        poll().catch(() => {
-          send({ status: "failed", error: "Status stream error" });
-          cleanup();
-        });
-      }, POLL_INTERVAL_MS);
+      schedulePoll();
+
+      heartbeatTimer = setInterval(sendHeartbeat, HEARTBEAT_INTERVAL_MS);
 
       timeout = setTimeout(() => {
         send({ type: "timeout", message: "Status stream closed; reconnect to continue." });


### PR DESCRIPTION
## **User description**
fixes #818

## what was wrong

`src/app/api/video/status/route.ts` polled `video_jobs` every 1.5s for the entire life of a stream. worst case one client watching one job to completion runs ~160 selects per 4-min stream. N concurrent generations → N × 40 queries/min against the same table for state that only actually changes 5-6 times per job (queued → OCR → script → TTS → render → uploaded → completed).

no periodic SSE comment either, so a job stuck at the same progress for 60-90s produced zero bytes on the wire and idle intermediaries (nginx, cloudflare, vercel proxy) silently closed the connection.

## fix

went with the exponential-backoff option from the issue (LISTEN/NOTIFY is a bigger change — needs worker plumbing and a dedicated pg driver connection, worth doing separately). the backoff alone cuts steady-state query load ~10x per the issue's estimate.

- replaced the fixed `setInterval` poll with a self-scheduling `setTimeout` loop. cadence starts at `INITIAL_POLL_INTERVAL_MS = 1500` and doubles on every unchanged poll up to `MAX_POLL_INTERVAL_MS = 15_000`. any snapshot delta resets the interval to 1.5s so we stay responsive during the rapid queued→OCR→script→TTS transitions.
- added a `: heartbeat\n\n` SSE comment frame every 20s (`HEARTBEAT_INTERVAL_MS`). this is comment-only, not a `data:` event, so clients ignore it — it just keeps the pipe warm.
- cleanup now clears the poll `setTimeout` and heartbeat `setInterval` separately.

didn't do LISTEN/NOTIFY here — the worker doesn't currently emit `NOTIFY` and switching to a pg driver connection for SSE is meaningful platform work (needs a connection strategy for vercel / neon serverless). happy to follow up with that if this baseline lands.

## test plan

- [x] `npx tsc --noEmit` clean
- [ ] manual: kick off video generation, watch `video_jobs` query count in neon during a stream — expect ≤ 15 queries per 4-min stream when the job sits in a single state, still fast (1.5s) response when the state actually flips
- [ ] manual: leave a tab open with a long-running job past nginx idle timeout — expect no disconnect (heartbeat keeps it alive)
- [ ] manual: check the client still gets a `data:` event within 1.5s of any real status change


___

## **CodeAnt-AI Description**
**Reduce video status stream load and prevent idle disconnects**

### What Changed
- The video status stream now checks for updates less often when nothing changes, then speeds back up as soon as progress moves.
- A heartbeat comment is sent every 20 seconds so long-running generations stay connected instead of being dropped by idle proxies.
- Stream cleanup now closes polling, heartbeat, and timeout timers separately when the job finishes or the client disconnects.

### Impact
`✅ Fewer video status requests during long generations`
`✅ Fewer stream drops on slow or stuck progress`
`✅ More reliable live status updates for video jobs`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
