### PR TITLE
fix: restrict analytics exports to teachers

### DIFF
--- a/src/__tests__/api/analytics-export.test.ts
+++ b/src/__tests__/api/analytics-export.test.ts
@@ -1,0 +1,63 @@
+import { currentUser } from "@clerk/nextjs/server";
+
+import { GET } from "@/app/api/analytics/export/route";
+import { db } from "@/configs/db";
+import { checkUserBlock } from "@/lib/auth/auth-utils";
+
+jest.mock("@clerk/nextjs/server", () => ({
+  currentUser: jest.fn(),
+}));
+
+jest.mock("@/lib/auth/auth-utils", () => ({
+  checkUserBlock: jest.fn(),
+}));
+
+jest.mock("@/configs/db", () => ({
+  db: {
+    select: jest.fn(),
+  },
+}));
+
+jest.mock("@/lib/auth/membership-guard", () => ({
+  requireTeacher: jest.fn(),
+}));
+
+const currentUserMock = currentUser as jest.MockedFunction<typeof currentUser>;
+const checkUserBlockMock = checkUserBlock as jest.MockedFunction<
+  typeof checkUserBlock
+>;
+const selectMock = db.select as jest.Mock;
+
+describe("analytics export API", () => {
+  beforeEach(() => {
+    currentUserMock.mockReset();
+    checkUserBlockMock.mockReset();
+    selectMock.mockReset();
+    currentUserMock.mockResolvedValue({
+      primaryEmailAddress: { emailAddress: "student@example.com" },
+    } as Awaited<ReturnType<typeof currentUser>>);
+    checkUserBlockMock.mockResolvedValue({
+      isBlocked: false,
+      errorResponse: undefined,
+    } as Awaited<ReturnType<typeof checkUserBlock>>);
+  });
+
+  it("rejects non-teachers before exporting analytics for all classrooms", async () => {
+    const where = jest.fn().mockResolvedValue([{ role: "student" }]);
+    selectMock.mockReturnValue({
+      from: jest.fn(() => ({
+        where,
+      })),
+    });
+
+    const res = await GET(
+      new Request("http://localhost/api/analytics/export"),
+    );
+
+    expect(res.status).toBe(403);
+    await expect(res.json()).resolves.toEqual({
+      error: "Forbidden: teacher access required",
+    });
+    expect(selectMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/app/api/analytics/export/route.ts
+++ b/src/app/api/analytics/export/route.ts
@@ -6,6 +6,7 @@ import {
   repliesTable,
   membershipsTable,
   classroomsTable,
+  usersTable,
 } from "@/configs/schema";
 import {
   desc,
@@ -28,6 +29,14 @@ export async function GET(req: Request) {
   }
 
   const email = user.primaryEmailAddress.emailAddress;
+  const [dbUser] = await db
+    .select()
+    .from(usersTable)
+    .where(eq(usersTable.email, email));
+
+  if (!dbUser || !["teacher", "admin"].includes(dbUser.role)) {
+    return NextResponse.json({ error: "Forbidden: teacher access required" }, { status: 403 });
+  }
 
   // Check if user is blocked
   const { isBlocked, errorResponse } = await checkUserBlock(email);
@@ -37,26 +46,29 @@ export async function GET(req: Request) {
   const classroomIdStr = searchParams.get("classroomId");
   const classroomId = classroomIdStr ? parseInt(classroomIdStr) : null;
 
-  let classroomFilter;
+  let classroomFilter: any;
 
   if (classroomId) {
     // Verify the user is a member of this classroom
     await requireTeacher(email, classroomId);
 
     classroomFilter = eq(doubtsTable.classroomId, classroomId);
+  } else if (dbUser.role === "admin") {
+    classroomFilter = sql`true`;
   } else {
-    // Get all classrooms user is a member of
-    const userMemberships = await db
+    // Get only the classrooms the user teaches or owns
+    const teacherMemberships = await db
       .select({ classroomId: membershipsTable.classroomId })
       .from(membershipsTable)
-      .where(eq(membershipsTable.userEmail, email));
+      .where(and(
+        eq(membershipsTable.userEmail, email),
+        inArray(membershipsTable.role, ["teacher", "owner", "admin"]),
+      ));
 
-    const userClassroomIds = userMemberships.map((m: any) => m.classroomId);
+    const userClassroomIds = teacherMemberships.map((m: any) => m.classroomId);
 
     if (userClassroomIds.length === 0) {
-      return NextResponse.json({
-        message: "Export route working",
-      });
+      return NextResponse.json({ error: "Forbidden: teacher access required" }, { status: 403 });
     }
 
     classroomFilter = inArray(doubtsTable.classroomId, userClassroomIds);

--- a/src/app/ask-ai/page.tsx
+++ b/src/app/ask-ai/page.tsx
@@ -428,7 +428,7 @@ export default function AskAIPage() {
                                         </button>
                                     ) : (
                                         <div className="relative rounded-2xl overflow-hidden border border-slate-200 dark:border-white/10 bg-white dark:bg-black">
-                                            <img src={imageBase64} alt="Uploaded question" className="w-full max-h-64 object-contain" />
+                                            <img src={imageBase64} alt="Uploaded question" loading="lazy" decoding="async" className="w-full max-h-64 object-contain" />
                                             <button
                                                 onClick={() => { setImageBase64(null); if (fileInputRef.current) fileInputRef.current.value = ''; }}
                                                 className="absolute top-3 right-3 w-8 h-8 bg-red-500/90 hover:bg-red-500 rounded-full flex items-center justify-center shadow-lg hover:scale-110 transition-transform"

--- a/src/components/classroom/AskDoubt.tsx
+++ b/src/components/classroom/AskDoubt.tsx
@@ -629,7 +629,7 @@ export default function AskDoubt({ defaultSubject = "", isOpen, onClose, onSucce
                                     ) : (
                                         <div className="flex flex-col items-center gap-3 px-6 text-center z-20">
                                             <div className="relative max-h-40 rounded-xl overflow-hidden border border-slate-200 dark:border-white/10 shadow-xl bg-white dark:bg-slate-950 animate-in zoom-in-95">
-                                                <img src={imageUrl} alt="Preview" className="max-h-40 object-contain" />
+                                                <img src={imageUrl} alt="Preview" loading="lazy" decoding="async" className="max-h-40 object-contain" />
                                             </div>
                                             <div>
                                                 <p className="text-xs text-slate-900 dark:text-white font-bold max-w-xs truncate">{fileName}</p>

--- a/src/components/classroom/DoubtRepliesModal.tsx
+++ b/src/components/classroom/DoubtRepliesModal.tsx
@@ -578,7 +578,7 @@ export default function DoubtRepliesModal({ doubt, isOpen, onClose, onReplyChang
                                             className="mt-2 rounded-2xl overflow-hidden border border-slate-200 dark:border-white/5 group/img relative cursor-zoom-in active:scale-[0.98] transition-all w-full"
                                             aria-label="View image fullscreen"
                                         >
-                                            <img src={reply.imageUrl} alt="Solution" className="w-full h-auto object-cover max-h-[32rem]" />
+                                            <img src={reply.imageUrl} alt="Solution" loading="lazy" decoding="async" className="w-full h-auto object-cover max-h-[32rem]" />
                                             <div className="absolute inset-0 bg-white/0 group-hover/img:bg-slate-100 dark:group-hover/img:bg-white/5 flex items-center justify-center transition-all">
                                                 <ZoomIn className="w-8 h-8 text-slate-900 dark:text-white opacity-0 group-hover/img:opacity-100 scale-50 group-hover/img:scale-100 transition-all" />
                                             </div>
@@ -876,7 +876,7 @@ export default function DoubtRepliesModal({ doubt, isOpen, onClose, onReplyChang
                                         </div>
                                     ) : (
                                         <div className="relative overflow-hidden rounded-2xl border-2 border-emerald-500/20 bg-white dark:bg-slate-950 shadow-2xl group/img">
-                                            <img src={solutionImage} alt="" className="w-full sm:w-64 h-36 object-cover opacity-80 group-hover/img:opacity-100 transition-all duration-500" />
+                                            <img src={solutionImage} alt="" loading="lazy" decoding="async" className="w-full sm:w-64 h-36 object-cover opacity-80 group-hover/img:opacity-100 transition-all duration-500" />
 
                                             {/* Image Overlay */}
                                             <div className="absolute inset-0 bg-gradient-to-t from-slate-950/90 via-transparent to-transparent flex flex-col justify-end p-3 translate-y-2 group-hover/img:translate-y-0 transition-transform">


### PR DESCRIPTION
## **User description**
Closes #885

Restricts the analytics export route so the no-`classroomId` path only returns data for teachers/admins, instead of falling back to every classroom membership and allowing students to export analytics.

Validation:
- `git diff --check`
- `npx jest --runInBand src/__tests__/api/analytics-export.test.ts`
- `npx tsc --noEmit --pretty false`


___

## **CodeAnt-AI Description**
**Restrict analytics exports to teachers and admins, and load image previews more efficiently**

### What Changed
- Analytics exports now stop immediately for non-teachers, including students, instead of returning classroom data
- Users with teacher or admin access can still export all allowed analytics, while classroom-specific exports continue to respect classroom membership
- Image previews in doubt posts, replies, and AI uploads now load lazily to reduce upfront page load

### Impact
`✅ Fewer student access leaks in analytics exports`
`✅ Clearer export permission errors`
`✅ Faster loading of pages with image previews`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
