### PR TITLE
Validate video OCR image bytes before Tesseract

### DIFF
--- a/src/__tests__/api/video-generate-route.test.ts
+++ b/src/__tests__/api/video-generate-route.test.ts
@@ -1,0 +1,74 @@
+import { POST } from "@/app/api/video/generate/route";
+
+jest.mock("@clerk/nextjs/server", () => ({
+    currentUser: jest.fn().mockResolvedValue({
+        id: "user_123",
+        primaryEmailAddress: { emailAddress: "student@example.com" },
+    }),
+}));
+
+jest.mock("@/lib/ratelimit/api-rate-limit", () => ({
+    enforceApiRateLimit: jest.fn().mockResolvedValue(null),
+}));
+
+jest.mock("@/lib/auth/auth-utils", () => ({
+    checkUserBlock: jest.fn().mockResolvedValue({
+        isBlocked: false,
+        errorResponse: undefined,
+        dbUser: undefined,
+    }),
+}));
+
+jest.mock("@/configs/db", () => ({
+    db: {
+        insert: jest.fn(),
+    },
+}));
+
+jest.mock("@/configs/schema", () => ({
+    videoJobsTable: {},
+}));
+
+jest.mock("@/inngest/client", () => ({
+    inngest: {
+        send: jest.fn(),
+    },
+}));
+
+jest.mock("@/lib/ratelimit/ratelimit", () => ({
+    videoLimiter: {
+        limit: jest.fn(),
+    },
+    redisClient: {
+        set: jest.fn(),
+        del: jest.fn(),
+    },
+}));
+
+describe("video generate route", () => {
+    it("rejects malformed image content before queueing OCR work", async () => {
+        const fetchSpy = jest.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+            new Response("not an image", {
+                status: 200,
+                headers: { "Content-Type": "image/jpeg" },
+            }),
+        );
+
+        const res = await POST(
+            new Request("http://localhost/api/video/generate", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({
+                    imageUrl: "https://example.com/malformed.jpg",
+                }),
+            }),
+        );
+
+        expect(fetchSpy).toHaveBeenCalledTimes(1);
+        expect(res.status).toBe(422);
+        await expect(res.json()).resolves.toEqual({
+            error: "Please upload a valid PNG, JPG, or WEBP image.",
+            code: "INVALID_IMAGE_PAYLOAD",
+        });
+    });
+});

--- a/src/__tests__/lib/video-image-validation.test.ts
+++ b/src/__tests__/lib/video-image-validation.test.ts
@@ -1,0 +1,45 @@
+import {
+    detectVideoImageMimeType,
+    validateVideoImageUrl,
+} from "@/lib/video/image-validation";
+
+describe("video image validation", () => {
+    it("detects PNG, JPEG, and WEBP magic bytes", () => {
+        expect(
+            detectVideoImageMimeType(
+                new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+            ),
+        ).toBe("image/png");
+        expect(detectVideoImageMimeType(new Uint8Array([0xff, 0xd8, 0xff, 0x00]))).toBe(
+            "image/jpeg",
+        );
+        expect(
+            detectVideoImageMimeType(
+                new Uint8Array([
+                    0x52, 0x49, 0x46, 0x46, 0x00, 0x00, 0x00, 0x00, 0x57, 0x45, 0x42, 0x50,
+                ]),
+            ),
+        ).toBe("image/webp");
+    });
+
+    it("rejects non-image payloads before OCR", async () => {
+        const fetchSpy = jest.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+            new Response("not an image", {
+                status: 200,
+                headers: { "Content-Type": "image/jpeg" },
+            }),
+        );
+
+        const result = await validateVideoImageUrl("https://example.com/malformed.jpg");
+
+        expect(fetchSpy).toHaveBeenCalledWith("https://example.com/malformed.jpg", {
+            cache: "no-store",
+        });
+        expect(result).toEqual({
+            ok: false,
+            status: 422,
+            code: "INVALID_IMAGE_PAYLOAD",
+            error: "Please upload a valid PNG, JPG, or WEBP image.",
+        });
+    });
+});

--- a/src/app/api/video/generate/route.ts
+++ b/src/app/api/video/generate/route.ts
@@ -6,6 +6,7 @@ import { redisClient, videoLimiter } from "@/lib/ratelimit/ratelimit";
 import { enforceApiRateLimit } from "@/lib/ratelimit/api-rate-limit";
 import { parseAndValidateRequest } from "@/lib/validations/validate";
 import { generateVideoSchema } from "@/lib/validations/video";
+import { validateVideoImageUrl } from "@/lib/video/image-validation";
 import { db } from "@/configs/db";
 import { videoJobsTable } from "@/configs/schema";
 import { inngest } from "@/inngest/client";
@@ -41,6 +42,19 @@ export async function POST(req: Request) {
 
   const { errorResponse, data } = await parseAndValidateRequest(req, generateVideoSchema);
   if (errorResponse) return errorResponse;
+
+  if (data.imageUrl) {
+    const imageValidation = await validateVideoImageUrl(data.imageUrl);
+    if (!imageValidation.ok) {
+      return NextResponse.json(
+        {
+          error: imageValidation.error,
+          code: imageValidation.code,
+        },
+        { status: imageValidation.status },
+      );
+    }
+  }
 
   // One active generation per user. The background job releases this lock when it
   // finishes (success or failure); a 5-minute TTL guards against leaked locks.

--- a/src/lib/video/image-validation.ts
+++ b/src/lib/video/image-validation.ts
@@ -1,0 +1,82 @@
+const PNG_SIGNATURE = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
+const JPEG_SIGNATURE = [0xff, 0xd8, 0xff];
+const WEBP_SIGNATURE_PREFIX = [0x52, 0x49, 0x46, 0x46];
+const WEBP_SIGNATURE_SUFFIX = [0x57, 0x45, 0x42, 0x50];
+
+export const VIDEO_IMAGE_ALLOWED_MIME_TYPES = [
+    'image/png',
+    'image/jpeg',
+    'image/webp',
+] as const;
+
+export const VIDEO_IMAGE_ALLOWED_TYPES_LABEL = 'PNG, JPG, or WEBP';
+
+export type VideoImageValidationResult =
+    | { ok: true; mimeType: string }
+    | {
+          ok: false;
+          status: 422 | 500;
+          code: string;
+          error: string;
+      };
+
+export function isAllowedVideoImageMimeType(mimeType: string) {
+    return (VIDEO_IMAGE_ALLOWED_MIME_TYPES as readonly string[]).includes(
+        mimeType.toLowerCase(),
+    );
+}
+
+export function detectVideoImageMimeType(bytes: Uint8Array): string | null {
+    if (bytes.length >= PNG_SIGNATURE.length && PNG_SIGNATURE.every((byte, index) => bytes[index] === byte)) {
+        return 'image/png';
+    }
+
+    if (bytes.length >= JPEG_SIGNATURE.length && JPEG_SIGNATURE.every((byte, index) => bytes[index] === byte)) {
+        return 'image/jpeg';
+    }
+
+    if (
+        bytes.length >= 12 &&
+        WEBP_SIGNATURE_PREFIX.every((byte, index) => bytes[index] === byte) &&
+        WEBP_SIGNATURE_SUFFIX.every((byte, index) => bytes[index + 8] === byte)
+    ) {
+        return 'image/webp';
+    }
+
+    return null;
+}
+
+export async function validateVideoImageUrl(imageUrl: string): Promise<VideoImageValidationResult> {
+    try {
+        const response = await fetch(imageUrl, { cache: 'no-store' });
+        if (!response.ok) {
+            return {
+                ok: false,
+                status: 422,
+                code: 'INVALID_IMAGE_PAYLOAD',
+                error: `Please upload a valid ${VIDEO_IMAGE_ALLOWED_TYPES_LABEL} image.`,
+            };
+        }
+
+        const bytes = new Uint8Array(await response.arrayBuffer());
+        const mimeType = detectVideoImageMimeType(bytes);
+
+        if (!mimeType || !isAllowedVideoImageMimeType(mimeType)) {
+            return {
+                ok: false,
+                status: 422,
+                code: 'INVALID_IMAGE_PAYLOAD',
+                error: `Please upload a valid ${VIDEO_IMAGE_ALLOWED_TYPES_LABEL} image.`,
+            };
+        }
+
+        return { ok: true, mimeType };
+    } catch {
+        return {
+            ok: false,
+            status: 422,
+            code: 'INVALID_IMAGE_PAYLOAD',
+            error: `Please upload a valid ${VIDEO_IMAGE_ALLOWED_TYPES_LABEL} image.`,
+        };
+    }
+}


### PR DESCRIPTION
## **User description**
Closes #873\n\nAdds server-side byte sniffing for the video generation image URL before the OCR pipeline runs. Malformed or non-image payloads now fail fast with a 422 instead of reaching Tesseract.js.\n\nValidation:\n- git diff --check\n- npm test -- --runInBand src/__tests__/lib/video-image-validation.test.ts src/__tests__/api/video-generate-route.test.ts


___

## **CodeAnt-AI Description**
**Reject invalid video upload images before starting OCR**

### What Changed
- Video generation now checks the uploaded image content before sending it into OCR
- Files that are not real PNG, JPG, or WEBP images are stopped early with a 422 error and a clear upload message
- The upload is also rejected when the image cannot be read or fetched correctly, instead of reaching the job pipeline

### Impact
`✅ Fewer failed video generation jobs`
`✅ Clearer image upload errors`
`✅ Less wasted OCR processing on invalid files`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added validation for image URLs used during video generation.
  - Supports PNG, JPEG, and WEBP images.
  - Provides clear error messages when an image is unavailable, invalid, or unsupported.

- **Bug Fixes**
  - Prevents video generation from proceeding with invalid image payloads.

- **Tests**
  - Added coverage for image type detection, URL validation, and invalid video-generation requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->