### PR TITLE
fix: gate analytics CSV export global branch to teacher-role memberships (#885)

### DIFF
--- a/src/app/api/analytics/export/route.ts
+++ b/src/app/api/analytics/export/route.ts
@@ -45,25 +45,39 @@ export async function GET(req: Request) {
 
     classroomFilter = eq(doubtsTable.classroomId, classroomId);
   } else {
-    // Only include classrooms where the caller is a teacher/owner/admin.
-    // Previously this branch pulled EVERY membership regardless of role, so
-    // a student who joined any classroom could omit the `?classroomId=`
-    // query param and receive the full teacher-only CSV aggregated across
-    // every classroom they were in (issue #885). The role filter mirrors
-    // the TEACHER_ROLES set used by `requireTeacher` so the two branches
-    // stay in sync — the sibling `/api/analytics` endpoint is intentionally
-    // student-visible; only `/export` needs the tighter gate.
-    const userMemberships = await db
-      .select({
-        classroomId: membershipsTable.classroomId,
-        role: membershipsTable.role,
-      })
-      .from(membershipsTable)
-      .where(eq(membershipsTable.userEmail, email));
+    // Only include classrooms where the caller is teacher/owner/admin.
+    // Two authorization paths, mirroring what requireTeacher/requireMembership
+    // accepts in the ?classroomId= branch so a legitimate owner doesn't get
+    // 403'd here just because their membership row is missing (see codeant
+    // review on #885):
+    //   1. membershipsTable row with role in TEACHER_ROLES
+    //   2. classroomsTable.teacherEmail matches (owner fallback used inside
+    //      requireMembership when no membership row exists)
+    // Role filter is pushed into SQL to avoid a JS-side re-filter
+    // (per coderabbit review).
+    const [teacherMemberships, ownedClassrooms] = await Promise.all([
+      db
+        .select({ classroomId: membershipsTable.classroomId })
+        .from(membershipsTable)
+        .where(
+          and(
+            eq(membershipsTable.userEmail, email),
+            inArray(membershipsTable.role, [...TEACHER_ROLES]),
+          ),
+        ),
+      db
+        .select({ id: classroomsTable.id })
+        .from(classroomsTable)
+        .where(eq(classroomsTable.teacherEmail, email)),
+    ]);
 
-    const userClassroomIds = userMemberships
-      .filter((m) => TEACHER_ROLES.has(m.role))
-      .map((m) => m.classroomId);
+    // Dedupe — a teacher will usually appear in both queries.
+    const userClassroomIds = Array.from(
+      new Set<number>([
+        ...teacherMemberships.map((m) => m.classroomId),
+        ...ownedClassrooms.map((c) => c.id),
+      ]),
+    );
 
     if (userClassroomIds.length === 0) {
       return NextResponse.json(

--- a/src/app/api/analytics/export/route.ts
+++ b/src/app/api/analytics/export/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { db } from "@/configs/db";
-import { requireTeacher } from "@/lib/auth/membership-guard";
+import { requireTeacher, TEACHER_ROLES } from "@/lib/auth/membership-guard";
 import {
   doubtsTable,
   repliesTable,
@@ -45,18 +45,31 @@ export async function GET(req: Request) {
 
     classroomFilter = eq(doubtsTable.classroomId, classroomId);
   } else {
-    // Get all classrooms user is a member of
+    // Only include classrooms where the caller is a teacher/owner/admin.
+    // Previously this branch pulled EVERY membership regardless of role, so
+    // a student who joined any classroom could omit the `?classroomId=`
+    // query param and receive the full teacher-only CSV aggregated across
+    // every classroom they were in (issue #885). The role filter mirrors
+    // the TEACHER_ROLES set used by `requireTeacher` so the two branches
+    // stay in sync — the sibling `/api/analytics` endpoint is intentionally
+    // student-visible; only `/export` needs the tighter gate.
     const userMemberships = await db
-      .select({ classroomId: membershipsTable.classroomId })
+      .select({
+        classroomId: membershipsTable.classroomId,
+        role: membershipsTable.role,
+      })
       .from(membershipsTable)
       .where(eq(membershipsTable.userEmail, email));
 
-    const userClassroomIds = userMemberships.map((m: any) => m.classroomId);
+    const userClassroomIds = userMemberships
+      .filter((m) => TEACHER_ROLES.has(m.role))
+      .map((m) => m.classroomId);
 
     if (userClassroomIds.length === 0) {
-      return NextResponse.json({
-        message: "Export route working",
-      });
+      return NextResponse.json(
+        { error: "Forbidden" },
+        { status: 403 }
+      );
     }
 
     classroomFilter = inArray(doubtsTable.classroomId, userClassroomIds);

--- a/src/lib/auth/membership-guard.ts
+++ b/src/lib/auth/membership-guard.ts
@@ -32,7 +32,10 @@ import { db } from "@/configs/db";
 import { classroomsTable, membershipsTable } from "@/configs/schema";
 import { ApiError } from "@/lib/errors/error-handler";
 
-const TEACHER_ROLES = new Set(["teacher", "owner", "admin"]);
+// Exported so route handlers building their own membership queries can
+// filter to teacher-scoped rows (see /api/analytics/export global branch,
+// issue #885).
+export const TEACHER_ROLES = new Set(["teacher", "owner", "admin"]);
 
 export type AuthenticatedUser = NonNullable<
     Awaited<ReturnType<typeof currentUser>>


### PR DESCRIPTION
## **User description**
### Summary

\`/api/analytics/export\` guarded the \`?classroomId=\` branch with \`requireTeacher()\` — but the branch that runs when no query param is given pulled **every** row from \`membershipsTable\` where \`userEmail = caller\`, regardless of role. Student-role memberships folded straight into the \`inArray(doubtsTable.classroomId, ...)\` filter, so any student who had joined any classroom could omit \`?classroomId=\` and receive the full teacher-only CSV aggregated across every classroom they were in.

Payload leaked: \`trendingDoubts\`, \`mostAskedTopics\`, \`solvedStats\`, top-contributor identifiers, weak-topic severity, recent AI pedagogy-drift replies. Straight horizontal privilege escalation with no bypass tooling — just skip a query param.

### What changed

- **Exported \`TEACHER_ROLES\`** from \`src/lib/auth/membership-guard.ts\` so consumers building their own membership queries can filter to the same role set \`requireTeacher\` uses. Keeps the two code paths in sync — if the role set ever expands (e.g. \`co-teacher\`), both branches pick it up.
- **Filter the else branch's memberships by \`TEACHER_ROLES\`** before building the classroom filter — students get zero \`classroomId\`s to fold into the query.
- **Return 403** (instead of the previous \`{"message": "Export route working"}\` 200) when the caller has no teacher-role memberships. Clean deny.

### What's unchanged

- The \`?classroomId=\` branch behavior is identical (still calls \`requireTeacher\`).
- The sibling \`/api/analytics\` route is intentionally student-visible so students can see their own progress. Only \`/export\` needed the tighter gate.

### Test plan

- [x] \`tsc --noEmit\` clean on both files
- [x] verified \`TEACHER_ROLES\` matches what \`requireTeacher\` compares against inside \`membership-guard.ts\` — no drift possible
- [ ] once approved: manual repro from a student account — hitting \`/api/analytics/export\` with no query string returns 403, not the CSV

Fixes #885


___

## **CodeAnt-AI Description**
**Restrict analytics CSV export to teacher memberships**

### What Changed
- The analytics CSV export now checks only teacher, owner, and admin memberships when no classroom is selected.
- Students who joined classrooms can no longer download the teacher-only export by leaving out the classroom filter.
- If the caller has no teacher-level classroom memberships, the export now returns a 403 instead of a successful response.
- The shared teacher-role list is now reused so both access checks stay aligned.

### Impact
`✅ Fewer teacher-only CSV leaks`
`✅ Clearer export access errors`
`✅ Safer analytics downloads`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restricted analytics exports without a specified classroom to teacher-authorized classrooms.
  * Added a clear “Forbidden” response when no eligible teacher classrooms are available.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->