### PR TITLE
fix: reset streak when user misses a full day at midnight cron (#886)

### DIFF
--- a/src/inngest/karma.ts
+++ b/src/inngest/karma.ts
@@ -170,6 +170,11 @@ export const dailyStreakProcessor = inngest.createFunction(
         const now = new Date();
         const todayMidnight = new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime();
         const oneDayMs = 24 * 60 * 60 * 1000;
+        // Calendar-day boundary for "yesterday". Used to guard the exact-24h
+        // edge case where a user contributed at yesterday's midnight — that
+        // legitimately counts as a contribution on the previous calendar day
+        // and must not reset the streak. See codeant review on #886.
+        const yesterdayMidnight = todayMidnight - oneDayMs;
 
         for (const user of users) {
             try {
@@ -240,20 +245,25 @@ export const dailyStreakProcessor = inngest.createFunction(
                     await checkAndAwardBadges(user.email);
                     processed++;
 
-                } else if (daysDiff >= 1) {
-                    // Any positive daysDiff at the midnight cron means the
-                    // user missed at least one full calendar day. Trace: cron
-                    // runs at Wed 00:00 → todayMidnight = Wed 00:00. If the
-                    // user last contributed Mon at 12:00, activeTimestamp is
-                    // 36h before todayMidnight, so daysDiff floors to 1 —
-                    // but Tuesday was entirely skipped, so the streak must
-                    // reset. Contributing yesterday (e.g. Tue 08:00) yields
-                    // daysDiff === 0 (16h < 24h), which is the streak-award
-                    // branch above. The old `daysDiff === 1` no-op branch
-                    // was therefore inverted and let anyone maintain a
-                    // streak while contributing only every other day,
-                    // corrupting the currentStreak field that gates
-                    // streak_days badges. See issue #886.
+                } else if (activeTimestamp >= yesterdayMidnight) {
+                    // Exact-24h boundary case: contribution was at (or after)
+                    // yesterday's midnight — that's still a valid contribution
+                    // for the previous calendar day. daysDiff would be 1 here
+                    // but the user did contribute yesterday. Do nothing;
+                    // today's contribution (if any) will award the bonus
+                    // through the daysDiff === 0 branch above. See codeant
+                    // review on #886.
+                    skippedNoOp++;
+                } else {
+                    // activeTimestamp < yesterdayMidnight → the user did NOT
+                    // contribute on the previous calendar day and missed at
+                    // least one full day. Trace: cron runs at Wed 00:00, user
+                    // last contributed Mon at 12:00 (before Tue 00:00 =
+                    // yesterdayMidnight), so Tuesday was entirely skipped and
+                    // the streak must reset. The old `daysDiff === 1` no-op
+                    // branch let anyone maintain a streak while contributing
+                    // only every other day, corrupting the currentStreak
+                    // field that gates streak_days badges. See issue #886.
                     await db
                         .update(usersTable)
                         .set({ currentStreak: 0 })

--- a/src/inngest/karma.ts
+++ b/src/inngest/karma.ts
@@ -240,15 +240,25 @@ export const dailyStreakProcessor = inngest.createFunction(
                     await checkAndAwardBadges(user.email);
                     processed++;
 
-                } else if (daysDiff >= 2) {
+                } else if (daysDiff >= 1) {
+                    // Any positive daysDiff at the midnight cron means the
+                    // user missed at least one full calendar day. Trace: cron
+                    // runs at Wed 00:00 → todayMidnight = Wed 00:00. If the
+                    // user last contributed Mon at 12:00, activeTimestamp is
+                    // 36h before todayMidnight, so daysDiff floors to 1 —
+                    // but Tuesday was entirely skipped, so the streak must
+                    // reset. Contributing yesterday (e.g. Tue 08:00) yields
+                    // daysDiff === 0 (16h < 24h), which is the streak-award
+                    // branch above. The old `daysDiff === 1` no-op branch
+                    // was therefore inverted and let anyone maintain a
+                    // streak while contributing only every other day,
+                    // corrupting the currentStreak field that gates
+                    // streak_days badges. See issue #886.
                     await db
                         .update(usersTable)
                         .set({ currentStreak: 0 })
                         .where(eq(usersTable.email, user.email));
                     processed++;
-                } else if (daysDiff === 1) {
-                    // Valid trailing active window path (Contributed yesterday, hasn't contributed today yet)
-                    skippedNoOp++;
                 }
                 
             } catch (err) {


### PR DESCRIPTION
## **User description**
### Summary

\`dailyStreakProcessor\` runs \`cron: "0 0 * * *"\` (midnight). At tick time \`todayMidnight ≈ now\`. The branch structure was:

\`\`\`ts
if (daysDiff === 0)       // -> award streak bonus
else if (daysDiff >= 2)   // -> reset streak
else if (daysDiff === 1)  // -> no-op ("Contributed yesterday, hasn't contributed today yet")
\`\`\`

But at a midnight cron, \`daysDiff === 1\` actually means the user's last contribution was **24-48 h before todayMidnight** — i.e. they contributed the day before yesterday and **missed all of yesterday**. The inline comment was inverted: contributing yesterday (e.g. Tue 08:00 with a Wed 00:00 cron) yields \`daysDiff === 0\` because 16 h < 24 h, and that already awards the streak bonus.

**Trace**: user contributes Mon 12:00 (streak = 5). Tue they do nothing. Wed 00:00 cron sees \`daysDiff = floor(36h / 24h) = 1\` → old branch does nothing → streak stays 5. Wed 08:00 they contribute. Thu 00:00 cron sees \`daysDiff = 0\` → awards streak, streak = 6.

Users could grow their streak indefinitely while contributing every other day — corrupting \`currentStreak\` which gates \`streak_days_*\` badges and leaderboard rankings.

### What changed

Merge the reset branch into \`daysDiff >= 1\`. Any positive daysDiff at a midnight cron means at least one full calendar day was missed → streak resets. Long comment block explaining the math so a future contributor doesn't "restore" the no-op branch.

### What's unchanged

- The \`daysDiff === 0\` branch (award + same-day ledger idempotency) is untouched.
- Same-day \`karmaTransactionsTable\` idempotency guard already prevents double-awards for the streak_bonus event.

### Test plan

- [x] \`tsc --noEmit\` clean
- [x] traced Mon → Tue-off → Wed → Thu pattern: with the fix, Wed 00:00 cron resets the streak to 0 as expected
- [ ] once approved: manual soak — contribute Sat, skip Sun, contribute Mon, verify \`currentStreak\` resets Sun 00:00 and grows from 1 again on Mon

Fixes #886


___

## **CodeAnt-AI Description**
**Reset streaks when a day is missed**

### What Changed
- Users who miss any full calendar day now have their streak reset at the midnight streak check.
- The old no-op path for a one-day gap was removed, so every missed day now breaks the streak instead of letting every-other-day activity keep it alive.

### Impact
`✅ Correct streak counts`
`✅ Fairer streak badges`
`✅ More accurate leaderboard rankings`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected daily streak handling so streaks reset when a user misses a scheduled day.
  * Improved processing of missed-day records to ensure streak status remains accurate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->