### PR TITLE
Tesseract.js OCR Missing File Type Validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "nextjs-boilerplate-1",
+  "name": "doubtdesk",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "nextjs-boilerplate-1",
+      "name": "doubtdesk",
       "version": "0.1.0",
       "dependencies": {
         "@clerk/nextjs": "^6.39.3",
@@ -54,6 +54,7 @@
         "drizzle-orm": "^0.45.2",
         "embla-carousel-react": "8.6.0",
         "file-saver": "2.0.5",
+        "file-type": "^22.0.1",
         "framer-motion": "^12.40.0",
         "google-tts-api": "^0.0.6",
         "groq-sdk": "1.1.1",
@@ -1922,6 +1923,16 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@borewit/text-codec": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@borewit/text-codec/-/text-codec-0.2.2.tgz",
+      "integrity": "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
     },
     "node_modules/@bufbuild/protobuf": {
       "version": "2.11.0",
@@ -9169,6 +9180,29 @@
         "@testing-library/dom": ">=7.21.4"
       }
     },
+    "node_modules/@tokenizer/inflate": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.4.1.tgz",
+      "integrity": "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "token-types": "^6.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/@tokenizer/token": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
+      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
+      "license": "MIT"
+    },
     "node_modules/@traceloop/ai-semantic-conventions": {
       "version": "0.20.0",
       "resolved": "https://registry.npmjs.org/@traceloop/ai-semantic-conventions/-/ai-semantic-conventions-0.20.0.tgz",
@@ -14582,6 +14616,24 @@
         "node": ">= 12"
       }
     },
+    "node_modules/file-type": {
+      "version": "22.0.1",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-22.0.1.tgz",
+      "integrity": "sha512-ww5Mhre0EE+jmBvOXTmXAbEMuZE7uX4a3+oRCQFNj8w++g3ev913N6tXQz0XTXbueQ5TWQfm6BdaViEHHn8bhA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/inflate": "^0.4.1",
+        "strtok3": "^10.3.5",
+        "token-types": "^6.1.2",
+        "uint8array-extras": "^1.5.0"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/file-type?sponsor=1"
+      }
+    },
     "node_modules/filelist": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.6.tgz",
@@ -15793,6 +15845,26 @@
       "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.2.2.tgz",
       "integrity": "sha512-yjD9nARJ/jb1g+CvD0tlhUHOrJ9Sy0P8T9MF3YaLlHnSRpwPfpTX0XIvpmw3gAJUmEu3FiICLBDPXVwyEvrleg==",
       "license": "Apache-2.0"
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/ignore": {
       "version": "5.3.2",
@@ -22933,6 +23005,22 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strtok3": {
+      "version": "10.3.5",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.5.tgz",
+      "integrity": "sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/token": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
     "node_modules/style-loader": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-4.0.0.tgz",
@@ -23584,6 +23672,24 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/token-types": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/token-types/-/token-types-6.1.2.tgz",
+      "integrity": "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@borewit/text-codec": "^0.2.1",
+        "@tokenizer/token": "^0.3.0",
+        "ieee754": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
     "node_modules/tough-cookie": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
@@ -23921,6 +24027,18 @@
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/uint8array-extras": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
+      "integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/ulid": {

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "drizzle-orm": "^0.45.2",
     "embla-carousel-react": "8.6.0",
     "file-saver": "2.0.5",
+    "file-type": "^22.0.1",
     "framer-motion": "^12.40.0",
     "google-tts-api": "^0.0.6",
     "groq-sdk": "1.1.1",

--- a/src/app/api/ask-ai/route.ts
+++ b/src/app/api/ask-ai/route.ts
@@ -6,7 +6,7 @@ import { db } from "@/configs/db";
 import { membershipsTable, usersTable, aiSessionsTable } from "@/configs/schema";
 import { enforceApiRateLimit } from "@/lib/ratelimit/api-rate-limit";
 import { aiLimiter } from "@/lib/ratelimit/ratelimit";
-import { AI_REQUEST_MAX_BYTES } from "@/lib/ai/ai-image-validation";
+import { AI_REQUEST_MAX_BYTES, validateAiImageDataUrl, type AiImageValidationResult } from "@/lib/ai/ai-image-validation";
 import { buildSystemMessages } from "@/lib/ai/socratic-prompt";
 import { buildErrorResponse } from "@/lib/errors/error-handler";
 import type { AIMode } from "@/types/ai-chat";
@@ -65,15 +65,12 @@ export async function POST(req: Request): Promise<NextResponse> {
         : "";
 
   if (body.imageBase64 !== undefined) {
-    const img = body.imageBase64 as string;
-    const validMime = /^data:image\/(png|jpe?g|webp);base64,/.test(img);
-    if (!validMime) {
+    const result = await validateAiImageDataUrl(body.imageBase64);
+    if (!result.ok) {
+      const err = result as Extract<AiImageValidationResult, { ok: false }>;
       return NextResponse.json(
-        {
-          error: "Please upload a valid PNG, JPG, or WEBP image.",
-          code: "INVALID_IMAGE_PAYLOAD",
-        },
-        { status: 422 }
+        { error: err.error, code: err.code },
+        { status: err.status }
       );
     }
   }

--- a/src/lib/ai/ai-image-validation.ts
+++ b/src/lib/ai/ai-image-validation.ts
@@ -1,3 +1,5 @@
+import { fileTypeFromBuffer } from 'file-type';
+
 export const AI_REQUEST_MAX_BYTES = 4 * 1024 * 1024;
 export const AI_IMAGE_MAX_BYTES = 3 * 1024 * 1024;
 
@@ -44,9 +46,42 @@ export function getBase64DecodedByteLength(base64Data: string) {
     return Math.floor((base64Data.length * 3) / 4) - padding;
 }
 
-export function validateAiImageDataUrl(
+/**
+ * Verify that the decoded base64 payload's magic bytes match the declared
+ * MIME type.  This prevents clients from spoofing the data URI prefix while
+ * sending a different (potentially malicious) binary format.
+ */
+async function validateMagicBytes(
+    base64Data: string,
+    declaredMime: string
+): Promise<AiImageValidationResult | null> {
+    const buffer = Buffer.from(base64Data, 'base64');
+    const detected = await fileTypeFromBuffer(buffer);
+
+    if (!detected) {
+        return {
+            ok: false,
+            status: 422,
+            code: 'INVALID_IMAGE_PAYLOAD',
+            error: 'Cannot verify image format. Please upload a valid PNG, JPG, or WEBP image.',
+        };
+    }
+
+    if (detected.mime !== declaredMime) {
+        return {
+            ok: false,
+            status: 422,
+            code: 'IMAGE_MIME_MISMATCH',
+            error: `Declared image type (${declaredMime}) does not match actual content (${detected.mime}).`,
+        };
+    }
+
+    return null;
+}
+
+export async function validateAiImageDataUrl(
     imageBase64: unknown
-): AiImageValidationResult {
+): Promise<AiImageValidationResult> {
     if (typeof imageBase64 !== "string") {
         return {
             ok: false,
@@ -107,6 +142,9 @@ export function validateAiImageDataUrl(
             error: `Images must be ${AI_IMAGE_MAX_SIZE_LABEL} or smaller.`,
         };
     }
+
+    const magicError = await validateMagicBytes(base64Data, mimeType);
+    if (magicError) return magicError;
 
     return {
         ok: true,


### PR DESCRIPTION
## **User description**
## Description
Add server-side magic byte verification to the image upload validation in the AI chat endpoint. Previously, only the client-supplied `Content-Type` / data URI prefix was checked, which can be trivially spoofed. Now the actual decoded file bytes are compared against known image signatures using the `file-type` package.

## Related Issue
Closes #873 

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Documentation update (README, guides, comments)
- [ ] Style / UI change (no logic change)
- [ ] Code refactor (no behavior change)
- [ ] Test addition or update
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Problem
The `validateAiImageDataUrl` function in `src/lib/ai/ai-image-validation.ts` only validated the client-supplied data URI prefix:
```ts
const validMime = /^data:image\/(png|jpe?g|webp);base64,/.test(img);
```
A malicious client could send:
```
data:image/png;base64,<crafted TIFF/WebP/binary payload>
```
This spoofed data URI would pass validation, and the payload would be forwarded to Groq's vision API. While the primary risk here is resource waste and potential parser crashes rather than code execution, the lack of content verification violates defense-in-depth principles.

## Fix

### 1. Magic byte verification (`src/lib/ai/ai-image-validation.ts`)
- Added `validateMagicBytes()` function that decodes the base64 payload and runs `fileTypeFromBuffer()` from the `file-type` package
- `file-type` reads the file's magic bytes (first 2-8 bytes) to determine the actual format:
  - **PNG**: `89 50 4E 47 0D 0A 1A 0A`
  - **JPEG**: `FF D8 FF`
  - **WebP**: `52 49 46 46 xx xx xx xx 57 45 42 50` (RIFF....WEBP)
- Returns `422 IMAGE_MIME_MISMATCH` if the declared MIME doesn't match the detected format
- Returns `422 INVALID_IMAGE_PAYLOAD` if the bytes don't match any known format

### 2. `validateAiImageDataUrl` is now async
The function signature changed from:
```ts
export function validateAiImageDataUrl(imageBase64: unknown): AiImageValidationResult
```
to:
```ts
export async function validateAiImageDataUrl(imageBase64: unknown): Promise<AiImageValidationResult>
```
This is necessary because `fileTypeFromBuffer` returns a Promise.

### 3. Updated caller (`src/app/api/ask-ai/route.ts`)
The ask-ai route's inline regex check was replaced with a call to the shared `validateAiImageDataUrl()` function, so all validation (format, MIME, size, magic bytes) happens in one place.

### Before (ask-ai route — inline regex only)
```ts
if (body.imageBase64 !== undefined) {
    const img = body.imageBase64 as string;
    const validMime = /^data:image\/(png|jpe?g|webp);base64,/.test(img);
    if (!validMime) {
        return NextResponse.json({ error: "..." }, { status: 422 });
    }
}
```

### After (ask-ai route — full validation)
```ts
if (body.imageBase64 !== undefined) {
    const result = await validateAiImageDataUrl(body.imageBase64);
    if (!result.ok) {
        return NextResponse.json(
            { error: result.error, code: result.code },
            { status: result.status }
        );
    }
}
```

## Files Changed
| File | Change |
|---|---|
| `src/lib/ai/ai-image-validation.ts` | Added `validateMagicBytes()` using `file-type` package; `validateAiImageDataUrl` is now `async` |
| `src/app/api/ask-ai/route.ts` | Replaced inline regex validation with `validateAiImageDataUrl()` call |
| `package.json` | Added `file-type` dependency |

## How Has This Been Tested?
- [ ] Tested locally with `npm run dev`
- [x] Verified TypeScript compilation (`npx tsc --noEmit` passes)
- [ ] Verified on mobile viewport (375px)
- [ ] Verified on desktop viewport (1440px)

## Checklist
- [x] I have tested my changes locally (`npx tsc --noEmit`)
- [x] My code follows the existing code style (TypeScript, no `any` types)
- [x] I have not introduced unrelated changes (each PR should address one issue)
- [ ] I have added comments where necessary
- [x] My branch is up to date with `main`
- [x] I have linked the related issue above
- [ ] Screenshots are included (if this is a UI change)


___

## **CodeAnt-AI Description**
**Reject spoofed image uploads in AI chat**

### What Changed
- Image uploads are now checked against their actual file contents, not just the file name or declared image type
- Uploads with mismatched or unrecognizable image data now fail with a clear error instead of being forwarded
- The AI chat endpoint now returns the specific validation error and status for invalid images

### Impact
`✅ Fewer rejected AI image requests later in the flow`
`✅ Clearer image upload errors`
`✅ Less chance of malformed files reaching vision requests`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
