### PR TITLE
fix: remove duplicate membership query in doubt patch action

### DIFF
--- a/src/app/api/doubts/action/[id]/route.ts
+++ b/src/app/api/doubts/action/[id]/route.ts
@@ -32,8 +32,9 @@ export async function PATCH(req: Request, { params }: { params: Promise<{ id: st
         if (!doubt) return NextResponse.json({ error: "Doubt not found" }, { status: 404 });
 
         // Security: Verify doubt visibility/classroom membership
+        let membership: typeof membershipsTable.$inferSelect | undefined;
         if (doubt.classroomId && email) {
-            const [membership] = await db.select().from(membershipsTable).where(
+            [membership] = await db.select().from(membershipsTable).where(
                 and(eq(membershipsTable.userEmail, email), eq(membershipsTable.classroomId, doubt.classroomId))
             );
             if (!membership) {
@@ -45,21 +46,7 @@ export async function PATCH(req: Request, { params }: { params: Promise<{ id: st
 
         // Permission check for sensitive actions
         const isOwner = email && doubt.userEmail === email;
-        let isTeacher = false;
-
-        if (doubt.classroomId && email) {
-            const [membership] = await db
-            .select()
-            .from(membershipsTable)
-            .where(
-                and(
-                    eq(membershipsTable.userEmail, email),
-                    eq(membershipsTable.classroomId, doubt.classroomId)
-                )
-            );
-
-            isTeacher = !!(membership && canTeach(membership.role));    
-        }
+        const isTeacher = !!(membership && canTeach(membership.role));
 
         if (action === "like") {
             if (!email) {


### PR DESCRIPTION
## Description
Removes the duplicate `membershipsTable` query in `PATCH`. The same `(email, classroomId)` lookup ran twice- once for the classroom access check, once to compute `isTeacher` despite needing the same row both times. The first lookup's result is now reused for the `isTeacher` check instead of re-querying. The existing `401` (anonymous + classroom doubt) and `403` (no membership) branches are unchanged.

## Related Issue
Closes #792

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Documentation update (README, guides, comments)
- [ ] Style / UI change (no logic change)
- [ ] Code refactor (no behavior change)
- [ ] Test addition or update
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## How Has This Been Tested?
No UI surface this is an API route change. I verified behavior parity (old vs. new logic) across every branch: classroom+teacher, classroom+student(owner), classroom+non-member, classroom+anonymous, no-classroom+owner, no-classroom+anonymous. All six give identical status codes and `isTeacher`/`isOwner` results, with the query count dropping 2→1 exactly where the duplication occurred. Also strict-checked the changed block with `tsc`.

- [x] Tested locally with `npm run dev`
- [ ] Verified on mobile viewport (375px) — N/A, no UI change
- [ ] Verified on desktop viewport (1440px) — N/A, no UI change

## Checklist
- [x] I have tested my changes locally (`npm run dev`)
- [x] My code follows the existing code style (TypeScript, Tailwind, no `any` types)
- [x] I have not introduced unrelated changes (each PR should address one issue)
- [x] I have added comments where necessary - none needed, existing comments already cover this block
- [x] My branch is up to date with `main`
- [x] I have linked the related issue above

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved permission handling when updating doubt actions, making authorization checks more reliable for classroom members.
  * Streamlined how teacher-level access is determined to reduce inconsistent behavior during solve actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->