### PR TITLE
feat: add profile notification preferences

### DIFF
--- a/src/app/api/profile/route.ts
+++ b/src/app/api/profile/route.ts
@@ -7,6 +7,12 @@ import { doubtsTable, repliesTable, membershipsTable, classroomsTable, usersTabl
 import { auth, currentUser } from "@clerk/nextjs/server";
 import { buildErrorResponse } from "@/lib/errors/error-handler";
 import type { ProfileClassroom } from "@/types/profile";
+import { z } from "zod";
+
+const profilePreferencesSchema = z.object({
+    emailNotificationsEnabled: z.boolean().optional(),
+    notificationPreference: z.enum(["instant", "daily", "weekly", "none"]).optional(),
+});
 
 export async function GET(req: Request) {
     try {
@@ -107,8 +113,12 @@ export async function POST(req: NextRequest) {
 
         const [dbUser] = await db.select().from(usersTable).where(eq(usersTable.email, email)).limit(1);
 
-        const body = await req.json();
-        const { emailNotificationsEnabled, notificationPreference } = body;
+        const parsed = profilePreferencesSchema.safeParse(await req.json());
+        if (!parsed.success) {
+            return NextResponse.json({ error: "Invalid preference payload" }, { status: 400 });
+        }
+
+        const { emailNotificationsEnabled, notificationPreference } = parsed.data;
 
         const updateData:  {
             emailNotificationsEnabled?: boolean;
@@ -125,10 +135,6 @@ export async function POST(req: NextRequest) {
         }
 
         if (notificationPreference !== undefined) {
-            const validPreferences = ["instant", "daily", "weekly", "none"];
-            if (!validPreferences.includes(notificationPreference)) {
-                return NextResponse.json({ error: "Invalid preference value" }, { status: 400 });
-            }
             updateData.notificationPreference = notificationPreference;
             if (notificationPreference === "none") {
                 updateData.emailNotificationsEnabled = false;

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -10,6 +10,7 @@ import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import { CalendarDays, MessageSquare, BookOpen, Users, ThumbsUp, Mail } from "lucide-react";
 import { format } from "date-fns";
+import { NotificationPreferencesCard } from "@/components/profile/NotificationPreferencesCard";
 
 // 1. Strict TypeScript Interface mapping user records to enforce full type safety
 interface DbUser {
@@ -20,6 +21,8 @@ interface DbUser {
   role?: string | null;
   university?: string | null;
   year?: string | number | null;
+  emailNotificationsEnabled?: boolean | null;
+  notificationPreference?: "instant" | "daily" | "weekly" | "none" | null;
 }
 
 export default async function ProfilePage() {
@@ -87,6 +90,8 @@ export default async function ProfilePage() {
     role: dbUser?.role || "Student",
     university: dbUser?.university || undefined,
     year: dbUser?.year || undefined,
+    emailNotificationsEnabled: dbUser?.emailNotificationsEnabled ?? true,
+    notificationPreference: (dbUser?.notificationPreference || "instant") as "instant" | "daily" | "weekly" | "none",
   };
 
   return (
@@ -181,6 +186,11 @@ export default async function ProfilePage() {
           </CardContent>
         </Card>
       </div>
+
+      <NotificationPreferencesCard
+        emailNotificationsEnabled={displayUser.emailNotificationsEnabled}
+        notificationPreference={displayUser.notificationPreference}
+      />
 
       {/* Tabs Menu Selection */}
       <Tabs defaultValue="doubts" className="w-full relative z-10">

--- a/src/components/profile/NotificationPreferencesCard.tsx
+++ b/src/components/profile/NotificationPreferencesCard.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+import { useState } from "react";
+import { BellRing, Loader2, Mail } from "lucide-react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
+
+type NotificationPreference = "instant" | "daily" | "weekly" | "none";
+
+type NotificationPreferencesCardProps = {
+  emailNotificationsEnabled: boolean;
+  notificationPreference: NotificationPreference;
+};
+
+const preferenceLabels: Record<NotificationPreference, string> = {
+  instant: "Instant",
+  daily: "Daily digest",
+  weekly: "Weekly digest",
+  none: "Off",
+};
+
+export function NotificationPreferencesCard({
+  emailNotificationsEnabled: initialEmailEnabled,
+  notificationPreference: initialPreference,
+}: NotificationPreferencesCardProps) {
+  const [emailNotificationsEnabled, setEmailNotificationsEnabled] = useState(initialEmailEnabled);
+  const [notificationPreference, setNotificationPreference] = useState<NotificationPreference>(initialPreference);
+  const [isSaving, setIsSaving] = useState(false);
+
+  const savePreferences = async (nextEmailEnabled: boolean, nextPreference: NotificationPreference) => {
+    setIsSaving(true);
+    try {
+      const res = await fetch("/api/profile", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          emailNotificationsEnabled: nextEmailEnabled,
+          notificationPreference: nextPreference,
+        }),
+      });
+
+      const data = await res.json();
+      if (!res.ok) {
+        throw new Error(data.error || "Failed to save preferences");
+      }
+
+      toast.success("Notification preferences saved");
+    } catch (error) {
+      setEmailNotificationsEnabled(initialEmailEnabled);
+      setNotificationPreference(initialPreference);
+      toast.error(error instanceof Error ? error.message : "Failed to save preferences");
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleToggle = (checked: boolean) => {
+    const nextPreference: NotificationPreference =
+      checked ? (notificationPreference === "none" ? "instant" : notificationPreference) : "none";
+
+    setEmailNotificationsEnabled(checked);
+    setNotificationPreference(nextPreference);
+    void savePreferences(checked, nextPreference);
+  };
+
+  const handlePreferenceChange = (value: string) => {
+    const nextPreference = value as NotificationPreference;
+    const nextEmailEnabled = nextPreference !== "none";
+
+    setNotificationPreference(nextPreference);
+    setEmailNotificationsEnabled(nextEmailEnabled);
+    void savePreferences(nextEmailEnabled, nextPreference);
+  };
+
+  return (
+    <Card className="mb-8 bg-white dark:bg-zinc-950/20 border-slate-200 dark:border-zinc-900 shadow-sm">
+      <CardHeader className="space-y-2">
+        <CardTitle className="flex items-center gap-2 text-lg">
+          <BellRing className="h-5 w-5 text-blue-500" aria-hidden="true" />
+          Notification preferences
+        </CardTitle>
+        <CardDescription>
+          Choose when DoubtDesk should send email updates for your account.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <div className="flex flex-col gap-4 rounded-2xl border border-slate-200 bg-slate-50/80 p-4 dark:border-white/10 dark:bg-white/5 sm:flex-row sm:items-center sm:justify-between">
+          <div className="space-y-1">
+            <div className="flex items-center gap-2 text-sm font-semibold text-slate-900 dark:text-white">
+              <Mail className="h-4 w-4 text-blue-500" aria-hidden="true" />
+              Email notifications
+            </div>
+            <p className="text-xs leading-5 text-slate-500 dark:text-zinc-400">
+              Turn email delivery on or off for replies and classroom activity.
+            </p>
+          </div>
+          <Switch
+            checked={emailNotificationsEnabled}
+            onCheckedChange={handleToggle}
+            aria-label="Toggle email notifications"
+          />
+        </div>
+
+        <div className="space-y-2">
+          <label className="text-xs font-bold uppercase tracking-[0.24em] text-slate-500 dark:text-zinc-400">
+            Digest frequency
+          </label>
+          <Select value={notificationPreference} onValueChange={handlePreferenceChange} disabled={isSaving}>
+            <SelectTrigger className="h-11 rounded-xl border-slate-200 bg-white dark:border-white/10 dark:bg-zinc-950/40">
+              <SelectValue placeholder="Select a frequency" />
+            </SelectTrigger>
+            <SelectContent>
+              {(Object.keys(preferenceLabels) as NotificationPreference[]).map((key) => (
+                <SelectItem key={key} value={key}>
+                  {preferenceLabels[key]}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="flex items-center justify-between gap-3 rounded-2xl border border-dashed border-slate-200 px-4 py-3 text-xs text-slate-500 dark:border-white/10 dark:text-zinc-400">
+          <span className="uppercase tracking-[0.24em] font-bold">Current state</span>
+          <span className="inline-flex items-center gap-2">
+            {isSaving ? <Loader2 className="h-3.5 w-3.5 animate-spin text-blue-500" aria-hidden="true" /> : null}
+            {emailNotificationsEnabled ? preferenceLabels[notificationPreference] : "Off"}
+          </span>
+        </div>
+
+        <Button
+          type="button"
+          variant="outline"
+          className="w-full sm:w-auto"
+          onClick={() => savePreferences(emailNotificationsEnabled, notificationPreference)}
+          disabled={isSaving}
+        >
+          {isSaving ? "Saving..." : "Save preferences"}
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}


### PR DESCRIPTION
## **User description**
Closes #520

Adds a profile settings card for email notifications and digest frequency, and validates the existing profile preferences payload with Zod before updating the database.

Validation:
- git diff --check
- npx tsc --noEmit --pretty false


___

## **CodeAnt-AI Description**
Add notification controls to the profile page and validate preference updates

### What Changed
- The profile page now shows a notification settings card where users can turn email updates on or off and choose instant, daily, weekly, or no digest
- Changes are saved from the profile page with a success or error message, and the current state is shown while saving
- Profile preference updates now reject invalid values before they are applied

### Impact
`✅ Manage email alerts from the profile page`
`✅ Fewer invalid notification settings`
`✅ Clearer feedback when saving preferences`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
