### PR TITLE
feat: add richer empty states for doubts

### DIFF
--- a/src/app/(routes)/public-rooms/page.tsx
+++ b/src/app/(routes)/public-rooms/page.tsx
@@ -11,6 +11,7 @@ import { useInView } from "react-intersection-observer";
 import ScrollToTopButton from "@/components/layout/ScrollToTopButton";
 import { Doubt } from "@/types";
 import { useUser } from "@clerk/nextjs";
+import { EmptyStatePanel } from "@/components/classroom/EmptyStatePanel";
 
 const PAGE_SIZE = 20;
 
@@ -393,84 +394,40 @@ export default function PublicRoomsPage() {
                     </button>
                 </div>
             ) : (
-                <div className="relative flex flex-col items-center justify-center py-20 rounded-2xl text-center px-6 overflow-hidden border border-slate-200 dark:border-zinc-900 bg-slate-50/30 dark:bg-zinc-950/10 shadow-inner z-10">
-                    <div className="absolute top-8 left-12 w-32 h-32 bg-blue-600/5 rounded-full blur-2xl" />
-                    <div className="absolute bottom-8 right-12 w-40 h-40 bg-indigo-600/5 rounded-full blur-2xl" />
-
-                    <div className="relative mb-6">
-                        {searchQuery ? (
-                            <div className="w-20 h-20 bg-blue-500/10 rounded-2xl flex items-center justify-center mb-4 border border-blue-500/20 shadow-sm">
-                                <MessageSquare className="w-10 h-10 text-blue-500" />
-                            </div>
-                        ) : (
-                            <svg width="120" height="100" viewBox="0 0 140 120" fill="none" xmlns="http://www.w3.org/2000/svg">
-                                <ellipse cx="70" cy="110" rx="45" ry="6" fill="rgba(59,130,246,0.1)" />
-                                <rect x="48" y="22" width="68" height="46" rx="12" fill="rgba(139,92,246,0.1)" stroke="rgba(139,92,246,0.25)" strokeWidth="1"/>
-                                <polygon points="100,62 112,72 104,62" fill="rgba(139,92,246,0.1)" stroke="rgba(139,92,246,0.25)" strokeWidth="1"/>
-                                <rect x="18" y="10" width="76" height="52" rx="14" fill="rgba(59,130,246,0.12)" stroke="rgba(59,130,246,0.3)" strokeWidth="1.2"/>
-                                <polygon points="30,57 18,72 38,57" fill="rgba(59,130,246,0.12)" stroke="rgba(59,130,246,0.3)" strokeWidth="1.2"/>
-                                <rect x="30" y="24" width="40" height="4" rx="2" fill="rgba(59,130,246,0.4)"/>
-                                <rect x="30" y="34" width="52" height="4" rx="2" fill="rgba(59,130,246,0.2)"/>
-                                <rect x="30" y="44" width="30" height="4" rx="2" fill="rgba(59,130,246,0.15)"/>
-                                <g opacity="0.6">
-                                    <line x1="118" y1="14" x2="118" y2="22" stroke="rgba(139,92,246,0.6)" strokeWidth="1.5" strokeLinecap="round"/>
-                                    <line x1="114" y1="18" x2="122" y2="18" stroke="rgba(139,92,246,0.6)" strokeWidth="1.5" strokeLinecap="round"/>
-                                </g>
-                                <circle cx="12" cy="35" r="2" fill="rgba(59,130,246,0.2)"/>
-                                <circle cx="130" cy="55" r="2" fill="rgba(59,130,246,0.2)"/>
-                            </svg>
-                        )}
-                    </div>
-
-                    <div className="relative space-y-2 mb-6">
-                        <h2 className="text-2xl font-black text-slate-900 dark:text-white tracking-tight">
-                            {searchQuery 
-                                ? "No matching doubts" 
-                                : filter === "Bookmarked"
-                                    ? "No bookmarked doubts yet"
-                                    : randomMessage.headline}{" "}
-                            <span className="text-blue-600 dark:text-blue-400">
-                                {searchQuery ? "" : filter === "Bookmarked" ? "" : randomMessage.accent}
-                            </span>
-                        </h2>
-                        <p className="text-slate-500 dark:text-zinc-400 max-w-sm mx-auto text-xs font-medium leading-relaxed">
-                            {searchQuery 
-                                ? `We couldn't find any doubts matching "${searchQuery}". Try a different keyword or subject.`
-                                : filter === "Bookmarked"
-                                    ? "Save important doubts by clicking the bookmark icon on any doubt card to view them here later."
-                                    : filter === "All"
-                                        ? randomMessage.sub
-                                        : `${filter} is wide open. Drop a doubt, and watch your classmates rally around it.`}
-                        </p>
-                    </div>
-
-                    <div className="relative flex flex-col items-center gap-3">
-                        {searchQuery ? (
-                            <button
-                                onClick={() => setSearchVal("")}
-                                className="flex items-center gap-3 px-6 py-3.5 bg-blue-600 hover:bg-blue-700 text-white rounded-xl font-bold uppercase tracking-wider text-xs transition-all duration-300 shadow-md shadow-blue-600/10 active:scale-[0.98]"
-                            >
-                                Clear Search
-                            </button>
-                        ) : filter === "Bookmarked" ? (
-                            <button
-                                onClick={() => setFilter("All")}
-                                className="group flex items-center gap-3 px-6 py-3.5 bg-blue-600 hover:bg-blue-700 text-white rounded-xl font-bold uppercase tracking-wider text-xs transition-all duration-300 shadow-md shadow-blue-600/10 active:scale-[0.98]"
-                            >
-                                Explore public doubts
-                            </button>
-                        ) : (
-                            <button
-                                onClick={() => setIsAskModalOpen(true)}
-                                className="group flex items-center gap-3 px-6 py-3.5 bg-blue-600 hover:bg-blue-700 text-white rounded-xl font-bold uppercase tracking-wider text-xs transition-all duration-300 shadow-md shadow-blue-600/10 active:scale-[0.98]"
-                            >
-                                <Plus className="w-4 h-4 group-hover:rotate-90 transition-transform duration-300" />
-                                Be the first to ask
-                            </button>
-                        )}
-                        <p className="text-slate-400 dark:text-zinc-500 text-[10px] font-bold uppercase tracking-wider">Anonymous · No login needed</p>
-                    </div>
-                </div>
+                <EmptyStatePanel
+                    icon={MessageSquare}
+                    title={
+                        searchQuery
+                            ? "No matching doubts"
+                            : filter === "Bookmarked"
+                                ? "No bookmarked doubts yet"
+                                : `${randomMessage.headline} ${randomMessage.accent}`
+                    }
+                    description={
+                        searchQuery
+                            ? `We couldn't find any doubts matching "${searchQuery}". Try a different keyword or subject.`
+                            : filter === "Bookmarked"
+                                ? "Save important doubts by clicking the bookmark icon on any doubt card to view them here later."
+                                : filter === "All"
+                                    ? randomMessage.sub
+                                    : `${filter} is wide open. Drop a doubt, and watch your classmates rally around it.`
+                    }
+                    actionLabel={
+                        searchQuery
+                            ? "Clear search"
+                            : filter === "Bookmarked"
+                                ? "Explore public doubts"
+                                : "Be the first to ask"
+                    }
+                    onAction={
+                        searchQuery
+                            ? () => setSearchVal("")
+                            : filter === "Bookmarked"
+                                ? () => setFilter("All")
+                                : () => setIsAskModalOpen(true)
+                    }
+                    secondaryLabel="Anonymous · No login needed"
+                />
             )}
 
             {isAskModalOpen && (

--- a/src/components/classroom/EmptyStatePanel.tsx
+++ b/src/components/classroom/EmptyStatePanel.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import Link from "next/link";
+import { LucideIcon } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+
+type EmptyStatePanelProps = {
+  icon: LucideIcon;
+  title: string;
+  description: string;
+  actionLabel?: string;
+  onAction?: () => void;
+  actionHref?: string;
+  secondaryLabel?: string;
+};
+
+export function EmptyStatePanel({
+  icon: Icon,
+  title,
+  description,
+  actionLabel,
+  onAction,
+  actionHref,
+  secondaryLabel,
+}: EmptyStatePanelProps) {
+  return (
+    <section className="relative overflow-hidden rounded-3xl border border-slate-200 bg-slate-50/70 px-6 py-10 text-center shadow-sm dark:border-white/10 dark:bg-white/5 sm:px-10 sm:py-12">
+      <div className="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-blue-500/30 to-transparent" />
+      <div className="mx-auto flex max-w-xl flex-col items-center gap-4">
+        <div className="flex h-16 w-16 items-center justify-center rounded-2xl border border-blue-500/20 bg-blue-500/10 text-blue-600 dark:text-blue-400">
+          <Icon className="h-8 w-8" aria-hidden="true" />
+        </div>
+
+        <div className="space-y-2">
+          <h2 className="text-2xl font-black tracking-tight text-slate-900 dark:text-white">
+            {title}
+          </h2>
+          <p className="mx-auto max-w-lg text-sm leading-6 text-slate-600 dark:text-zinc-400">
+            {description}
+          </p>
+        </div>
+
+        {actionLabel ? (
+          actionHref ? (
+            <Button asChild>
+              <Link href={actionHref}>{actionLabel}</Link>
+            </Button>
+          ) : (
+            <Button onClick={onAction}>{actionLabel}</Button>
+          )
+        ) : null}
+
+        {secondaryLabel ? (
+          <p className="text-[10px] font-bold uppercase tracking-[0.28em] text-slate-400 dark:text-zinc-500">
+            {secondaryLabel}
+          </p>
+        ) : null}
+      </div>
+    </section>
+  );
+}

--- a/src/components/classroom/InfiniteDoubtFeed.tsx
+++ b/src/components/classroom/InfiniteDoubtFeed.tsx
@@ -4,6 +4,7 @@ import { MessageSquare, Loader2, ChevronDown } from "lucide-react";
 import DoubtCard from "@/components/classroom/DoubtCard";
 import useSWRInfinite from "swr/infinite";
 import { PublicDoubt } from "@/types";
+import { EmptyStatePanel } from "@/components/classroom/EmptyStatePanel";
 
 const fetcher = async (url: string) => {
     const res = await fetch(url);
@@ -127,18 +128,14 @@ export default function InfiniteDoubtFeed({
 
     if (isEmpty) {
         return (
-            <div className="py-24 text-center space-y-4 bg-slate-100 dark:bg-white/5 border border-dashed border-slate-200 dark:border-white/10 rounded-[2.5rem]">
-                <MessageSquare className="w-12 h-12 text-slate-700 mx-auto" />
-                <p className="text-slate-500 dark:text-slate-500 font-bold uppercase tracking-widest text-xs">{emptyMessage}</p>
-                {emptyAction && (
-                    <button
-                        onClick={emptyAction}
-                        className="text-blue-500 font-black uppercase tracking-widest text-[10px] hover:underline underline-offset-4"
-                     aria-label="Interactive button">
-                        {emptyActionLabel}
-                    </button>
-                )}
-            </div>
+            <EmptyStatePanel
+                icon={MessageSquare}
+                title={emptyMessage}
+                description="This classroom is quiet right now. Start the thread by posting a doubt or try a different filter."
+                actionLabel={emptyActionLabel || "Post a doubt"}
+                onAction={emptyAction}
+                secondaryLabel="No doubts found"
+            />
         );
     }
 


### PR DESCRIPTION
## **User description**
Closes #234

Adds a shared empty-state panel and wires it into the public doubts feed and classroom infinite feed so empty or search-no-result states show a clearer CTA instead of a plain text fallback.

Validation:
- git diff --check
- npx tsc --noEmit --pretty false


___

## **CodeAnt-AI Description**
**Add shared empty states for doubts and classroom feeds**

### What Changed
- Replaced the plain empty-screen layouts with a shared panel that shows a clearer title, message, icon, and primary action
- On the public doubts page, empty results now adapt to the situation: clearing a search, switching back to all doubts, or opening the ask dialog
- On the classroom feed, the empty state now explains that no doubts are available and offers a direct way to post one

### Impact
`✅ Clearer empty screens`
`✅ Faster recovery from no-search-results states`
`✅ Easier first post from an empty classroom`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a reusable empty-state panel with configurable icons, messaging, actions, and secondary labels.
  * Improved empty results in public rooms with context-aware messages and actions for searches and filters.
  * Updated empty doubt feeds with clearer guidance and a “Post a doubt” action.

* **Style**
  * Standardized the appearance and behavior of empty-state screens across the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->