### PR TITLE
Cache personal analytics responses

### DIFF
--- a/src/__tests__/api/personal-analytics.test.ts
+++ b/src/__tests__/api/personal-analytics.test.ts
@@ -1,0 +1,118 @@
+import { GET } from "@/app/api/analytics/personal/route";
+import { db } from "@/configs/db";
+
+var cacheStore = new Map<string, string>();
+
+jest.mock("@/lib/auth/membership-guard", () => ({
+  requireAuth: jest.fn().mockResolvedValue({ email: "student@example.com" }),
+  requireMembership: jest.fn().mockResolvedValue({ role: "student" }),
+  parseClassroomId: jest.fn((value: string) => Number(value)),
+}));
+
+jest.mock("groq-sdk", () =>
+  {
+    const mockGroqCreate = jest.fn();
+    const fn = jest.fn().mockImplementation(() => ({
+      chat: {
+        completions: {
+          create: mockGroqCreate,
+        },
+      },
+    })) as any;
+    return {
+      __esModule: true,
+      default: fn,
+      Groq: fn,
+      __mockGroqCreate: mockGroqCreate,
+    };
+  },
+);
+
+jest.mock("@/lib/ratelimit/ratelimit", () => ({
+  redisClient: {
+    get: jest.fn(async (key: string) => cacheStore.get(key) ?? null),
+    set: jest.fn(async (key: string, value: string) => {
+      cacheStore.set(key, value);
+      return "OK";
+    }),
+  },
+}));
+
+jest.mock("@/configs/schema", () => ({
+  doubtsTable: {
+    content: {},
+    subject: {},
+    createdAt: {},
+    classroomId: {},
+    userEmail: {},
+    deletedAt: {},
+  },
+}));
+
+const selectMock = db.select as jest.Mock;
+const groqCreateMock = require("groq-sdk").__mockGroqCreate as jest.Mock;
+
+jest.mock("@/configs/db", () => ({
+  db: {
+    select: jest.fn(),
+  },
+}));
+
+const doubts = [
+  {
+    content: "What is recursion?",
+    subject: "Programming",
+    createdAt: new Date("2026-07-01T10:00:00.000Z"),
+  },
+  {
+    content: "How do call stacks work?",
+    subject: "Programming",
+    createdAt: new Date("2026-07-02T10:00:00.000Z"),
+  },
+];
+
+const createChain = (rows: any[]) => {
+  const chain: any = {
+    from: () => chain,
+    where: () => chain,
+    orderBy: () => chain,
+    then: (resolve: (value: any[]) => unknown) => Promise.resolve(resolve(rows)),
+  };
+  return chain;
+};
+
+describe("personal analytics route", () => {
+  beforeEach(() => {
+    cacheStore.clear();
+    groqCreateMock.mockReset().mockResolvedValue({
+      choices: [
+        {
+          message: {
+            content: JSON.stringify({
+              weakTopics: [],
+              insight: "Great progress.",
+              recommendations: {
+                practiceQuestions: ["Q1"],
+                conceptExplainer: "Keep going.",
+              },
+            }),
+          },
+        },
+      ],
+    });
+    selectMock.mockReset().mockImplementation(() => createChain(doubts));
+  });
+
+  it("reuses cached analytics for the same doubt snapshot", async () => {
+    const first = await GET(new Request("http://localhost/api/analytics/personal?classroomId=7"));
+    const firstJson = await first.json();
+
+    const second = await GET(new Request("http://localhost/api/analytics/personal?classroomId=7"));
+    const secondJson = await second.json();
+
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(200);
+    expect(firstJson).toEqual(secondJson);
+    expect(groqCreateMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/app/api/analytics/personal/route.ts
+++ b/src/app/api/analytics/personal/route.ts
@@ -3,12 +3,14 @@ import { db } from '@/configs/db';
 import { doubtsTable } from '@/configs/schema';
 import { and, eq, desc, isNull } from 'drizzle-orm';
 import Groq from 'groq-sdk';
+import { createHash } from 'crypto';
 import { buildErrorResponse } from '@/lib/errors/error-handler';
 import {
     parseClassroomId,
     requireAuth,
     requireMembership,
 } from '@/lib/auth/membership-guard';
+import { redisClient } from '@/lib/ratelimit/ratelimit';
 
 const groq = new Groq({
     apiKey: process.env.GROQ_API_KEY || 'dummy_key',
@@ -50,6 +52,24 @@ export async function GET(req: Request) {
             });
         }
 
+        const snapshot = userDoubts.map((d: any) => ({
+            content: d.content,
+            subject: d.subject,
+            createdAt: d.createdAt,
+        }));
+        const snapshotHash = createHash("sha256")
+            .update(JSON.stringify(snapshot))
+            .digest("hex");
+        const cacheKey = `personal-analytics:${email}:${classroomId}:${snapshotHash}`;
+        const cachedResponse = await (redisClient as any).get?.(cacheKey);
+        if (cachedResponse) {
+            try {
+                return NextResponse.json(JSON.parse(cachedResponse));
+            } catch {
+                // Fall through to regenerate if the cached payload is malformed.
+            }
+        }
+
         // Prepare doubt summaries for AI analysis
         const doubtContext = userDoubts.map((d: any) => `- [${d.subject}]: ${d.content}`).join('\n');
 
@@ -78,11 +98,14 @@ export async function GET(req: Request) {
         });
 
         const result = JSON.parse(response.choices[0].message.content || "{}");
-
-        return NextResponse.json({
+        const payload = {
             isEngaged: true,
             ...result
-        });
+        };
+
+        await (redisClient as any).set?.(cacheKey, JSON.stringify(payload), { ex: 60 * 60 });
+
+        return NextResponse.json(payload);
 
     } catch (error: unknown) {
         const { status, body } = buildErrorResponse(error);

--- a/src/lib/ratelimit/ratelimit.ts
+++ b/src/lib/ratelimit/ratelimit.ts
@@ -24,6 +24,7 @@ interface MockLimiter {
 
 interface MockRedis {
     setnx(key: string, value: unknown): Promise<number>;
+    get(key: string): Promise<string | null>;
     set(
       key: string,
       value: unknown,
@@ -97,6 +98,7 @@ if (isRedisConfigured) {
   // Simple in-memory fallback for local development
   // Note: This won't be perfectly accurate in distributed environments but works for local testing
   const memoryMap = new Map<string, { count: number; reset: number }>();
+  const valueMap = new Map<string, { value: string; reset: number }>();
 
   const createMockLimiter = (limit: number, windowMs: number) => ({
     limit: async (identifier: string) => {
@@ -134,6 +136,15 @@ if (isRedisConfigured) {
       memoryMap.set(key, { count: 1, reset: Date.now() + 5 * 60 * 1000 });
       return 1;
     },
+    get: async (key: string) => {
+      const record = valueMap.get(key);
+      if (!record) return null;
+      if (record.reset <= Date.now()) {
+        valueMap.delete(key);
+        return null;
+      }
+      return record.value;
+    },
     set: async (
       key: string,
       value: unknown,
@@ -141,11 +152,12 @@ if (isRedisConfigured) {
     ): Promise<"OK" | null> => {
       if (opts?.nx && memoryMap.has(key)) return null;
       const ttlMs = opts?.ex ? opts.ex * 1000 : 5 * 60 * 1000;
-      memoryMap.set(key, { count: 1, reset: Date.now() + ttlMs });
+      valueMap.set(key, { value: String(value), reset: Date.now() + ttlMs });
       return "OK";
     },
     del: async (key: string) => {
       memoryMap.delete(key);
+      valueMap.delete(key);
       return 1;
     },
     expire: async (key: string, seconds: number) => {


### PR DESCRIPTION
## **User description**
Closes #841\n\nCache personal analytics responses by classroom and current doubt snapshot so repeated requests with unchanged data can skip the Groq call. The cache key changes automatically when a doubt is added or edited because it is derived from the current snapshot.\n\nValidation:\n- git diff --check\n- npm test -- --runInBand src/__tests__/api/personal-analytics.test.ts


___

## **CodeAnt-AI Description**
**Cache personal analytics responses for repeated classroom requests**

### What Changed
- Personal analytics now reuses a saved result when the same student asks for analytics on the same doubt snapshot, so repeated requests can return immediately instead of recalculating.
- The saved result is tied to the current set of doubts, so adding or changing a doubt automatically leads to a fresh analytics response.
- Local development and tests now support reading cached values, and a test covers the cache reuse flow.

### Impact
`✅ Faster personal analytics`
`✅ Fewer repeated AI calls`
`✅ More consistent results after unchanged requests`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
