### PR TITLE
fix: lazy load image previews

### DIFF
--- a/src/app/ask-ai/page.tsx
+++ b/src/app/ask-ai/page.tsx
@@ -428,7 +428,7 @@ export default function AskAIPage() {
                                         </button>
                                     ) : (
                                         <div className="relative rounded-2xl overflow-hidden border border-slate-200 dark:border-white/10 bg-white dark:bg-black">
-                                            <img src={imageBase64} alt="Uploaded question" className="w-full max-h-64 object-contain" />
+                                            <img src={imageBase64} alt="Uploaded question" loading="lazy" decoding="async" className="w-full max-h-64 object-contain" />
                                             <button
                                                 onClick={() => { setImageBase64(null); if (fileInputRef.current) fileInputRef.current.value = ''; }}
                                                 className="absolute top-3 right-3 w-8 h-8 bg-red-500/90 hover:bg-red-500 rounded-full flex items-center justify-center shadow-lg hover:scale-110 transition-transform"

--- a/src/components/classroom/AskDoubt.tsx
+++ b/src/components/classroom/AskDoubt.tsx
@@ -629,7 +629,7 @@ export default function AskDoubt({ defaultSubject = "", isOpen, onClose, onSucce
                                     ) : (
                                         <div className="flex flex-col items-center gap-3 px-6 text-center z-20">
                                             <div className="relative max-h-40 rounded-xl overflow-hidden border border-slate-200 dark:border-white/10 shadow-xl bg-white dark:bg-slate-950 animate-in zoom-in-95">
-                                                <img src={imageUrl} alt="Preview" className="max-h-40 object-contain" />
+                                                <img src={imageUrl} alt="Preview" loading="lazy" decoding="async" className="max-h-40 object-contain" />
                                             </div>
                                             <div>
                                                 <p className="text-xs text-slate-900 dark:text-white font-bold max-w-xs truncate">{fileName}</p>

--- a/src/components/classroom/DoubtRepliesModal.tsx
+++ b/src/components/classroom/DoubtRepliesModal.tsx
@@ -578,7 +578,7 @@ export default function DoubtRepliesModal({ doubt, isOpen, onClose, onReplyChang
                                             className="mt-2 rounded-2xl overflow-hidden border border-slate-200 dark:border-white/5 group/img relative cursor-zoom-in active:scale-[0.98] transition-all w-full"
                                             aria-label="View image fullscreen"
                                         >
-                                            <img src={reply.imageUrl} alt="Solution" className="w-full h-auto object-cover max-h-[32rem]" />
+                                            <img src={reply.imageUrl} alt="Solution" loading="lazy" decoding="async" className="w-full h-auto object-cover max-h-[32rem]" />
                                             <div className="absolute inset-0 bg-white/0 group-hover/img:bg-slate-100 dark:group-hover/img:bg-white/5 flex items-center justify-center transition-all">
                                                 <ZoomIn className="w-8 h-8 text-slate-900 dark:text-white opacity-0 group-hover/img:opacity-100 scale-50 group-hover/img:scale-100 transition-all" />
                                             </div>
@@ -876,7 +876,7 @@ export default function DoubtRepliesModal({ doubt, isOpen, onClose, onReplyChang
                                         </div>
                                     ) : (
                                         <div className="relative overflow-hidden rounded-2xl border-2 border-emerald-500/20 bg-white dark:bg-slate-950 shadow-2xl group/img">
-                                            <img src={solutionImage} alt="" className="w-full sm:w-64 h-36 object-cover opacity-80 group-hover/img:opacity-100 transition-all duration-500" />
+                                            <img src={solutionImage} alt="" loading="lazy" decoding="async" className="w-full sm:w-64 h-36 object-cover opacity-80 group-hover/img:opacity-100 transition-all duration-500" />
 
                                             {/* Image Overlay */}
                                             <div className="absolute inset-0 bg-gradient-to-t from-slate-950/90 via-transparent to-transparent flex flex-col justify-end p-3 translate-y-2 group-hover/img:translate-y-0 transition-transform">


### PR DESCRIPTION
## **User description**
Closes #238

Adds lazy loading and async decoding to the raw image preview surfaces in doubt replies, ask-doubt, and ask-ai flows so offscreen media is not loaded eagerly.

Validation:
- `git diff --check`
- `npx tsc --noEmit --pretty false`


___

## **CodeAnt-AI Description**
**Lazy-load image previews in doubt and AI upload flows**

### What Changed
- Image previews now load lazily in doubt replies, ask-doubt, ask-ai, and reply attachment views instead of loading immediately
- Preview images also decode asynchronously, which helps keep these screens responsive while media is shown
- No visible layout or content changes were made to the upload and preview panels

### Impact
`✅ Faster image-heavy screens`
`✅ Fewer preview-related slowdowns`
`✅ Lower loading pressure for offscreen attachments`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
