### PR TITLE
fix: apply organization visibility filter to recommendations

### DIFF
--- a/src/app/api/recommendations/route.ts
+++ b/src/app/api/recommendations/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { currentUser } from "@clerk/nextjs/server";
-import { and, desc, eq, inArray, sql } from "drizzle-orm";
+import { and, eq, sql, isNull,notInArray } from "drizzle-orm";
 
 import { db } from "@/configs/db";
 import {
@@ -52,17 +52,14 @@ export async function GET() {
         );
 
         // 4. Fetch all candidate classrooms
-const classrooms = await db
-    .select()
-    .from(classroomsTable)
-    .where(
-        joinedIds.length
-            ? sql`${classroomsTable.id} NOT IN (${sql.join(
-                  joinedIds.map((id: any) => sql`${id}`),
-                  sql`, `
-              )})`
-            : sql`true`
-    );
+        const classroomConditions = [isNull(classroomsTable.organizationId)];
+        if (joinedIds.length) {
+            classroomConditions.push(notInArray(classroomsTable.id, joinedIds));
+        }
+        const classrooms = await db
+        .select()
+        .from(classroomsTable)
+        .where(and(...classroomConditions));
 
         if (!classrooms.length) {
             return NextResponse.json({


### PR DESCRIPTION
## **User description**
## Description

This PR makes the recommendation endpoint follow the same organization visibility rules already implemented in the classroom listing endpoint.

Previously, `/api/recommendations` did not exclude organization-scoped classrooms (`organizationId IS NOT NULL`) when generating classroom recommendations, while `/api/rooms` explicitly filtered them out. This inconsistency could result in different visibility behavior between the two endpoints.

### Changes
- Added `isNull(classroomsTable.organizationId)` to the recommendation query.
- Replaced the raw SQL `NOT IN` condition with Drizzle ORM's `notInArray()` helper for consistency with the rest of the codebase.
- Kept the existing recommendation logic and API response unchanged.

## Related Issue

Closes #871 

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Documentation update (README, guides, comments)
- [ ] Style / UI change (no logic change)
- [ ] Code refactor (no behavior change)
- [ ] Test addition or update
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Screenshots (if UI change)

N/A (Backend API change)

## How Has This Been Tested?

- [x] Tested locally with `npm run dev`
- [ ] Verified on mobile viewport (375px)
- [ ] Verified on desktop viewport (1440px)

Additional verification:
- Successfully built the project using `npm run build`.
- Verified TypeScript compilation completed successfully.
- Ran the existing test suite (43 test suites, 217 tests passed).

## Checklist

- [x] I have tested my changes locally (`npm run dev`)
- [x] My code follows the existing code style (TypeScript, Tailwind, no `any` types)
- [x] I have not introduced unrelated changes (each PR should address one issue)
- [ ] I have added comments where necessary
- [x] My branch is up to date with `main`
- [x] I have linked the related issue above
- [ ] Screenshots are included (if this is a UI change)


___

## **CodeAnt-AI Description**
**Keep recommendations limited to public classrooms and exclude ones already joined**

### What Changed
- Recommendation results now skip classrooms tied to an organization, matching the classroom list visibility rules
- Users no longer see classrooms they have already joined in their recommendations
- The recommendation response itself stays the same; only which classrooms appear in it changes

### Impact
`✅ Fewer private classroom recommendations`
`✅ More consistent classroom visibility`
`✅ Less duplicate recommendations`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved classroom recommendations by limiting results to eligible classrooms.
  * Prevented recommendations from including classrooms the user has already joined.
  * Preserved existing recommendation scoring, sorting, and result limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->