### PR TITLE
feat: persist classroom board filters in url

### DIFF
--- a/src/app/(routes)/rooms/[id]/page.tsx
+++ b/src/app/(routes)/rooms/[id]/page.tsx
@@ -104,7 +104,7 @@ export default function ClassroomPage() {
   const [copied, setCopied] = useState(false);
   const [doubtFilter, setDoubtFilter] = useState<
     "unsolved" | "in-progress" | "solved"
-  >("unsolved");
+  >((searchParams.get("doubtFilter") as "unsolved" | "in-progress" | "solved") || "unsolved");
   const [searchVal, setSearchVal] = useState(searchParams.get("search") || "");
   useEffect(() => {
     const urlSearch = searchParams.get("search");
@@ -119,6 +119,11 @@ export default function ClassroomPage() {
   const [tagFilter, setTagFilter] = useState("");
   const sort = (searchParams.get("sort") as DoubtSortValue) || "newest";
   const notificationTab = searchParams.get("tab");
+  const urlDoubtFilter = searchParams.get("doubtFilter") as
+    | "unsolved"
+    | "in-progress"
+    | "solved"
+    | null;
 
   useEffect(() => {
     const timer = setTimeout(() => {
@@ -140,6 +145,18 @@ export default function ClassroomPage() {
       setActiveTab("community");
     }
   }, [notificationTab, searchParams]);
+
+  useEffect(() => {
+    if (
+      urlDoubtFilter &&
+      (urlDoubtFilter === "unsolved" ||
+        urlDoubtFilter === "in-progress" ||
+        urlDoubtFilter === "solved") &&
+      urlDoubtFilter !== doubtFilter
+    ) {
+      setDoubtFilter(urlDoubtFilter);
+    }
+  }, [doubtFilter, urlDoubtFilter]);
 
   const type =
     activeTab === "teacher-doubts"
@@ -163,6 +180,24 @@ export default function ClassroomPage() {
       scroll: false,
     });
     setSize(1);
+  };
+
+  const updateDoubtFilter = (
+    nextFilter: "unsolved" | "in-progress" | "solved",
+  ) => {
+    setDoubtFilter(nextFilter);
+
+    const nextParams = new URLSearchParams(searchParams.toString());
+    if (nextFilter === "unsolved") {
+      nextParams.delete("doubtFilter");
+    } else {
+      nextParams.set("doubtFilter", nextFilter);
+    }
+
+    const query = nextParams.toString();
+    router.replace(query ? `${pathname}?${query}` : pathname, {
+      scroll: false,
+    });
   };
 
   const getKey = (pageIndex: number, previousPageData: any) => {
@@ -525,19 +560,19 @@ export default function ClassroomPage() {
 
               <div className="flex items-center gap-1.5 bg-white dark:bg-zinc-900 p-1.5 rounded-xl border border-slate-200 dark:border-zinc-800 w-full sm:w-auto overflow-x-auto flex-nowrap scrollbar-hide whitespace-nowrap">
                 <button
-                  onClick={() => setDoubtFilter("unsolved")}
+                  onClick={() => updateDoubtFilter("unsolved")}
                   className={`px-4 py-2 rounded-lg text-[11px] font-bold uppercase tracking-wider transition-all duration-300 ${doubtFilter === "unsolved" ? "bg-red-500/10 text-red-600 dark:text-red-400 border border-red-500/20" : "text-slate-400 dark:text-zinc-500 hover:text-slate-900 dark:hover:text-zinc-200"}`}
                 >
                   Unsolved
                 </button>
                 <button
-                  onClick={() => setDoubtFilter("in-progress")}
+                  onClick={() => updateDoubtFilter("in-progress")}
                   className={`px-4 py-2 rounded-lg text-[11px] font-bold uppercase tracking-wider transition-all duration-300 ${doubtFilter === "in-progress" ? "bg-amber-500/10 text-amber-600 dark:text-amber-400 border border-amber-500/20" : "text-slate-400 dark:text-zinc-500 hover:text-slate-900 dark:hover:text-zinc-200"}`}
                 >
                   In Progress
                 </button>
                 <button
-                  onClick={() => setDoubtFilter("solved")}
+                  onClick={() => updateDoubtFilter("solved")}
                   className={`px-4 py-2 rounded-lg text-[11px] font-bold uppercase tracking-wider transition-all duration-300 ${doubtFilter === "solved" ? "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 border border-emerald-500/20" : "text-slate-400 dark:text-zinc-500 hover:text-slate-900 dark:hover:text-zinc-200"}`}
                 >
                   Resolved
@@ -757,19 +792,19 @@ export default function ClassroomPage() {
 
               <div className="flex items-center gap-1.5 bg-white dark:bg-zinc-900 p-1.5 rounded-xl border border-slate-200 dark:border-zinc-800 w-full sm:w-auto overflow-x-auto flex-nowrap scrollbar-hide whitespace-nowrap">
                 <button
-                  onClick={() => setDoubtFilter("unsolved")}
+                  onClick={() => updateDoubtFilter("unsolved")}
                   className={`px-4 py-2 rounded-lg text-[11px] font-bold uppercase tracking-wider transition-all duration-300 ${doubtFilter === "unsolved" ? "bg-red-500/10 text-red-600 dark:text-red-400 border border-red-500/20" : "text-slate-400 dark:text-zinc-500 hover:text-slate-900 dark:hover:text-zinc-200"}`}
                 >
                   Unsolved
                 </button>
                 <button
-                  onClick={() => setDoubtFilter("in-progress")}
+                  onClick={() => updateDoubtFilter("in-progress")}
                   className={`px-4 py-2 rounded-lg text-[11px] font-bold uppercase tracking-wider transition-all duration-300 ${doubtFilter === "in-progress" ? "bg-amber-500/10 text-amber-600 dark:text-amber-400 border border-amber-500/20" : "text-slate-400 dark:text-zinc-500 hover:text-slate-900 dark:hover:text-zinc-200"}`}
                 >
                   In Progress
                 </button>
                 <button
-                  onClick={() => setDoubtFilter("solved")}
+                  onClick={() => updateDoubtFilter("solved")}
                   className={`px-4 py-2 rounded-lg text-[11px] font-bold uppercase tracking-wider transition-all duration-300 ${doubtFilter === "solved" ? "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 border border-emerald-500/20" : "text-slate-400 dark:text-zinc-500 hover:text-slate-900 dark:hover:text-zinc-200"}`}
                 >
                   Resolved


### PR DESCRIPTION
## **User description**
Closes #523

Persists the classroom board filter preset in the URL so teachers can bookmark or share the current queue state and return to the same filter after navigation.

Validation:
- git diff --check
- npx tsc --noEmit --pretty false


___

## **CodeAnt-AI Description**
**Classroom board filters now stay in the URL and restore when you return**

### What Changed
- The classroom board filter is now saved in the page URL, so the selected state can be bookmarked, shared, and restored after navigation
- Opening a classroom link with a saved filter now shows that same board view right away
- Changing the filter updates the URL without reloading the page, while keeping the current board view in place

### Impact
`✅ Shareable classroom board views`
`✅ Restored filters after navigation`
`✅ Fewer lost filter selections`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
