### PR TITLE
feat(notifications): urgent teacher alerts for classroom activity

### DIFF
--- a/src/app/api/doubts/flag/route.ts
+++ b/src/app/api/doubts/flag/route.ts
@@ -1,3 +1,4 @@
+import { inngest } from "@/inngest/client";
 import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/configs/db";
 import { contentFlagsTable, doubtsTable } from "@/configs/schema";
@@ -25,7 +26,7 @@ export async function POST(req: NextRequest) {
         }
 
         const [doubt] = await db
-            .select({ id: doubtsTable.id })
+            .select({ id: doubtsTable.id, classroomId: doubtsTable.classroomId })
             .from(doubtsTable)
             .where(eq(doubtsTable.id, doubtId));
 
@@ -64,6 +65,13 @@ export async function POST(req: NextRequest) {
         if (recentFlagCount >= AUTO_HIDE_FLAG_THRESHOLD) {
             await db.update(doubtsTable).set({ isHidden: true }).where(eq(doubtsTable.id, doubtId));
             autoHidden = true;
+
+            if (doubt.classroomId) {
+                await inngest.send({
+                    name: "doubt/auto-hidden",
+                    data: { doubtId, classroomId: doubt.classroomId },
+                });
+            }
         }
 
         return NextResponse.json({

--- a/src/app/api/doubts/flag/route.ts
+++ b/src/app/api/doubts/flag/route.ts
@@ -67,10 +67,17 @@ export async function POST(req: NextRequest) {
             autoHidden = true;
 
             if (doubt.classroomId) {
-                await inngest.send({
-                    name: "doubt/auto-hidden",
-                    data: { doubtId, classroomId: doubt.classroomId },
-                });
+                // Best-effort: the flag insert and auto-hide update have already
+                // committed above, so a notification-dispatch failure shouldn't
+                // turn this into an error response for the client.
+                try {
+                    await inngest.send({
+                        name: "doubt/auto-hidden",
+                        data: { doubtId, classroomId: doubt.classroomId },
+                    });
+                } catch (error) {
+                    console.error("Failed to send doubt/auto-hidden event", error);
+                }
             }
         }
 

--- a/src/app/api/inngest/UrgentActivityDetector.ts
+++ b/src/app/api/inngest/UrgentActivityDetector.ts
@@ -1,0 +1,145 @@
+// src/app/api/inngest/UrgentActivityDetector.ts
+// Detects classroom conditions that need a teacher's immediate attention:
+// - Too many unresolved doubts piling up
+// - A doubt that's gone unanswered for too long
+// - Content that got auto-hidden due to flags
+// Each condition notifies the classroom's teacher, with a per-classroom,
+// per-alert-type cooldown so the 15-minute cron doesn't spam.
+import { inngest } from "@/inngest/client";
+import { db } from "@/configs/db";
+import { classroomsTable, doubtsTable } from "@/configs/schema";
+import { and, eq, isNull, ne, asc, count, lt } from "drizzle-orm";
+import { createUrgentClassroomAlert } from "@/lib/notifications/service";
+
+const UNRESOLVED_THRESHOLD = 10;
+const STALE_MS = 72 * 60 * 60 * 1000; // 72 hours
+const ALERT_COOLDOWN_MS = 6 * 60 * 60 * 1000; // 6 hours per classroom+type
+
+interface InngestEvent {
+    data: Record<string, unknown>;
+}
+
+type InngestStep = {
+    run: <T>(id: string, fn: () => Promise<T>) => Promise<T>;
+};
+
+export const checkUrgentClassroomActivity = inngest.createFunction(
+    { id: "check-urgent-classroom-activity", triggers: [{ cron: "*/15 * * * *" }] },
+    async ({ step }: { step: InngestStep }) => {
+        const classrooms = await step.run("fetch-classrooms", async () => {
+            return db
+                .select({ id: classroomsTable.id, teacherEmail: classroomsTable.teacherEmail, name: classroomsTable.name })
+                .from(classroomsTable);
+        });
+
+        let alertsCreated = 0;
+
+        for (const classroom of classrooms) {
+            const result = await step.run(`check-classroom-${classroom.id}`, async () => {
+                if (!classroom.teacherEmail) return { created: 0 };
+
+                let created = 0;
+
+                // ── Condition 1: too many unresolved doubts ──────────────────
+                const [unresolvedRow] = await db
+                    .select({ value: count() })
+                    .from(doubtsTable)
+                    .where(
+                        and(
+                            eq(doubtsTable.classroomId, classroom.id),
+                            ne(doubtsTable.isSolved, "solved"),
+                            eq(doubtsTable.isHidden, false),
+                            isNull(doubtsTable.deletedAt),
+                        ),
+                    );
+                const unresolvedCount = unresolvedRow?.value ?? 0;
+
+                if (unresolvedCount > UNRESOLVED_THRESHOLD) {
+                    const sent = await createUrgentClassroomAlert({
+                        teacherEmail: classroom.teacherEmail,
+                        classroomId: classroom.id,
+                        type: "urgent_unresolved_spike",
+                        title: `${unresolvedCount} unresolved doubts in ${classroom.name}`,
+                        message: `${classroom.name} has ${unresolvedCount} open doubts — more than students should be waiting on.`,
+                        link: `/dashboard/teacher?classroomId=${classroom.id}`,
+                        cooldownMs: ALERT_COOLDOWN_MS,
+                    });
+                    if (sent) created++;
+                }
+
+                // ── Condition 2: a doubt has gone stale ───────────────────────
+                const staleCutoff = new Date(Date.now() - STALE_MS);
+                const [staleDoubt] = await db
+                    .select({ id: doubtsTable.id, subject: doubtsTable.subject, createdAt: doubtsTable.createdAt })
+                    .from(doubtsTable)
+                    .where(
+                        and(
+                            eq(doubtsTable.classroomId, classroom.id),
+                            ne(doubtsTable.isSolved, "solved"),
+                            eq(doubtsTable.isHidden, false),
+                            isNull(doubtsTable.deletedAt),
+                            lt(doubtsTable.createdAt, staleCutoff),
+                        ),
+                    )
+                    .orderBy(asc(doubtsTable.createdAt))
+                    .limit(1);
+
+                if (staleDoubt) {
+                    const sent = await createUrgentClassroomAlert({
+                        teacherEmail: classroom.teacherEmail,
+                        classroomId: classroom.id,
+                        type: "urgent_stale_doubt",
+                        title: `A doubt in ${classroom.name} has waited 72h+`,
+                        message: `A ${staleDoubt.subject || "student"} doubt has been unresolved for over 3 days.`,
+                        link: `/doubts/${staleDoubt.id}`,
+                        cooldownMs: ALERT_COOLDOWN_MS,
+                    });
+                    if (sent) created++;
+                }
+
+                return { created };
+            });
+
+            alertsCreated += result.created;
+        }
+
+        return { classroomsChecked: classrooms.length, alertsCreated };
+    },
+);
+
+// Fired directly from the flag route the moment a doubt is auto-hidden —
+// more immediate and precise than waiting for the next cron pass.
+export const notifyFlaggedContentHidden = inngest.createFunction(
+    { id: "notify-flagged-content-hidden", triggers: [{ event: "doubt/auto-hidden" }] },
+    async ({ event, step }: { event: InngestEvent; step: InngestStep }) => {
+        const { doubtId, classroomId } = event.data as { doubtId?: number; classroomId?: number };
+
+        if (!doubtId || !classroomId) {
+            return { skipped: "Missing doubtId or classroomId" };
+        }
+
+        const result = await step.run("notify-teacher", async () => {
+            const [classroom] = await db
+                .select({ teacherEmail: classroomsTable.teacherEmail, name: classroomsTable.name })
+                .from(classroomsTable)
+                .where(eq(classroomsTable.id, classroomId))
+                .limit(1);
+
+            if (!classroom?.teacherEmail) return { sent: false };
+
+            const sent = await createUrgentClassroomAlert({
+                teacherEmail: classroom.teacherEmail,
+                classroomId,
+                type: "urgent_flagged_content",
+                title: `Content auto-hidden in ${classroom.name}`,
+                message: "A doubt was automatically hidden after multiple flags and needs review.",
+                link: `/doubts/${doubtId}`,
+                cooldownMs: ALERT_COOLDOWN_MS,
+            });
+
+            return { sent };
+        });
+
+        return result;
+    },
+);

--- a/src/app/api/inngest/UrgentActivityDetector.ts
+++ b/src/app/api/inngest/UrgentActivityDetector.ts
@@ -8,7 +8,7 @@
 import { inngest } from "@/inngest/client";
 import { db } from "@/configs/db";
 import { classroomsTable, doubtsTable } from "@/configs/schema";
-import { and, eq, isNull, ne, asc, count, lt } from "drizzle-orm";
+import { and, eq, isNull, ne, or, asc, count, lt, sql } from "drizzle-orm";
 import { createUrgentClassroomAlert } from "@/lib/notifications/service";
 
 const UNRESOLVED_THRESHOLD = 10;
@@ -32,6 +32,45 @@ export const checkUrgentClassroomActivity = inngest.createFunction(
                 .from(classroomsTable);
         });
 
+        // ── Batch fetch both signals in 2 queries total instead of 2 per classroom ──
+        const staleCutoff = new Date(Date.now() - STALE_MS);
+
+        const { unresolvedCounts, staleDoubts } = await step.run("fetch-activity-signals", async () => {
+            const unresolvedRows = await db
+                .select({ classroomId: doubtsTable.classroomId, value: count() })
+                .from(doubtsTable)
+                .where(
+                    and(
+                        or(ne(doubtsTable.isSolved, "solved"), isNull(doubtsTable.isSolved)),
+                        eq(doubtsTable.isHidden, false),
+                        isNull(doubtsTable.deletedAt),
+                    ),
+                )
+                .groupBy(doubtsTable.classroomId);
+
+            const staleResult = await db.execute<{ classroomId: number; id: number; subject: string | null; createdAt: string }>(sql`
+                select distinct on (${doubtsTable.classroomId})
+                    ${doubtsTable.classroomId} as "classroomId",
+                    ${doubtsTable.id} as "id",
+                    ${doubtsTable.subject} as "subject",
+                    ${doubtsTable.createdAt} as "createdAt"
+                from ${doubtsTable}
+                where (${doubtsTable.isSolved} is distinct from 'solved')
+                    and ${doubtsTable.isHidden} = false
+                    and ${doubtsTable.deletedAt} is null
+                    and ${doubtsTable.createdAt} < ${staleCutoff}
+                order by ${doubtsTable.classroomId}, ${doubtsTable.createdAt} asc
+            `);
+
+            return {
+                unresolvedCounts: unresolvedRows.map((row) => [row.classroomId, row.value] as const),
+                staleDoubts: staleResult.rows.map((row) => [row.classroomId, row] as const),
+            };
+        });
+
+        const unresolvedByClassroom = new Map(unresolvedCounts);
+        const staleByClassroom = new Map(staleDoubts);
+
         let alertsCreated = 0;
 
         for (const classroom of classrooms) {
@@ -41,18 +80,7 @@ export const checkUrgentClassroomActivity = inngest.createFunction(
                 let created = 0;
 
                 // ── Condition 1: too many unresolved doubts ──────────────────
-                const [unresolvedRow] = await db
-                    .select({ value: count() })
-                    .from(doubtsTable)
-                    .where(
-                        and(
-                            eq(doubtsTable.classroomId, classroom.id),
-                            ne(doubtsTable.isSolved, "solved"),
-                            eq(doubtsTable.isHidden, false),
-                            isNull(doubtsTable.deletedAt),
-                        ),
-                    );
-                const unresolvedCount = unresolvedRow?.value ?? 0;
+                const unresolvedCount = unresolvedByClassroom.get(classroom.id) ?? 0;
 
                 if (unresolvedCount > UNRESOLVED_THRESHOLD) {
                     const sent = await createUrgentClassroomAlert({
@@ -68,21 +96,7 @@ export const checkUrgentClassroomActivity = inngest.createFunction(
                 }
 
                 // ── Condition 2: a doubt has gone stale ───────────────────────
-                const staleCutoff = new Date(Date.now() - STALE_MS);
-                const [staleDoubt] = await db
-                    .select({ id: doubtsTable.id, subject: doubtsTable.subject, createdAt: doubtsTable.createdAt })
-                    .from(doubtsTable)
-                    .where(
-                        and(
-                            eq(doubtsTable.classroomId, classroom.id),
-                            ne(doubtsTable.isSolved, "solved"),
-                            eq(doubtsTable.isHidden, false),
-                            isNull(doubtsTable.deletedAt),
-                            lt(doubtsTable.createdAt, staleCutoff),
-                        ),
-                    )
-                    .orderBy(asc(doubtsTable.createdAt))
-                    .limit(1);
+                const staleDoubt = staleByClassroom.get(classroom.id);
 
                 if (staleDoubt) {
                     const sent = await createUrgentClassroomAlert({
@@ -91,7 +105,7 @@ export const checkUrgentClassroomActivity = inngest.createFunction(
                         type: "urgent_stale_doubt",
                         title: `A doubt in ${classroom.name} has waited 72h+`,
                         message: `A ${staleDoubt.subject || "student"} doubt has been unresolved for over 3 days.`,
-                        link: `/doubts/${staleDoubt.id}`,
+                        link: `/dashboard/teacher?classroomId=${classroom.id}`,
                         cooldownMs: ALERT_COOLDOWN_MS,
                     });
                     if (sent) created++;
@@ -133,7 +147,7 @@ export const notifyFlaggedContentHidden = inngest.createFunction(
                 type: "urgent_flagged_content",
                 title: `Content auto-hidden in ${classroom.name}`,
                 message: "A doubt was automatically hidden after multiple flags and needs review.",
-                link: `/doubts/${doubtId}`,
+                link: `/dashboard/teacher?classroomId=${classroomId}`,
                 cooldownMs: ALERT_COOLDOWN_MS,
             });
 

--- a/src/app/api/inngest/route.ts
+++ b/src/app/api/inngest/route.ts
@@ -9,7 +9,9 @@ import {
     sendWeeklyDigest,
     detectConfusionSpikes,
     generateVideo,
-    cleanupStaleVideoJobs
+    cleanupStaleVideoJobs,
+    checkUrgentClassroomActivity,
+    notifyFlaggedContentHidden
 } from "../../../inngest/functions";
 
 // Serve your registered background processes safely
@@ -23,6 +25,8 @@ export const { GET, POST, PUT } = serve({
         sendWeeklyDigest,
         detectConfusionSpikes,
         generateVideo,
-        cleanupStaleVideoJobs
+        cleanupStaleVideoJobs,
+        checkUrgentClassroomActivity,
+        notifyFlaggedContentHidden
     ],
 });

--- a/src/components/layout/NotificationBell.tsx
+++ b/src/components/layout/NotificationBell.tsx
@@ -245,10 +245,10 @@ export default function NotificationBell() {
                                             markAsRead(notification.id)
                                         }
                                     }}
-                                    className={`relative flex flex-col gap-1 p-4 border-b border-border/20 last:border-0 hover:bg-accent/50 cursor-pointer transition-colors ${!notification.isRead ? 'bg-accent/20' : ''}`}
+                                    className={`relative flex flex-col gap-1 p-4 border-b border-border/20 last:border-0 hover:bg-accent/50 cursor-pointer transition-colors ${!notification.isRead ? 'bg-accent/20' : ''} ${notification.type.startsWith('urgent_') ? 'border-l-2 border-l-red-500' : ''}`}
                                 >
                                     {!notification.isRead && (
-                                        <div className="absolute left-2 top-1/2 -translate-y-1/2 w-1.5 h-1.5 rounded-full bg-blue-500" />
+                                        <div className={`absolute left-2 top-1/2 -translate-y-1/2 w-1.5 h-1.5 rounded-full ${notification.type.startsWith('urgent_') ? 'bg-red-500' : 'bg-blue-500'}`} />
                                     )}
                                     <div className="flex items-start justify-between gap-2 pl-2">
                                         <div className="flex flex-col gap-1">

--- a/src/inngest/functions.ts
+++ b/src/inngest/functions.ts
@@ -334,6 +334,7 @@ export const sendWeeklyDigest = inngest.createFunction(
 );
 
 export { detectConfusionSpikes } from "../app/api/inngest/ConfusionSpikeDetector";
+export { checkUrgentClassroomActivity, notifyFlaggedContentHidden } from "../app/api/inngest/UrgentActivityDetector";
 // ── Async video generation (issue #321) ──────────────────────────────────────
 // Runs the OCR -> AI script -> TTS -> Remotion render pipeline off the request
 // path, persisting progress to the video_jobs row so clients can stream it.

--- a/src/lib/notifications/service.ts
+++ b/src/lib/notifications/service.ts
@@ -1,4 +1,4 @@
-import { eq, and, gte } from "drizzle-orm";
+import { eq, and, gte, sql } from "drizzle-orm";
 import { db } from "@/configs/db";
 import { classroomsTable, membershipsTable, notificationsTable } from "@/configs/schema";
 import { publishNotification, type NotificationRecord } from "@/lib/notifications/realtime";
@@ -115,23 +115,32 @@ export async function createUrgentClassroomAlert(params: {
     const { teacherEmail, type, title, message, link, cooldownMs } = params;
     const cutoff = new Date(Date.now() - cooldownMs);
 
-    const [recent] = await db
-        .select({ id: notificationsTable.id })
-        .from(notificationsTable)
-        .where(
-            and(
-                eq(notificationsTable.userEmail, teacherEmail),
-                eq(notificationsTable.type, type),
-                eq(notificationsTable.link, link),
-                gte(notificationsTable.createdAt, cutoff),
-            ),
-        )
-        .limit(1);
+    return db.transaction(async (tx) => {
+        // Serialize concurrent calls for the same (teacherEmail, type, link) so
+        // overlapping cron runs can't both pass the cooldown check before either
+        // inserts (TOCTOU race).
+        await tx.execute(
+            sql`select pg_advisory_xact_lock(hashtext(${teacherEmail} || ${type} || ${link}))`,
+        );
 
-    if (recent) {
-        return false;
-    }
+        const [recent] = await tx
+            .select({ id: notificationsTable.id })
+            .from(notificationsTable)
+            .where(
+                and(
+                    eq(notificationsTable.userEmail, teacherEmail),
+                    eq(notificationsTable.type, type),
+                    eq(notificationsTable.link, link),
+                    gte(notificationsTable.createdAt, cutoff),
+                ),
+            )
+            .limit(1);
 
-    await createNotifications([{ userEmail: teacherEmail, title, message, link, type }]);
-    return true;
+        if (recent) {
+            return false;
+        }
+
+        await tx.insert(notificationsTable).values({ userEmail: teacherEmail, title, message, link, type });
+        return true;
+    });
 }

--- a/src/lib/notifications/service.ts
+++ b/src/lib/notifications/service.ts
@@ -1,4 +1,4 @@
-import { eq } from "drizzle-orm";
+import { eq, and, gte } from "drizzle-orm";
 import { db } from "@/configs/db";
 import { classroomsTable, membershipsTable, notificationsTable } from "@/configs/schema";
 import { publishNotification, type NotificationRecord } from "@/lib/notifications/realtime";
@@ -98,4 +98,40 @@ export async function createReplyNotification(params: {
             type: "doubt_reply",
         },
     ]);
+}
+// ── Urgent classroom alerts (issue #540) ──────────────────────────────────
+// Notifies a classroom's teacher of urgent conditions (unresolved spike,
+// stale doubt, auto-hidden flagged content), with a cooldown per
+// classroom+type so repeated cron runs don't spam the same alert.
+export async function createUrgentClassroomAlert(params: {
+    teacherEmail: string;
+    classroomId: number;
+    type: string;
+    title: string;
+    message: string;
+    link: string;
+    cooldownMs: number;
+}): Promise<boolean> {
+    const { teacherEmail, type, title, message, link, cooldownMs } = params;
+    const cutoff = new Date(Date.now() - cooldownMs);
+
+    const [recent] = await db
+        .select({ id: notificationsTable.id })
+        .from(notificationsTable)
+        .where(
+            and(
+                eq(notificationsTable.userEmail, teacherEmail),
+                eq(notificationsTable.type, type),
+                eq(notificationsTable.link, link),
+                gte(notificationsTable.createdAt, cutoff),
+            ),
+        )
+        .limit(1);
+
+    if (recent) {
+        return false;
+    }
+
+    await createNotifications([{ userEmail: teacherEmail, title, message, link, type }]);
+    return true;
 }


### PR DESCRIPTION
## **User description**
## Description
Adds real-time teacher notifications for conditions needing immediate attention:
- `checkUrgentClassroomActivity` (15-min cron): flags classrooms with >10 unresolved doubts, or any doubt unresolved for 72h+
- `notifyFlaggedContentHidden`: fires when a doubt is auto-hidden after repeated flags, notifying the teacher immediately rather than waiting for the next cron pass
- `createUrgentClassroomAlert()` in `notifications/service.ts`: shared helper with a per-classroom, per-alert-type cooldown (6h) to prevent repeat cron runs from spamming the same alert
- `NotificationBell`: `urgent_*` notification types get a distinct red accent instead of the default blue unread indicator

Intentionally does not touch confusion spike detection — that's already handled by the existing `detectConfusionSpikes` + `confusionAlertsTable`/`ConfusionAlertPanel` path. This PR only covers the three conditions from the issue that weren't already handled: unresolved count, staleness, and flagged content.

## Related Issue
Closes #540

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Documentation update (README, guides, comments)
- [ ] Style / UI change (no logic change)
- [ ] Code refactor (no behavior change)
- [ ] Test addition or update
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## How Has This Been Tested?
- [x] Tested locally with `npm run dev`
- [ ] Verified on mobile viewport (375px)
- [ ] Verified on desktop viewport (1440px)

Full local Jest suite run: pre-existing failures unrelated to this change (missing `GROQ_API_KEY` in local `.env`, a `migration-integrity` mismatch, and Playwright specs incorrectly picked up by Jest). None of the failures reference any file touched in this PR; `confusion-spike-detector.test.ts` passes.

## Checklist
- [x] I have tested my changes locally (`npm run dev`)
- [x] My code follows the existing code style (TypeScript, Tailwind, no `any` types)
- [x] I have not introduced unrelated changes (each PR should address one issue)
- [ ] I have added comments where necessary
- [x] My branch is up to date with `main`
- [x] I have linked the related issue above
- [ ] Screenshots are included (if this is a UI change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated urgent alerts for classroom activity: high unresolved-doubt volume, stale doubts, and automatically hidden flagged content.
  * Teachers receive targeted urgent notifications with links to the relevant classroom view.
  * Implemented cooldown-based deduplication to reduce repeat urgent alerts.
* **UI Improvements**
  * Updated the notification list to clearly highlight urgent items with red visual indicators and improved unread styling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Send urgent teacher alerts for unresolved, stale, and auto-hidden classroom activity**

### What Changed
- Teachers now get urgent alerts when a classroom has too many unresolved doubts, when a doubt has been unanswered for 72 hours or more, and when a doubt is automatically hidden after repeated flags
- Auto-hidden flagged content now triggers an alert right away instead of waiting for the next scheduled check
- Urgent notifications are marked with a red indicator in the notification list so they stand out from regular unread items
- Duplicate urgent alerts are limited during repeated checks, reducing repeat notifications for the same classroom issue

### Impact
`✅ Faster teacher awareness of urgent classroom issues`
`✅ Fewer missed stale or unresolved doubts`
`✅ Clearer high-priority notifications in the inbox` 
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
