### PR TITLE
fix(api): remove creator emails from tag responses

### DIFF
--- a/src/__tests__/api/tags.test.ts
+++ b/src/__tests__/api/tags.test.ts
@@ -1,104 +1,183 @@
 import { GET, POST } from '@/app/api/tags/route';
 
-jest.mock('@clerk/nextjs/server', () => ({
-    currentUser: jest.fn().mockImplementation(async () => ({
-        primaryEmailAddress: { emailAddress: 'student@example.com' },
-        fullName: 'Test Student'
-    }))
-}));
+const mockSelectResults: Array<Array<Record<string, unknown>>> = [];
+let mockInsertedTag: Record<string, unknown>;
 
-const mockTags = [
-    { id: 1, name: 'Calculus', normalizedName: 'calculus', classroomId: null },
-    { id: 2, name: 'Kinematics', normalizedName: 'kinematics', classroomId: null },
-    { id: 3, name: 'Optics', normalizedName: 'optics', classroomId: null }
+const internalTags = [
+    {
+        id: 1,
+        name: 'Calculus',
+        normalizedName: 'calculus',
+        classroomId: null,
+        createdByEmail: 'creator@example.com',
+        createdAt: '2026-07-16T00:00:00.000Z',
+    },
+    {
+        id: 2,
+        name: 'Kinematics',
+        normalizedName: 'kinematics',
+        classroomId: null,
+        createdByEmail: 'teacher@example.com',
+        createdAt: '2026-07-15T00:00:00.000Z',
+    },
 ];
 
-const createEmptyChain = () => {
-    const chain: any = {
-        from: () => chain,
-        where: () => chain,
-        orderBy: () => chain,
-        limit: () => chain,
-        groupBy: () => chain,
-        innerJoin: () => chain,
-        then: (resolve: any) => Promise.resolve(resolve([])),
-    };
+const mockProjectRows = (
+    rows: Array<Record<string, unknown>>,
+    fields?: Record<string, unknown>,
+) => {
+    if (!fields) return rows;
+
+    return rows.map((row) => Object.fromEntries(
+        Object.keys(fields).map((key) => [key, row[key]]),
+    ));
+};
+
+const mockCreateSelectChain = (
+    rows: Array<Record<string, unknown>>,
+    fields?: Record<string, unknown>,
+) => {
+    const projectedRows = mockProjectRows(rows, fields);
+    const chain: Record<string, unknown> = {};
+
+    for (const method of ['from', 'where', 'orderBy', 'limit', 'groupBy', 'innerJoin']) {
+        chain[method] = jest.fn(() => chain);
+    }
+    chain.then = (resolve: (value: Array<Record<string, unknown>>) => unknown) =>
+        Promise.resolve(resolve(projectedRows));
+
     return chain;
 };
 
-const createChainWithData = (data: any[]) => {
-    const chain: any = {
-        from: () => chain,
-        where: () => chain,
-        orderBy: () => chain,
-        limit: () => chain,
-        groupBy: () => chain,
-        innerJoin: () => chain,
-        then: (resolve: any) => Promise.resolve(resolve(data)),
-    };
-    return chain;
-};
-
-// Track DB calls to test subject filtering
-let selectSubjectParam: any = null;
-let isPostActive = false;
+const mockValues = jest.fn(() => ({
+    returning: jest.fn((fields?: Record<string, unknown>) =>
+        Promise.resolve(mockProjectRows([mockInsertedTag], fields))),
+}));
 
 jest.mock('@/configs/db', () => ({
     db: {
-        select: jest.fn().mockImplementation((fields: any) => {
-            // Check if it is the membership verification query
-            if (fields && fields.role) {
-                return createEmptyChain();
-            }
-            if (isPostActive) {
-                return createEmptyChain();
-            }
-            return createChainWithData(mockTags);
-        }),
-        insert: jest.fn().mockImplementation(() => ({
-            values: jest.fn().mockImplementation(() => ({
-                returning: jest.fn().mockResolvedValue([{
-                    id: 4,
-                    name: 'Electromagnetism',
-                    normalizedName: 'electromagnetism',
-                    classroomId: null
-                }])
-            }))
-        }))
-    }
+        select: jest.fn((fields?: Record<string, unknown>) =>
+            mockCreateSelectChain(mockSelectResults.shift() ?? [], fields)),
+        insert: jest.fn(() => ({
+            values: mockValues,
+        })),
+    },
 }));
 
-describe('Tags API Endpoints', () => {
-    it('GET should return list of tags', async () => {
-        const req = new Request('http://localhost/api/tags');
-        const res = await GET(req);
-        const json = await res.json();
-        expect(res.status).toBe(200);
-        expect(Array.isArray(json)).toBe(true);
-        expect(json.length).toBe(3);
+jest.mock('@/lib/auth/membership-guard', () => ({
+    requireAuth: jest.fn().mockResolvedValue({ email: 'student@example.com' }),
+    requireMembership: jest.fn().mockResolvedValue({ role: 'student' }),
+    parseOptionalClassroomId: jest.fn((value?: string | number | null) => {
+        if (value === undefined || value === null || value === '') return null;
+        return Number(value);
+    }),
+}));
+
+jest.mock('@/lib/ratelimit/api-rate-limit', () => ({
+    enforceApiRateLimit: jest.fn().mockResolvedValue(null),
+}));
+
+const expectPublicTag = (tag: Record<string, unknown>) => {
+    expect(tag).toEqual(expect.objectContaining({
+        id: expect.any(Number),
+        name: expect.any(String),
+        normalizedName: expect.any(String),
+    }));
+    expect(tag).toHaveProperty('classroomId');
+    expect(tag).toHaveProperty('createdAt');
+    expect(tag).not.toHaveProperty('createdByEmail');
+};
+
+describe('Tags API privacy', () => {
+    beforeEach(() => {
+        mockSelectResults.length = 0;
+        mockInsertedTag = {
+            id: 3,
+            name: 'Electromagnetism',
+            normalizedName: 'electromagnetism',
+            classroomId: null,
+            createdByEmail: 'student@example.com',
+            createdAt: '2026-07-16T00:00:00.000Z',
+        };
+        jest.clearAllMocks();
     });
 
-    it('GET with subject should query subject popular tags', async () => {
-        const req = new Request('http://localhost/api/tags?subject=Physics');
-        const res = await GET(req);
+    it.each([
+        ['general list', 'http://localhost/api/tags'],
+        ['search results', 'http://localhost/api/tags?q=math'],
+        ['classroom-filtered results', 'http://localhost/api/tags?classroomId=12'],
+    ])('omits creator emails from %s', async (_scenario, url) => {
+        mockSelectResults.push(internalTags);
+
+        const res = await GET(new Request(url));
         const json = await res.json();
+
         expect(res.status).toBe(200);
-        expect(Array.isArray(json)).toBe(true);
+        expect(json).toHaveLength(2);
+        json.forEach(expectPublicTag);
     });
 
-    it('POST should create a new tag', async () => {
-        isPostActive = true;
-        const req = new Request('http://localhost/api/tags', {
+    it('omits creator emails from subject-specific popular tags', async () => {
+        mockSelectResults.push(internalTags);
+
+        const res = await GET(new Request('http://localhost/api/tags?subject=Physics'));
+        const json = await res.json();
+
+        expect(res.status).toBe(200);
+        expect(json).toHaveLength(2);
+        json.forEach(expectPublicTag);
+    });
+
+    it('omits creator emails from the subject popularity fallback', async () => {
+        mockSelectResults.push([], internalTags);
+
+        const res = await GET(new Request('http://localhost/api/tags?subject=Physics'));
+        const json = await res.json();
+
+        expect(res.status).toBe(200);
+        expect(json).toHaveLength(2);
+        json.forEach(expectPublicTag);
+    });
+
+    it('omits creator emails from the recent-tags fallback', async () => {
+        mockSelectResults.push([], [], internalTags);
+
+        const res = await GET(new Request('http://localhost/api/tags?subject=Physics'));
+        const json = await res.json();
+
+        expect(res.status).toBe(200);
+        expect(json).toHaveLength(2);
+        json.forEach(expectPublicTag);
+    });
+
+    it('omits the creator email when returning an existing tag', async () => {
+        mockSelectResults.push([internalTags[0]]);
+
+        const res = await POST(new Request('http://localhost/api/tags', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({
-                name: 'electromagnetism'
-            })
-        });
-        const res = await POST(req);
+            body: JSON.stringify({ name: 'calculus' }),
+        }));
         const json = await res.json();
+
+        expect(res.status).toBe(200);
+        expectPublicTag(json);
+    });
+
+    it('omits the creator email when returning a newly created tag', async () => {
+        mockSelectResults.push([]);
+
+        const res = await POST(new Request('http://localhost/api/tags', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ name: 'electromagnetism' }),
+        }));
+        const json = await res.json();
+
         expect(res.status).toBe(201);
-        expect(json.id).toBe(4);
-        expect(json.name).toBe('Electromagnetism');
+        expect(mockValues).toHaveBeenCalledWith(expect.objectContaining({
+            createdByEmail: 'student@example.com',
+        }));
+        expectPublicTag(json);
     });
 });

--- a/src/app/api/tags/route.ts
+++ b/src/app/api/tags/route.ts
@@ -14,6 +14,14 @@ import { escapeLike } from "@/lib/utils/utils";
 
 const normalizeTagName = (name: string) => name.trim().replace(/\s+/g, " ").toLowerCase();
 
+const publicTagSelection = {
+    id: tagsTable.id,
+    name: tagsTable.name,
+    normalizedName: tagsTable.normalizedName,
+    classroomId: tagsTable.classroomId,
+    createdAt: tagsTable.createdAt,
+};
+
 export async function GET(req: Request) {
     try {
         const { email } = await requireAuth();
@@ -30,14 +38,7 @@ export async function GET(req: Request) {
 
         if (subject) {
             // Query to return top 5 tags ordered by frequency under the selected subject
-            const popularTags = await db.select({
-                id: tagsTable.id,
-                name: tagsTable.name,
-                normalizedName: tagsTable.normalizedName,
-                classroomId: tagsTable.classroomId,
-                createdByEmail: tagsTable.createdByEmail,
-                createdAt: tagsTable.createdAt
-            })
+            const popularTags = await db.select(publicTagSelection)
             .from(tagsTable)
             .innerJoin(doubtTagsTable, eq(tagsTable.id, doubtTagsTable.tagId))
             .innerJoin(doubtsTable, eq(doubtTagsTable.doubtId, doubtsTable.id))
@@ -58,14 +59,7 @@ export async function GET(req: Request) {
             }
 
             // Fallback: overall most popular tags across the entire platform
-            const fallbackTags = await db.select({
-                id: tagsTable.id,
-                name: tagsTable.name,
-                normalizedName: tagsTable.normalizedName,
-                classroomId: tagsTable.classroomId,
-                createdByEmail: tagsTable.createdByEmail,
-                createdAt: tagsTable.createdAt
-            })
+            const fallbackTags = await db.select(publicTagSelection)
             .from(tagsTable)
             .innerJoin(doubtTagsTable, eq(tagsTable.id, doubtTagsTable.tagId))
             .where(
@@ -82,7 +76,7 @@ export async function GET(req: Request) {
             }
 
             // Fallback 2: if there are no popular tags at all (e.g. fresh DB), get the 5 most recently created tags
-            const recentTags = await db.select()
+            const recentTags = await db.select(publicTagSelection)
                 .from(tagsTable)
                 .where(
                     classroomId
@@ -105,7 +99,7 @@ export async function GET(req: Request) {
             conditions.push(ilike(tagsTable.name, `%${escapeLike(query)}%`));
         }
 
-        const tags = await db.select().from(tagsTable)
+        const tags = await db.select(publicTagSelection).from(tagsTable)
             .where(and(...conditions))
             .orderBy(desc(tagsTable.createdAt));
 
@@ -135,7 +129,7 @@ export async function POST(req: Request) {
             await requireMembership(email, classroomId);
         }
 
-        const [existing] = await db.select().from(tagsTable).where(
+        const [existing] = await db.select(publicTagSelection).from(tagsTable).where(
             and(
                 eq(tagsTable.normalizedName, normalizedName),
                 classroomId ? eq(tagsTable.classroomId, classroomId) : isNull(tagsTable.classroomId)
@@ -149,7 +143,7 @@ export async function POST(req: Request) {
             normalizedName,
             classroomId,
             createdByEmail: email,
-        }).returning();
+        }).returning(publicTagSelection);
 
         return NextResponse.json(tag, { status: 201 });
     } catch (error: unknown) {


### PR DESCRIPTION
## **User description**
## Description

This PR fixes a privacy issue in the tags API where the internal `createdByEmail` field was being exposed in public API responses.

A shared `publicTagSelection` projection was introduced and applied consistently across all tag response paths to ensure only client-required fields are returned. The creator email is still stored server-side when tags are created but is no longer serialized in API responses.

The fix covers:

* Subject-specific popular tag responses
* Popularity fallback responses
* Recent-tags fallback responses
* General tag listing and search responses
* Existing-tag POST responses
* Newly created tag POST responses

Regression tests were expanded to verify that `createdByEmail` is never exposed while all expected public fields remain available.

## Related Issue

Closes #925

## Type of Change

* [x] Bug fix (non-breaking change that fixes an issue)
* [x] Test addition or update

## Screenshots (if UI change)

N/A – Backend API change only.

## How Has This Been Tested?

* [x] Direct ESLint validation on changed files
* [x] Focused Jest test suite (`src/__tests__/api/tags.test.ts`) — 8/8 tests passed
* [x] TypeScript validation (`npx tsc --noEmit`)

Notes:

* The repository's `npm run lint` script currently invokes `next lint`, which is no longer supported by the installed Next.js version. Direct ESLint validation on the modified files passed successfully.

## Checklist

* [ ] I have tested my changes locally (`npm run dev`)
* [ ] My code follows the existing code style (TypeScript, Tailwind, no `any` types)
* [x] I have not introduced unrelated changes (each PR should address one issue)
* [ ] I have added comments where necessary
* [x] My branch is up to date with `main`
* [x] I have linked the related issue above
* [x] Screenshots are included (if this is a UI change) — N/A


___

## **CodeAnt-AI Description**
**Remove creator email from tag API responses**

### What Changed
- Tag list, search, subject-based, and fallback tag results now return only public tag details, without the creator email.
- The tag create flow still saves the creator email internally, but the API response no longer includes it for either existing or newly created tags.
- Test coverage now checks that `createdByEmail` is never exposed across all tag response paths.

### Impact
`✅ Private creator emails no longer leak through tag APIs`
`✅ Safer tag responses for classroom and public views`
`✅ Fewer privacy regressions in tag creation and lookup`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tag privacy by ensuring API responses include only publicly relevant tag details.
  * Removed creator email addresses from tag lists, searches, popular and recent tag results, and tag creation responses.
  * Applied consistent response fields when retrieving existing tags or creating new tags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->