### PR TITLE
fix: remove dummy_key Groq fallback, validate GROQ_API_KEY at init

### DIFF
--- a/src/__tests__/api/confusion-spike-detector.test.ts
+++ b/src/__tests__/api/confusion-spike-detector.test.ts
@@ -20,16 +20,39 @@ jest.mock('@/configs/schema', () => ({
 }));
 
 describe('confusion spike detector configuration', () => {
-    it('can load during a production build without a Groq API key', async () => {
+    afterEach(() => {
+        jest.resetModules();
+    });
+
+    it('throws a clear error instead of falling back to a dummy key when GROQ_API_KEY is missing', async () => {
         const originalApiKey = process.env.GROQ_API_KEY;
         delete process.env.GROQ_API_KEY;
 
-        await import('@/app/api/inngest/ConfusionSpikeDetector');
+        await expect(import('@/app/api/inngest/ConfusionSpikeDetector')).rejects.toThrow(
+            /GROQ_API_KEY is not set/
+        );
 
-        expect(mockGroq).toHaveBeenCalledWith({ apiKey: 'dummy_key' });
+        expect(mockGroq).not.toHaveBeenCalledWith(
+            expect.objectContaining({ apiKey: expect.stringContaining('dummy') })
+        );
 
         if (originalApiKey) {
             process.env.GROQ_API_KEY = originalApiKey;
+        }
+    });
+
+    it('initializes the shared Groq client with the configured key when GROQ_API_KEY is set', async () => {
+        const originalApiKey = process.env.GROQ_API_KEY;
+        process.env.GROQ_API_KEY = 'test_key';
+
+        await import('@/app/api/inngest/ConfusionSpikeDetector');
+
+        expect(mockGroq).toHaveBeenCalledWith({ apiKey: 'test_key' });
+
+        if (originalApiKey) {
+            process.env.GROQ_API_KEY = originalApiKey;
+        } else {
+            delete process.env.GROQ_API_KEY;
         }
     });
 });

--- a/src/app/api/analytics/personal/route.ts
+++ b/src/app/api/analytics/personal/route.ts
@@ -2,17 +2,13 @@ import { NextResponse } from 'next/server';
 import { db } from '@/configs/db';
 import { doubtsTable } from '@/configs/schema';
 import { and, eq, desc, isNull } from 'drizzle-orm';
-import Groq from 'groq-sdk';
+import { groq } from '@/lib/ai/groq-client';
 import { buildErrorResponse } from '@/lib/errors/error-handler';
 import {
     parseClassroomId,
     requireAuth,
     requireMembership,
 } from '@/lib/auth/membership-guard';
-
-const groq = new Groq({
-    apiKey: process.env.GROQ_API_KEY || 'dummy_key',
-});
 
 export async function GET(req: Request) {
     try {

--- a/src/app/api/ask-ai/route.ts
+++ b/src/app/api/ask-ai/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import Groq from "groq-sdk";
+import { groq } from "@/lib/ai/groq-client";
 import { and, eq } from "drizzle-orm";
 import { auth, currentUser } from "@clerk/nextjs/server";
 import { db } from "@/configs/db";
@@ -11,7 +11,6 @@ import { buildSystemMessages } from "@/lib/ai/socratic-prompt";
 import { buildErrorResponse } from "@/lib/errors/error-handler";
 import type { AIMode } from "@/types/ai-chat";
 
-const groq = new Groq({ apiKey: process.env.GROQ_API_KEY || "dummy_build_key" });
 const MODEL = "llama-3.3-70b-versatile";
 
 export async function POST(req: Request): Promise<NextResponse> {

--- a/src/app/api/doubts/check-similarity/route.ts
+++ b/src/app/api/doubts/check-similarity/route.ts
@@ -2,7 +2,7 @@ import { db } from "@/configs/db";
 import { doubtsTable, repliesTable } from "@/configs/schema";
 import { and, eq, isNull, desc, inArray } from "drizzle-orm";
 import { NextResponse } from "next/server";
-import Groq from "groq-sdk";
+import { groq } from "@/lib/ai/groq-client";
 import { findSemanticDuplicates } from "@/lib/ai/embeddings";
 import { enforceApiRateLimit } from "@/lib/ratelimit/api-rate-limit";
 import { buildErrorResponse } from "@/lib/errors/error-handler";
@@ -18,10 +18,6 @@ import {
   requireAuth,
   requireMembership,
 } from "@/lib/auth/membership-guard";
-
-const groq = new Groq({
-  apiKey: process.env.GROQ_API_KEY || "dummy_key",
-});
 
 export interface SimilarDoubt {
   id: number;

--- a/src/app/api/inngest/ConfusionSpikeDetector.ts
+++ b/src/app/api/inngest/ConfusionSpikeDetector.ts
@@ -3,9 +3,7 @@ import { inngest } from "@/inngest/client";
 import { db } from "@/configs/db";
 import { doubtsTable, confusionAlertsTable } from "@/configs/schema";
 import { and, gte, eq, desc } from "drizzle-orm";
-import Groq from "groq-sdk";
-
-const groq = new Groq({ apiKey: process.env.GROQ_API_KEY || "dummy_key" });
+import { groq } from "@/lib/ai/groq-client";
 
 const LOOKBACK_MS = 30 * 60 * 1000; // 30 minutes
 const COOLDOWN_MS = 30 * 60 * 1000; // 30 minutes per topic

--- a/src/app/api/video/script/route.ts
+++ b/src/app/api/video/script/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import Groq from 'groq-sdk';
+import { groq } from '@/lib/ai/groq-client';
 import { currentUser } from '@clerk/nextjs/server';
 import { enforceApiRateLimit } from '@/lib/ratelimit/api-rate-limit';
 import { videoLimiter } from '@/lib/ratelimit/ratelimit';
@@ -18,10 +18,6 @@ export async function POST(req: Request) {
 
         const rateLimitResponse = await enforceApiRateLimit(videoLimiter, email, 'video');
         if (rateLimitResponse) return rateLimitResponse;
-
-        const groq = new Groq({
-            apiKey: process.env.GROQ_API_KEY || 'dummy_key',
-        });
 
         const { content } = await req.json();
         if (!content) {

--- a/src/lib/ai/categorizer.ts
+++ b/src/lib/ai/categorizer.ts
@@ -1,8 +1,5 @@
-import Groq from 'groq-sdk';
-
-const groq = new Groq({
-    apiKey: process.env.GROQ_API_KEY || 'dummy_key',
-});
+import type Groq from 'groq-sdk';
+import { groq } from '@/lib/ai/groq-client';
 
 /**
  * Automatically categorizes a doubt into a specific sub-topic based on its content and subject.

--- a/src/lib/ai/embeddings.ts
+++ b/src/lib/ai/embeddings.ts
@@ -1,11 +1,7 @@
-import Groq from "groq-sdk";
+import { groq } from "@/lib/ai/groq-client";
 import { db } from "@/configs/db";
 import { doubtsTable, repliesTable } from "@/configs/schema";
 import { and, eq, isNull, desc, inArray, SQL, sql } from "drizzle-orm";
-
-const groq = new Groq({
-  apiKey: process.env.GROQ_API_KEY || "dummy_key",
-});
 
 const EMBEDDING_DIMENSIONS = 1536;
 const DEFAULT_SIMILARITY_THRESHOLD = 80; // 0..100 scale, matching similarity expression output

--- a/src/lib/ai/groq-client.ts
+++ b/src/lib/ai/groq-client.ts
@@ -1,0 +1,18 @@
+import Groq from "groq-sdk";
+
+/**
+ * Centralized Groq client.
+ *
+ * Every route/module that needs Groq should import `groq` from here instead
+ * of constructing its own client. This guarantees that if GROQ_API_KEY is
+ * missing, the app fails fast with a clear error at initialization time
+ * instead of silently constructing a client with a "dummy_key" fallback
+ * that only surfaces as an opaque API error once a real request is made.
+ */
+if (!process.env.GROQ_API_KEY) {
+  throw new Error(
+    "GROQ_API_KEY is not set. Add it to your .env file (see .env.example) before starting the app."
+  );
+}
+
+export const groq = new Groq({ apiKey: process.env.GROQ_API_KEY });

--- a/src/lib/moderation/moderation.ts
+++ b/src/lib/moderation/moderation.ts
@@ -1,13 +1,9 @@
-import { Groq } from "groq-sdk";
+import { groq } from "@/lib/ai/groq-client";
 import { db } from "@/configs/db";
 import { usersTable, moderationLogsTable } from "@/configs/schema";
 import { eq, sql } from "drizzle-orm";
 import { sendWarningEmail, sendBlockEmail } from "@/lib/email/email";
 import { z } from "zod";
-
-const groq = new Groq({
-    apiKey: process.env.GROQ_API_KEY || 'dummy_key',
-});
 
 /**
  * Moderation Reliability & Security Protection

--- a/src/lib/video/pipeline.ts
+++ b/src/lib/video/pipeline.ts
@@ -2,7 +2,7 @@ import { renderMedia, selectComposition } from "@remotion/renderer";
 import path from "path";
 import fs from "fs";
 import os from "os";
-import Groq from "groq-sdk";
+import { groq } from "@/lib/ai/groq-client";
 import axios from "axios";
 import Tesseract from "tesseract.js";
 import { uploadVideo } from "./storage";
@@ -41,10 +41,6 @@ export async function cleanupVideoArtifacts(tempDir: string, outputLocation: str
     fs.promises.rm(tempDir, { recursive: true, force: true }).catch(() => {}),
   ]);
 }
-
-const groq = new Groq({
-  apiKey: process.env.GROQ_API_KEY || "dummy_key",
-});
 
 function splitTextIntoChunks(text: string, maxLen: number = 200): string[] {
   const rawWords = text.split(/\s+/);


### PR DESCRIPTION
## **User description**
## Description
Removes the `"dummy_key"` / `"dummy_build_key"` fallback used when constructing the Groq client across multiple routes/modules. Introduces a shared `src/lib/ai/groq-client.ts` that constructs the Groq client once and throws a clear error at module initialization if `GROQ_API_KEY` is missing, instead of silently constructing a client that only fails with an opaque API error once a real request is made.

Updated all routes/modules that previously constructed their own Groq client with a dummy-key fallback to import the shared client instead:
- `app/api/ask-ai/route.ts`
- `app/api/doubts/check-similarity/route.ts`
- `app/api/inngest/ConfusionSpikeDetector.ts`
- `app/api/video/script/route.ts`
- `app/api/analytics/personal/route.ts`
- `lib/ai/embeddings.ts`
- `lib/ai/categorizer.ts`
- `lib/moderation/moderation.ts`
- `lib/video/pipeline.ts`

Also updated the `ConfusionSpikeDetector` test, which previously asserted the old dummy-key fallback behavior, to instead assert that the module throws a descriptive error when `GROQ_API_KEY` is unset and initializes correctly when it is set.

Note: `practice/generate/route.ts`, `practice/grade/route.ts`, and `lib/ai/recommendations.ts` already validated `GROQ_API_KEY` correctly before use, so they were left unchanged.

## Related Issue
Closes #799

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Documentation update (README, guides, comments)
- [ ] Style / UI change (no logic change)
- [ ] Code refactor (no behavior change)
- [x] Test addition or update
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Screenshots (if UI change)
N/A — backend-only change, no UI affected.

## How Has This Been Tested?
- [x] Tested locally with `npm run dev`
- [ ] Verified on mobile viewport (375px)
- [ ] Verified on desktop viewport (1440px)
- [x] Ran `npm test -- confusion-spike-detector` to confirm the updated test passes
- [x] Ran `npm run build` to confirm module-level initialization doesn't break the build when `GROQ_API_KEY` is set

## Checklist
- [x] I have tested my changes locally (`npm run dev`)
- [x] My code follows the existing code style (TypeScript, Tailwind, no `any` types)
- [x] I have not introduced unrelated changes (each PR should address one issue)
- [x] I have added comments where necessary
- [x] My branch is up to date with `main`
- [x] I have linked the related issue above
- [ ] Screenshots are included (if this is a UI change)


___

## **CodeAnt-AI Description**
**Stop Groq requests from starting with a placeholder key**

### What Changed
- Groq is now set up from one shared place and fails immediately if `GROQ_API_KEY` is missing, instead of using a dummy key that only breaks later during a request
- Routes and services that use Groq now rely on the shared client, including AI chat, doubt similarity checks, embeddings, video script generation, moderation, analytics, and confusion spike detection
- The confusion spike detector test now checks for the new startup error when the key is missing and confirms the client uses the real key when it is present

### Impact
`✅ Clearer startup errors for missing AI keys`
`✅ Fewer failed AI requests during use`
`✅ Safer Groq setup across AI features`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * AI-powered features now fail clearly when the required API key is missing instead of using a placeholder key.
  * Ensured configured API credentials are used consistently across AI-powered requests.
  * Preserved solved-answer details when checking doubt similarity.

* **Tests**
  * Added coverage for missing and configured API key behavior.
  * Verified placeholder credentials are never used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->