### PR TITLE
Use shared Redis-backed limiter for unsubscribe

### DIFF
--- a/src/__tests__/api/unsubscribe.test.ts
+++ b/src/__tests__/api/unsubscribe.test.ts
@@ -6,6 +6,17 @@ jest.mock('@clerk/nextjs/server', () => ({
     currentUser: () => currentUserMock(),
 }));
 
+jest.mock('@/lib/ratelimit/ratelimit', () => {
+    const mockGeneralLimiter = {
+        limit: jest.fn(),
+    };
+
+    return {
+        generalLimiter: mockGeneralLimiter,
+        __mockGeneralLimiter: mockGeneralLimiter,
+    };
+});
+
 import { GET, POST } from '@/app/api/unsubscribe/route';
 
 jest.mock('@/configs/db', () => {
@@ -25,6 +36,7 @@ jest.mock('@/configs/db', () => {
 });
 
 const { mockUpdate, mockSet, mockWhere } = require('@/configs/db')._mocks;
+const generalLimiterMock = require('@/lib/ratelimit/ratelimit').__mockGeneralLimiter;
 
 jest.mock('@/configs/schema', () => ({
     usersTable: {
@@ -96,6 +108,17 @@ describe('Unsubscribe API Endpoint', () => {
         process.env.UNSUBSCRIBE_SECRET = 'test-unsubscribe-secret';
         jest.clearAllMocks();
         currentUserMock.mockResolvedValue(null);
+        let requestCount = 0;
+        generalLimiterMock.limit.mockImplementation(async () => {
+            requestCount += 1;
+            const limit = 30;
+            return {
+                success: requestCount <= limit,
+                limit,
+                remaining: Math.max(0, limit - requestCount),
+                reset: Date.now() + 60_000,
+            };
+        });
     });
 
     it('emits a CSRF nonce cookie and embeds the same nonce in the form', async () => {
@@ -177,7 +200,7 @@ describe('Unsubscribe API Endpoint', () => {
     it('rate limits repeated unsubscribe attempts from the same IP', async () => {
         let res: Response | undefined;
 
-        for (let i = 0; i < 11; i += 1) {
+        for (let i = 0; i < 31; i += 1) {
             res = await POST(makeUnsignedRequest('POST', '127.0.0.3'));
         }
 

--- a/src/app/api/unsubscribe/route.ts
+++ b/src/app/api/unsubscribe/route.ts
@@ -5,10 +5,7 @@ import { db } from "@/configs/db";
 import { usersTable } from "@/configs/schema";
 import { verifyUnsubscribeToken } from "@/lib/email/email";
 import { randomBytes } from "crypto";
-
-const RATE_LIMIT_WINDOW_MS = 60 * 1000;
-const RATE_LIMIT_MAX_REQUESTS = 10;
-const unsubscribeAttempts = new Map<string, { count: number; resetAt: number }>();
+import { generalLimiter } from "@/lib/ratelimit/ratelimit";
 
 /**
  * CSRF protection cookie name.
@@ -30,19 +27,6 @@ function getClientIp(req: NextRequest) {
         req.headers.get("x-real-ip") ||
         "unknown"
     );
-}
-
-function isRateLimited(ip: string) {
-    const now = Date.now();
-    const current = unsubscribeAttempts.get(ip);
-
-    if (!current || current.resetAt <= now) {
-        unsubscribeAttempts.set(ip, { count: 1, resetAt: now + RATE_LIMIT_WINDOW_MS });
-        return false;
-    }
-
-    current.count += 1;
-    return current.count > RATE_LIMIT_MAX_REQUESTS;
 }
 
 function getParams(req: NextRequest) {
@@ -137,7 +121,8 @@ export async function GET(req: NextRequest) {
 export async function POST(req: NextRequest) {
     try {
         const ip = getClientIp(req);
-        if (isRateLimited(ip)) {
+        const rateLimitResult = await generalLimiter.limit(`unsubscribe:${ip}`);
+        if (!rateLimitResult.success) {
             return redirectWithError(req, "Too many unsubscribe attempts. Please try again later.");
         }
 


### PR DESCRIPTION
Closes #787\n\nReplace the per-process in-memory unsubscribe counter with the shared generalLimiter so rate limiting works across multiple instances. The route now redirects with the same browser-facing error when the shared limiter trips.\n\nValidation:\n- git diff --check\n- npm test -- --runInBand src/__tests__/api/unsubscribe.test.ts