### PR TITLE
fix: add missing security headers to next.config.mjs

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -5,6 +5,64 @@ const withPWA = withPWAInit({
   disable: process.env.NODE_ENV === "development",
 });
 
+const isDev = process.env.NODE_ENV === "development";
+
+// Clerk's Frontend API host is base64-encoded inside the publishable key
+// (`pk_<env>_<base64("<host>$")>`), so it's derived here instead of being
+// hardcoded. This keeps the CSP correct for every Clerk instance (local,
+// staging, production) without any extra config.
+// See: https://clerk.com/docs/guides/how-clerk-works/overview
+function getClerkFrontendApiOrigin() {
+  const key = process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY;
+  if (!key) return "";
+  try {
+    const host = Buffer.from(key.replace(/^pk_(test|live)_/, ""), "base64")
+      .toString("utf-8")
+      .replace(/\$$/, "");
+    return /^[a-z0-9.-]+$/i.test(host) ? `https://${host}` : "";
+  } catch {
+    return "";
+  }
+}
+
+// Doubt/profile images and generated videos are uploaded to Supabase Storage
+// server-side and served back to the browser via their public URL, so that
+// origin needs to be allow-listed too.
+function getSupabaseOrigin() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  if (!url) return "";
+  try {
+    return new URL(url).origin;
+  } catch {
+    return "";
+  }
+}
+
+const clerkFrontendApi = getClerkFrontendApiOrigin();
+const supabaseOrigin = getSupabaseOrigin();
+
+// Baseline CSP for a Next.js + Clerk app. 'unsafe-inline' is required for
+// script-src/style-src because this repo doesn't use nonce-based Middleware
+// (see https://nextjs.org/docs/app/guides/content-security-policy); 'unsafe-eval'
+// is added only in development, where React needs it for error overlays.
+const contentSecurityPolicy = `
+  default-src 'self';
+  script-src 'self' 'unsafe-inline' ${clerkFrontendApi} https://challenges.cloudflare.com${isDev ? " 'unsafe-eval'" : ""};
+  style-src 'self' 'unsafe-inline';
+  img-src 'self' data: blob: https://img.clerk.com https://ui-avatars.com https://avatars.githubusercontent.com ${supabaseOrigin};
+  media-src 'self' ${supabaseOrigin};
+  font-src 'self';
+  connect-src 'self' ${clerkFrontendApi};
+  worker-src 'self' blob:;
+  frame-src 'self' https://challenges.cloudflare.com;
+  object-src 'none';
+  base-uri 'self';
+  form-action 'self';
+  frame-ancestors 'none';
+`
+  .replace(/\s{2,}/g, " ")
+  .trim();
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   typescript: {
@@ -40,6 +98,26 @@ const nextConfig = {
           {
             key: "X-Frame-Options",
             value: "DENY",
+          },
+          {
+            key: "X-Content-Type-Options",
+            value: "nosniff",
+          },
+          {
+            key: "Referrer-Policy",
+            value: "strict-origin-when-cross-origin",
+          },
+          {
+            key: "Permissions-Policy",
+            value: "camera=(), microphone=(), geolocation=()",
+          },
+          {
+            key: "Strict-Transport-Security",
+            value: "max-age=63072000; includeSubDomains; preload",
+          },
+          {
+            key: "Content-Security-Policy",
+            value: contentSecurityPolicy,
           },
         ],
       },

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -6,15 +6,14 @@ const withPWA = withPWAInit({
 });
 
 const isDev = process.env.NODE_ENV === "development";
+// Same fallback as layout.tsx's <ClerkProvider>, so the CSP stays in sync
+// with whichever Clerk instance actually loads. Publishable, not secret.
+const CLERK_FALLBACK_PUBLISHABLE_KEY = "pk_test_ZHVtbXkuY2xlcmsuYWNjb3VudHMuZGV2JA";
 
-// Clerk's Frontend API host is base64-encoded inside the publishable key
-// (`pk_<env>_<base64("<host>$")>`), so it's derived here instead of being
-// hardcoded. This keeps the CSP correct for every Clerk instance (local,
-// staging, production) without any extra config.
-// See: https://clerk.com/docs/guides/how-clerk-works/overview
+// Clerk's Frontend API host is base64-encoded in the publishable key
+// (pk_<env>_<base64("<host>$")>) - derived here so this works for any instance.
 function getClerkFrontendApiOrigin() {
-  const key = process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY;
-  if (!key) return "";
+  const key = process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY || CLERK_FALLBACK_PUBLISHABLE_KEY;
   try {
     const host = Buffer.from(key.replace(/^pk_(test|live)_/, ""), "base64")
       .toString("utf-8")
@@ -25,9 +24,7 @@ function getClerkFrontendApiOrigin() {
   }
 }
 
-// Doubt/profile images and generated videos are uploaded to Supabase Storage
-// server-side and served back to the browser via their public URL, so that
-// origin needs to be allow-listed too.
+// Uploaded images/videos are served back from Supabase Storage's public URL.
 function getSupabaseOrigin() {
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
   if (!url) return "";
@@ -41,10 +38,8 @@ function getSupabaseOrigin() {
 const clerkFrontendApi = getClerkFrontendApiOrigin();
 const supabaseOrigin = getSupabaseOrigin();
 
-// Baseline CSP for a Next.js + Clerk app. 'unsafe-inline' is required for
-// script-src/style-src because this repo doesn't use nonce-based Middleware
-// (see https://nextjs.org/docs/app/guides/content-security-policy); 'unsafe-eval'
-// is added only in development, where React needs it for error overlays.
+// 'unsafe-inline' is needed since this repo has no nonce-based CSP middleware
+// (Next's hydration scripts + Radix's inline styles both rely on it).
 const contentSecurityPolicy = `
   default-src 'self';
   script-src 'self' 'unsafe-inline' ${clerkFrontendApi} https://challenges.cloudflare.com${isDev ? " 'unsafe-eval'" : ""};


### PR DESCRIPTION
## **User description**
## Description
Adds all five headers flagged in #791 to the existing `headers()` block in `next.config.mjs`: `X-Content-Type-Options`, `Referrer-Policy`, `Permissions-Policy`, `Strict-Transport-Security`, and `Content-Security-Policy`, alongside the existing `X-Frame-Options: DENY`.

## Related Issue
Closes #791

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## How Has This Been Tested?
- [x] Tested locally with `npm run dev`
- `curl -sI http://localhost:3000/` confirms all six headers are present with the correct values, and `x-clerk-auth-status` still returns normally, confirming Clerk isn't broken by the CSP.
- `npm run build`, `npx tsc --noEmit`, `npx eslint . --ext .ts,.tsx`, and `npm test` all pass locally.

## Checklist
- [x] I have tested my changes locally (`npm run dev`)
- [x] My code follows the existing code style
- [x] I have not introduced unrelated changes
- [x] My branch is up to date with `main`
- [x] I have linked the related issue above


___

## **CodeAnt-AI Description**
**Add the missing security headers to every page response**

### What Changed
- Every page now sends the missing browser security headers: content type protection, referrer limits, permissions limits, transport security, and a content security policy
- The content security policy now allows the app’s real services to load correctly, including Clerk sign-in, Cloudflare Turnstile, Supabase-hosted images and videos, and the PWA service worker
- In development, the policy still allows React’s error overlay so local debugging continues to work

### Impact
`✅ Safer page loads`
`✅ Fewer blocked sign-in or verification requests`
`✅ Reduced risk from unsafe browser features`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Enhancements**
  * Added comprehensive security headers across all routes.
  * Strengthened content loading policies for Clerk, Supabase, and application resources.
  * Added protections against MIME-type sniffing, excessive referrer sharing, unwanted browser capabilities, and insecure transport.
  * Preserved development compatibility while maintaining stricter policies in production.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->