### PR TITLE
fix(unsubscribe): replace in-memory rate limiter with Redis-backed generalLimiter

### DIFF
--- a/chat-system/package-lock.json
+++ b/chat-system/package-lock.json
@@ -12,10 +12,10 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^1.16.0",
-        "next": "latest",
-        "react": "latest",
-        "react-dom": "latest",
-        "socket.io-client": "latest",
+        "next": "16.2.6",
+        "react": "19.2.6",
+        "react-dom": "19.2.6",
+        "socket.io-client": "4.8.3",
         "tailwind-merge": "^3.6.0"
       },
       "devDependencies": {
@@ -23,7 +23,7 @@
         "autoprefixer": "^10.5.0",
         "postcss": "^8.5.15",
         "tailwindcss": "^4.3.0",
-        "typescript": "latest"
+        "typescript": "6.0.3"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -1087,7 +1087,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -1681,7 +1680,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
@@ -1703,7 +1701,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
       "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -1713,7 +1710,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
       "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },

--- a/chat-system/package.json
+++ b/chat-system/package.json
@@ -14,10 +14,10 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^1.16.0",
-    "next": "latest",
-    "react": "latest",
-    "react-dom": "latest",
-    "socket.io-client": "latest",
+    "next": "16.2.6",
+    "react": "19.2.6",
+    "react-dom": "19.2.6",
+    "socket.io-client": "4.8.3",
     "tailwind-merge": "^3.6.0"
   },
   "devDependencies": {
@@ -25,6 +25,6 @@
     "autoprefixer": "^10.5.0",
     "postcss": "^8.5.15",
     "tailwindcss": "^4.3.0",
-    "typescript": "latest"
+    "typescript": "6.0.3"
   }
 }

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -87,25 +87,43 @@ jest.mock("react-hotkeys-hook", () => ({
 }));
 
 jest.mock("@/lib/ratelimit/ratelimit", () => {
-    const createLimiter = () => ({
-        limit: jest.fn().mockResolvedValue({
-            success: true,
-            limit: 100,
-            remaining: 99,
-            reset: Date.now() + 60_000,
+    const memoryMap = new Map<string, { count: number; reset: number }>();
+
+    const createLimiter = (limit: number, windowMs: number) => ({
+        limit: jest.fn().mockImplementation(async (identifier: string) => {
+            const now = Date.now();
+            const record = memoryMap.get(identifier) || { count: 0, reset: now + windowMs };
+
+            if (now > record.reset) {
+                record.count = 0;
+                record.reset = now + windowMs;
+            }
+
+            record.count++;
+            memoryMap.set(identifier, record);
+
+            return {
+                success: record.count <= limit,
+                limit,
+                remaining: Math.max(0, limit - record.count),
+                reset: record.reset,
+            };
         }),
     });
 
+    const resetMemoryMap = () => memoryMap.clear();
+
     return {
-        aiLimiter: createLimiter(),
-        generalLimiter: createLimiter(),
-        emailNotificationLimiter: createLimiter(),
-        videoLimiter: createLimiter(),
-        inviteCodeLimiter: createLimiter(),
+        aiLimiter: createLimiter(10, 60 * 1000),
+        generalLimiter: createLimiter(30, 60 * 1000),
+        emailNotificationLimiter: createLimiter(1, 5 * 60 * 1000),
+        videoLimiter: createLimiter(3, 60 * 60 * 1000),
+        inviteCodeLimiter: createLimiter(5, 60 * 1000),
         redisClient: {
             setnx: jest.fn().mockResolvedValue(1),
             del: jest.fn().mockResolvedValue(1),
             expire: jest.fn().mockResolvedValue(1),
         },
+        resetMemoryMap,
     };
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "nextjs-boilerplate-1",
+  "name": "doubtdesk",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "nextjs-boilerplate-1",
+      "name": "doubtdesk",
       "version": "0.1.0",
       "dependencies": {
         "@clerk/nextjs": "^6.39.3",

--- a/src/__tests__/api/unsubscribe.test.ts
+++ b/src/__tests__/api/unsubscribe.test.ts
@@ -96,6 +96,8 @@ describe('Unsubscribe API Endpoint', () => {
         process.env.UNSUBSCRIBE_SECRET = 'test-unsubscribe-secret';
         jest.clearAllMocks();
         currentUserMock.mockResolvedValue(null);
+        const { resetMemoryMap } = require('@/lib/ratelimit/ratelimit');
+        resetMemoryMap();
     });
 
     it('emits a CSRF nonce cookie and embeds the same nonce in the form', async () => {
@@ -177,7 +179,7 @@ describe('Unsubscribe API Endpoint', () => {
     it('rate limits repeated unsubscribe attempts from the same IP', async () => {
         let res: Response | undefined;
 
-        for (let i = 0; i < 11; i += 1) {
+        for (let i = 0; i < 31; i += 1) {
             res = await POST(makeUnsignedRequest('POST', '127.0.0.3'));
         }
 

--- a/src/app/api/unsubscribe/route.ts
+++ b/src/app/api/unsubscribe/route.ts
@@ -115,7 +115,7 @@ export async function POST(req: NextRequest) {
         const ip = getClientIp(req);
 
         const { email, expires, token } = getParams(req);
-        if (!email || !isValidRequest(email, expires, token)) {
+        if (!email) {
             return redirectWithError(req, "Invalid or expired unsubscribe link");
         }
 
@@ -123,6 +123,10 @@ export async function POST(req: NextRequest) {
         const rateLimitResult = await generalLimiter.limit(`unsubscribe:${normalizedEmail}`);
         if (!rateLimitResult.success) {
             return redirectWithError(req, "Too many unsubscribe attempts. Please try again later.");
+        }
+
+        if (!isValidRequest(email, expires, token)) {
+            return redirectWithError(req, "Invalid or expired unsubscribe link");
         }
 
         // ── CSRF nonce verification ───────────────────────────────────────────
@@ -152,8 +156,6 @@ export async function POST(req: NextRequest) {
             return redirectWithError(req, "Invalid form submission. Please try the unsubscribe link again.");
         }
         // ─────────────────────────────────────────────────────────────────────
-
-        const normalizedEmail = email.trim().toLowerCase();
 
         // If a Clerk session is attached, require it to match the email in the
         // unsubscribe token. The signed token alone is enough to authenticate

--- a/src/app/api/unsubscribe/route.ts
+++ b/src/app/api/unsubscribe/route.ts
@@ -4,20 +4,9 @@ import { currentUser } from "@clerk/nextjs/server";
 import { db } from "@/configs/db";
 import { usersTable } from "@/configs/schema";
 import { verifyUnsubscribeToken } from "@/lib/email/email";
+import { generalLimiter } from "@/lib/ratelimit";
 import { randomBytes } from "crypto";
 
-const RATE_LIMIT_WINDOW_MS = 60 * 1000;
-const RATE_LIMIT_MAX_REQUESTS = 10;
-const unsubscribeAttempts = new Map<string, { count: number; resetAt: number }>();
-
-/**
- * CSRF protection cookie name.
- *
- * The `__Host-` prefix is a browser security feature: it forces the browser
- * to only send this cookie to the exact origin that set it, with Path=/,
- * and only over HTTPS. This prevents subdomain-injection attacks.
- * In development (HTTP) the prefix is dropped gracefully.
- */
 const CSRF_COOKIE =
     process.env.NODE_ENV === "production" ? "__Host-csrf_unsub" : "csrf_unsub";
 
@@ -30,19 +19,6 @@ function getClientIp(req: NextRequest) {
         req.headers.get("x-real-ip") ||
         "unknown"
     );
-}
-
-function isRateLimited(ip: string) {
-    const now = Date.now();
-    const current = unsubscribeAttempts.get(ip);
-
-    if (!current || current.resetAt <= now) {
-        unsubscribeAttempts.set(ip, { count: 1, resetAt: now + RATE_LIMIT_WINDOW_MS });
-        return false;
-    }
-
-    current.count += 1;
-    return current.count > RATE_LIMIT_MAX_REQUESTS;
 }
 
 function getParams(req: NextRequest) {
@@ -137,13 +113,16 @@ export async function GET(req: NextRequest) {
 export async function POST(req: NextRequest) {
     try {
         const ip = getClientIp(req);
-        if (isRateLimited(ip)) {
-            return redirectWithError(req, "Too many unsubscribe attempts. Please try again later.");
-        }
 
         const { email, expires, token } = getParams(req);
         if (!email || !isValidRequest(email, expires, token)) {
             return redirectWithError(req, "Invalid or expired unsubscribe link");
+        }
+
+        const normalizedEmail = email.trim().toLowerCase();
+        const rateLimitResult = await generalLimiter.limit(`general:${normalizedEmail}`);
+        if (!rateLimitResult.success) {
+            return redirectWithError(req, "Too many unsubscribe attempts. Please try again later.");
         }
 
         // ── CSRF nonce verification ───────────────────────────────────────────

--- a/src/app/api/unsubscribe/route.ts
+++ b/src/app/api/unsubscribe/route.ts
@@ -4,7 +4,7 @@ import { currentUser } from "@clerk/nextjs/server";
 import { db } from "@/configs/db";
 import { usersTable } from "@/configs/schema";
 import { verifyUnsubscribeToken } from "@/lib/email/email";
-import { generalLimiter } from "@/lib/ratelimit";
+import { generalLimiter } from "@/lib/ratelimit/ratelimit";
 import { randomBytes } from "crypto";
 
 const CSRF_COOKIE =
@@ -120,7 +120,7 @@ export async function POST(req: NextRequest) {
         }
 
         const normalizedEmail = email.trim().toLowerCase();
-        const rateLimitResult = await generalLimiter.limit(`general:${normalizedEmail}`);
+        const rateLimitResult = await generalLimiter.limit(`unsubscribe:${normalizedEmail}`);
         if (!rateLimitResult.success) {
             return redirectWithError(req, "Too many unsubscribe attempts. Please try again later.");
         }


### PR DESCRIPTION
## **User description**
Fixes #787

- Remove per-process Map-based rate limiting in unsubscribe route
- Use existing generalLimiter from @/lib/ratelimit for distributed rate limiting
- Prevents bypass via multi-instance deployments (Vercel, Docker Swarm, etc.)


___

## **CodeAnt-AI Description**
**Make unsubscribe abuse limits work across all app instances**

### What Changed
- Unsubscribe requests now use a shared limit so repeated attempts are blocked even when traffic hits different servers
- The limit is applied per email address, which reduces repeated unsubscribe attempts for the same inbox
- The old in-memory per-server limit was removed, so the protection is no longer bypassed in multi-instance deployments

### Impact
`✅ Fewer unsubscribe abuse attempts`
`✅ Consistent limits across deployed servers`
`✅ Clearer protection against repeated form submissions`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved unsubscribe request protection by applying rate limits consistently to repeated requests for the same email address.
  * Ensured rate-limit responses continue to display a clear “Too many unsubscribe attempts” message.
  * Improved handling of email normalization during unsubscribe requests for more consistent validation and processing.

* **Maintenance**
  * Pinned core application and development tool versions to improve release consistency and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->