### PR TITLE
perf: lazy load image previews

### DIFF
--- a/src/app/ask-ai/page.tsx
+++ b/src/app/ask-ai/page.tsx
@@ -428,7 +428,7 @@ export default function AskAIPage() {
                                         </button>
                                     ) : (
                                         <div className="relative rounded-2xl overflow-hidden border border-slate-200 dark:border-white/10 bg-white dark:bg-black">
-                                            <img src={imageBase64} alt="Uploaded question" className="w-full max-h-64 object-contain" />
+                                            <img src={imageBase64} alt="Uploaded question" loading="lazy" decoding="async" className="w-full max-h-64 object-contain" />
                                             <button
                                                 onClick={() => { setImageBase64(null); if (fileInputRef.current) fileInputRef.current.value = ''; }}
                                                 className="absolute top-3 right-3 w-8 h-8 bg-red-500/90 hover:bg-red-500 rounded-full flex items-center justify-center shadow-lg hover:scale-110 transition-transform"

--- a/src/components/classroom/AskDoubt.tsx
+++ b/src/components/classroom/AskDoubt.tsx
@@ -629,7 +629,7 @@ export default function AskDoubt({ defaultSubject = "", isOpen, onClose, onSucce
                                     ) : (
                                         <div className="flex flex-col items-center gap-3 px-6 text-center z-20">
                                             <div className="relative max-h-40 rounded-xl overflow-hidden border border-slate-200 dark:border-white/10 shadow-xl bg-white dark:bg-slate-950 animate-in zoom-in-95">
-                                                <img src={imageUrl} alt="Preview" className="max-h-40 object-contain" />
+                                                <img src={imageUrl} alt="Preview" loading="lazy" decoding="async" className="max-h-40 object-contain" />
                                             </div>
                                             <div>
                                                 <p className="text-xs text-slate-900 dark:text-white font-bold max-w-xs truncate">{fileName}</p>

--- a/src/components/classroom/DoubtCard.tsx
+++ b/src/components/classroom/DoubtCard.tsx
@@ -327,6 +327,8 @@ export default function DoubtCard({ doubt, onUpdate, onViewAISolution, role, ope
                             <img
                                 src={doubt.imageUrl}
                                 alt={`Doubt image for ${doubt.subject} by ${doubt.author || 'Anonymous'}`}
+                                loading="lazy"
+                                decoding="async"
                                 className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-700"
                             />
                             <div className="absolute inset-0 bg-black/20 opacity-0 group-hover/img:opacity-100 transition-opacity flex items-center justify-center">
@@ -549,6 +551,8 @@ export default function DoubtCard({ doubt, onUpdate, onViewAISolution, role, ope
                         <img
                             src={doubt.imageUrl ?? undefined}
                             alt={`Full view of doubt image for ${doubt.subject} by ${doubt.author || 'Anonymous'}`}
+                            loading="lazy"
+                            decoding="async"
                             className="max-w-full max-h-full object-contain rounded-xl shadow-2xl border border-slate-200 dark:border-white/10"
                         />
                     </div>

--- a/src/components/classroom/DoubtRepliesModal.tsx
+++ b/src/components/classroom/DoubtRepliesModal.tsx
@@ -578,7 +578,7 @@ export default function DoubtRepliesModal({ doubt, isOpen, onClose, onReplyChang
                                             className="mt-2 rounded-2xl overflow-hidden border border-slate-200 dark:border-white/5 group/img relative cursor-zoom-in active:scale-[0.98] transition-all w-full"
                                             aria-label="View image fullscreen"
                                         >
-                                            <img src={reply.imageUrl} alt="Solution" className="w-full h-auto object-cover max-h-[32rem]" />
+                                            <img src={reply.imageUrl} alt="Solution" loading="lazy" decoding="async" className="w-full h-auto object-cover max-h-[32rem]" />
                                             <div className="absolute inset-0 bg-white/0 group-hover/img:bg-slate-100 dark:group-hover/img:bg-white/5 flex items-center justify-center transition-all">
                                                 <ZoomIn className="w-8 h-8 text-slate-900 dark:text-white opacity-0 group-hover/img:opacity-100 scale-50 group-hover/img:scale-100 transition-all" />
                                             </div>
@@ -876,7 +876,7 @@ export default function DoubtRepliesModal({ doubt, isOpen, onClose, onReplyChang
                                         </div>
                                     ) : (
                                         <div className="relative overflow-hidden rounded-2xl border-2 border-emerald-500/20 bg-white dark:bg-slate-950 shadow-2xl group/img">
-                                            <img src={solutionImage} alt="" className="w-full sm:w-64 h-36 object-cover opacity-80 group-hover/img:opacity-100 transition-all duration-500" />
+                                            <img src={solutionImage} alt="Solution attachment preview" loading="lazy" decoding="async" className="w-full sm:w-64 h-36 object-cover opacity-80 group-hover/img:opacity-100 transition-all duration-500" />
 
                                             {/* Image Overlay */}
                                             <div className="absolute inset-0 bg-gradient-to-t from-slate-950/90 via-transparent to-transparent flex flex-col justify-end p-3 translate-y-2 group-hover/img:translate-y-0 transition-transform">
@@ -1022,6 +1022,8 @@ export default function DoubtRepliesModal({ doubt, isOpen, onClose, onReplyChang
                             <img
                                 src={fullscreenImageUrl}
                                 alt="Fullscreen View"
+                                loading="lazy"
+                                decoding="async"
                                 className="max-w-full max-h-[85vh] rounded-2xl shadow-2xl border border-slate-200 dark:border-white/10 object-contain animate-in zoom-in-95 duration-300"
                             />
                             <div className="absolute -bottom-12 left-0 right-0 flex justify-center">


### PR DESCRIPTION
Closes #238

## Summary
- lazy-loads uploaded, doubt, and reply image previews
- enables asynchronous image decoding for these previews
- adds descriptive alt text to the solution attachment preview

## Validation
- targeted ESLint passed for all four changed files
- repository pre-commit hooks passed ESLint and TypeScript checks
- `git diff --check` passed
- `npm run build` compiled successfully but stopped during page-data collection because `GROQ_API_KEY` and `DATABASE_URL` are unavailable in this environment

This is the current-upstream continuation of closed PR #902, which was automatically closed before the issue assignment was active. The issue is now assigned to `saurabhhhcodes`.
