### PR TITLE
Fix classroom chat sidebar link

### DIFF
--- a/src/__tests__/components/Sidebar.test.tsx
+++ b/src/__tests__/components/Sidebar.test.tsx
@@ -43,6 +43,7 @@ jest.mock('@/components/layout/KeyboardShortcutsProvider', () => ({
 }));
 
 import Sidebar from '@/components/layout/Sidebar';
+import { usePathname } from 'next/navigation';
 
 describe('Sidebar Component', () => {
     it('renders platform title', () => {
@@ -57,5 +58,16 @@ describe('Sidebar Component', () => {
         expect(screen.getByText('Bookmarks')).toBeInTheDocument();
         expect(screen.getByText('Public Doubts')).toBeInTheDocument();
         expect(screen.getByText('Ask AI Solver')).toBeInTheDocument();
+    });
+
+    it('links Classroom Chat to the current room community tab when inside a room', () => {
+        (usePathname as jest.Mock).mockReturnValue('/rooms/42');
+
+        render(<Sidebar isOpen={true} onClose={jest.fn()} />);
+
+        expect(screen.getByText('Classroom Chat').closest('a')).toHaveAttribute(
+            'href',
+            '/rooms/42?tab=community',
+        );
     });
 });

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -43,7 +43,13 @@ export default function Sidebar({ isOpen, onClose }: SidebarProps) {
     const { appUser } = useAppUser()
 
     const chatSystemUrl = process.env.NEXT_PUBLIC_CHAT_SYSTEM_URL?.replace(/\/$/, "")
-    const classroomChatHref = chatSystemUrl ? `${chatSystemUrl}/chat` : '/chat'
+    const roomMatch = pathname.match(/^\/rooms\/(\d+)/)
+    const currentRoomId = roomMatch?.[1]
+    const classroomChatHref = currentRoomId
+        ? `/rooms/${currentRoomId}?tab=community`
+        : chatSystemUrl
+            ? `${chatSystemUrl}/chat`
+            : '/rooms'
     const peerToPeerHref = chatSystemUrl ? `${chatSystemUrl}/chat/peer-to-peer` : '/chat/peer-to-peer'
 
     const linkClasses = (isActive: boolean) =>
@@ -161,7 +167,9 @@ export default function Sidebar({ isOpen, onClose }: SidebarProps) {
                                             <Link
                                                 href={classroomChatHref}
                                                 onClick={onClose}
-                                                className={linkClasses(pathname === '/chat')}
+                                                className={linkClasses(
+                                                    pathname.startsWith('/rooms/') || pathname === '/chat'
+                                                )}
                                             >
                                                 <div className="p-1 rounded-md bg-slate-50 dark:bg-zinc-900/60 border border-slate-200/40 dark:border-zinc-800/40">
                                                     <MessageSquare className="w-3.5 h-3.5 text-cyan-400" />


### PR DESCRIPTION
## **User description**
Closes #659\n\nWhen the user is already inside a classroom room, the Classroom Chat sidebar link now resolves to that room's community tab instead of falling back to the dead /chat path. If no room context exists, the link falls back to /rooms rather than a 404.\n\nValidation:\n- git diff --check\n- npm test -- --runInBand src/__tests__/components/Sidebar.test.tsx


___

## **CodeAnt-AI Description**
**Classroom Chat now opens the current room’s community tab**

### What Changed
- In a classroom room, the Classroom Chat link now opens that room’s community tab instead of sending users to a separate chat page
- If there is no classroom room in view, the link now falls back to the rooms page instead of a broken chat path
- The active state for Classroom Chat now stays highlighted when viewing a room or the old chat page

### Impact
`✅ Fewer broken classroom chat links`
`✅ Faster access to the right room discussion`
`✅ Fewer dead-end navigation paths`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
