### PR TITLE
feat: add route error boundaries for graceful crash handling

### DIFF
--- a/src/app/(routes)/dashboard/error.tsx
+++ b/src/app/(routes)/dashboard/error.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { useEffect } from "react";
+import Link from "next/link";
+import { motion } from "framer-motion";
+import { AlertTriangle, RefreshCcw, LayoutDashboard } from "lucide-react";
+
+export default function DashboardError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="min-h-[70vh] bg-[#030712] flex items-center justify-center p-6 relative overflow-hidden text-slate-200 font-sans rounded-2xl">
+      <div className="absolute inset-0 bg-[linear-gradient(to_right,#33415522_1px,transparent_1px),linear-gradient(to_bottom,#33415522_1px,transparent_1px)] bg-[size:40px_40px] [mask-image:radial-gradient(ellipse_60%_60%_at_50%_50%,#000_70%,transparent_100%)] pointer-events-none" />
+
+      <motion.div
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.6, ease: "easeOut" }}
+        className="relative z-10 w-full max-w-lg"
+      >
+        <div className="backdrop-blur-xl bg-slate-900/40 border border-slate-700/50 rounded-3xl p-8 sm:p-10 shadow-[0_0_50px_rgba(220,38,38,0.1)] flex flex-col items-center text-center">
+          <div className="inline-flex items-center gap-2 px-3 py-1.5 rounded-full bg-red-500/10 border border-red-500/20 text-red-400 text-[10px] font-bold uppercase tracking-widest mb-6">
+            <AlertTriangle className="w-3.5 h-3.5" />
+            Dashboard Error
+          </div>
+
+          <h2 className="text-xl sm:text-2xl font-bold text-white tracking-tight mb-3">
+            Couldn't load your dashboard
+          </h2>
+          <p className="text-slate-400 text-sm max-w-md mx-auto leading-relaxed mb-8">
+            {error.message || "Something went wrong while loading dashboard data."}
+          </p>
+
+          <div className="flex flex-col sm:flex-row gap-4 w-full justify-center">
+            <button onClick={reset} className="group relative">
+              <div className="absolute -inset-0.5 bg-gradient-to-r from-blue-500 to-cyan-500 rounded-xl blur opacity-30 group-hover:opacity-70 transition duration-500 ease-out" />
+              <div className="relative flex items-center justify-center gap-2 px-6 py-3 bg-slate-900 border border-slate-700/50 group-hover:border-cyan-500/50 rounded-xl text-white font-medium text-sm transition-all duration-300 ease-out">
+                <RefreshCcw className="w-4 h-4 text-cyan-400" />
+                Try Again
+              </div>
+            </button>
+
+            <Link href="/dashboard" className="group relative">
+              <div className="absolute -inset-0.5 bg-gradient-to-r from-slate-600 to-slate-500 rounded-xl blur opacity-20 group-hover:opacity-40 transition duration-500 ease-out" />
+              <div className="relative flex items-center justify-center gap-2 px-6 py-3 bg-slate-800/50 border border-slate-700/50 group-hover:border-slate-500/50 rounded-xl text-slate-300 group-hover:text-white font-medium text-sm transition-all duration-300 ease-out">
+                <LayoutDashboard className="w-4 h-4" />
+                Reload Dashboard
+              </div>
+            </Link>
+          </div>
+        </div>
+      </motion.div>
+    </div>
+  );
+}

--- a/src/app/(routes)/rooms/error.tsx
+++ b/src/app/(routes)/rooms/error.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { useEffect } from "react";
+import Link from "next/link";
+import { motion } from "framer-motion";
+import { AlertTriangle, RefreshCcw, LayoutDashboard } from "lucide-react";
+
+export default function RoomsError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="min-h-[70vh] bg-[#030712] flex items-center justify-center p-6 relative overflow-hidden text-slate-200 font-sans rounded-2xl">
+      <div className="absolute inset-0 bg-[linear-gradient(to_right,#33415522_1px,transparent_1px),linear-gradient(to_bottom,#33415522_1px,transparent_1px)] bg-[size:40px_40px] [mask-image:radial-gradient(ellipse_60%_60%_at_50%_50%,#000_70%,transparent_100%)] pointer-events-none" />
+
+      <motion.div
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.6, ease: "easeOut" }}
+        className="relative z-10 w-full max-w-lg"
+      >
+        <div className="backdrop-blur-xl bg-slate-900/40 border border-slate-700/50 rounded-3xl p-8 sm:p-10 shadow-[0_0_50px_rgba(220,38,38,0.1)] flex flex-col items-center text-center">
+          <div className="inline-flex items-center gap-2 px-3 py-1.5 rounded-full bg-red-500/10 border border-red-500/20 text-red-400 text-[10px] font-bold uppercase tracking-widest mb-6">
+            <AlertTriangle className="w-3.5 h-3.5" />
+            Room Error
+          </div>
+
+          <h2 className="text-xl sm:text-2xl font-bold text-white tracking-tight mb-3">
+            Couldn't load this room
+          </h2>
+          <p className="text-slate-400 text-sm max-w-md mx-auto leading-relaxed mb-8">
+            {error.message || "Something went wrong while loading this classroom."}
+          </p>
+
+          <div className="flex flex-col sm:flex-row gap-4 w-full justify-center">
+            <button onClick={reset} className="group relative">
+              <div className="absolute -inset-0.5 bg-gradient-to-r from-blue-500 to-cyan-500 rounded-xl blur opacity-30 group-hover:opacity-70 transition duration-500 ease-out" />
+              <div className="relative flex items-center justify-center gap-2 px-6 py-3 bg-slate-900 border border-slate-700/50 group-hover:border-cyan-500/50 rounded-xl text-white font-medium text-sm transition-all duration-300 ease-out">
+                <RefreshCcw className="w-4 h-4 text-cyan-400" />
+                Try Again
+              </div>
+            </button>
+
+            <Link href="/rooms" className="group relative">
+              <div className="absolute -inset-0.5 bg-gradient-to-r from-slate-600 to-slate-500 rounded-xl blur opacity-20 group-hover:opacity-40 transition duration-500 ease-out" />
+              <div className="relative flex items-center justify-center gap-2 px-6 py-3 bg-slate-800/50 border border-slate-700/50 group-hover:border-slate-500/50 rounded-xl text-slate-300 group-hover:text-white font-medium text-sm transition-all duration-300 ease-out">
+                <LayoutDashboard className="w-4 h-4" />
+                Back to Classrooms
+              </div>
+            </Link>
+          </div>
+        </div>
+      </motion.div>
+    </div>
+  );
+}

--- a/src/app/ask-ai/error.tsx
+++ b/src/app/ask-ai/error.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { useEffect } from "react";
+import Link from "next/link";
+import { motion } from "framer-motion";
+import { AlertTriangle, RefreshCcw, LayoutDashboard } from "lucide-react";
+
+export default function AskAiError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="min-h-[70vh] bg-[#030712] flex items-center justify-center p-6 relative overflow-hidden text-slate-200 font-sans rounded-2xl">
+      <div className="absolute inset-0 bg-[linear-gradient(to_right,#33415522_1px,transparent_1px),linear-gradient(to_bottom,#33415522_1px,transparent_1px)] bg-[size:40px_40px] [mask-image:radial-gradient(ellipse_60%_60%_at_50%_50%,#000_70%,transparent_100%)] pointer-events-none" />
+
+      <motion.div
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.6, ease: "easeOut" }}
+        className="relative z-10 w-full max-w-lg"
+      >
+        <div className="backdrop-blur-xl bg-slate-900/40 border border-slate-700/50 rounded-3xl p-8 sm:p-10 shadow-[0_0_50px_rgba(220,38,38,0.1)] flex flex-col items-center text-center">
+          <div className="inline-flex items-center gap-2 px-3 py-1.5 rounded-full bg-red-500/10 border border-red-500/20 text-red-400 text-[10px] font-bold uppercase tracking-widest mb-6">
+            <AlertTriangle className="w-3.5 h-3.5" />
+            AI Assistant Error
+          </div>
+
+          <h2 className="text-xl sm:text-2xl font-bold text-white tracking-tight mb-3">
+            The AI assistant hit a snag
+          </h2>
+          <p className="text-slate-400 text-sm max-w-md mx-auto leading-relaxed mb-8">
+            {error.message || "Something went wrong while processing your request."}
+          </p>
+
+          <div className="flex flex-col sm:flex-row gap-4 w-full justify-center">
+            <button onClick={reset} className="group relative">
+              <div className="absolute -inset-0.5 bg-gradient-to-r from-blue-500 to-cyan-500 rounded-xl blur opacity-30 group-hover:opacity-70 transition duration-500 ease-out" />
+              <div className="relative flex items-center justify-center gap-2 px-6 py-3 bg-slate-900 border border-slate-700/50 group-hover:border-cyan-500/50 rounded-xl text-white font-medium text-sm transition-all duration-300 ease-out">
+                <RefreshCcw className="w-4 h-4 text-cyan-400" />
+                Try Again
+              </div>
+            </button>
+
+            <Link href="/dashboard" className="group relative">
+              <div className="absolute -inset-0.5 bg-gradient-to-r from-slate-600 to-slate-500 rounded-xl blur opacity-20 group-hover:opacity-40 transition duration-500 ease-out" />
+              <div className="relative flex items-center justify-center gap-2 px-6 py-3 bg-slate-800/50 border border-slate-700/50 group-hover:border-slate-500/50 rounded-xl text-slate-300 group-hover:text-white font-medium text-sm transition-all duration-300 ease-out">
+                <LayoutDashboard className="w-4 h-4" />
+                Go to Dashboard
+              </div>
+            </Link>
+          </div>
+        </div>
+      </motion.div>
+    </div>
+  );
+}

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { useEffect } from "react";
+import Link from "next/link";
+import { motion } from "framer-motion";
+import { AlertTriangle, RefreshCcw, LayoutDashboard } from "lucide-react";
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="min-h-screen bg-[#030712] flex items-center justify-center p-6 relative overflow-hidden text-slate-200 font-sans">
+      <div className="absolute inset-0 bg-[linear-gradient(to_right,#33415522_1px,transparent_1px),linear-gradient(to_bottom,#33415522_1px,transparent_1px)] bg-[size:40px_40px] [mask-image:radial-gradient(ellipse_60%_60%_at_50%_50%,#000_70%,transparent_100%)] pointer-events-none" />
+
+      <motion.div
+        animate={{ scale: [1, 1.2, 1], opacity: [0.15, 0.3, 0.15] }}
+        transition={{ duration: 8, repeat: Infinity, ease: "easeInOut" }}
+        className="absolute top-1/4 left-1/4 w-[400px] h-[400px] bg-red-600/20 rounded-full blur-[120px] pointer-events-none"
+      />
+
+      <motion.div
+        initial={{ opacity: 0, y: 30 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.6, ease: "easeOut" }}
+        className="relative z-10 w-full max-w-xl"
+      >
+        <div className="backdrop-blur-xl bg-slate-900/40 border border-slate-700/50 rounded-3xl p-8 sm:p-12 shadow-[0_0_50px_rgba(220,38,38,0.1)] flex flex-col items-center text-center relative overflow-hidden">
+          <div className="inline-flex items-center gap-2 px-3 py-1.5 rounded-full bg-red-500/10 border border-red-500/20 text-red-400 text-[10px] font-bold uppercase tracking-widest mb-8">
+            <AlertTriangle className="w-3.5 h-3.5" />
+            Runtime Error
+          </div>
+
+          <h2 className="text-2xl sm:text-3xl font-bold text-white tracking-tight mb-3">
+            Something went wrong
+          </h2>
+          <p className="text-slate-400 text-sm sm:text-base max-w-md mx-auto leading-relaxed mb-8">
+            {error.message || "An unexpected error occurred while loading this page."}
+          </p>
+
+          <div className="flex flex-col sm:flex-row gap-4 w-full justify-center">
+            <button onClick={reset} className="group relative">
+              <div className="absolute -inset-0.5 bg-gradient-to-r from-blue-500 to-cyan-500 rounded-xl blur opacity-30 group-hover:opacity-70 transition duration-500 ease-out" />
+              <div className="relative flex items-center justify-center gap-2 px-6 py-3.5 bg-slate-900 border border-slate-700/50 group-hover:border-cyan-500/50 rounded-xl text-white font-medium text-sm transition-all duration-300 ease-out">
+                <RefreshCcw className="w-4 h-4 text-cyan-400" />
+                Try Again
+              </div>
+            </button>
+
+            <Link href="/dashboard" className="group relative">
+              <div className="absolute -inset-0.5 bg-gradient-to-r from-slate-600 to-slate-500 rounded-xl blur opacity-20 group-hover:opacity-40 transition duration-500 ease-out" />
+              <div className="relative flex items-center justify-center gap-2 px-6 py-3.5 bg-slate-800/50 border border-slate-700/50 group-hover:border-slate-500/50 rounded-xl text-slate-300 group-hover:text-white font-medium text-sm transition-all duration-300 ease-out">
+                <LayoutDashboard className="w-4 h-4" />
+                Go to Dashboard
+              </div>
+            </Link>
+          </div>
+        </div>
+      </motion.div>
+    </div>
+  );
+}


### PR DESCRIPTION
## **User description**
## Description
DoubtDesk had zero `error.tsx` error boundary files, so runtime errors (API failures, undefined variables, etc.) fell through to the default Next.js error page — ugly and unhelpful. This PR adds themed error boundaries at the root level and for 3 key routes (dashboard, ask-ai, rooms), each with a "Try Again" reset button and a link back to a safe route, styled consistently with the existing `not-found.tsx` design.

## Related Issue
Closes #167

## Type of Change
- [x] New feature (non-breaking change that adds functionality)
- [x] Style / UI change (no logic change)

## How Has This Been Tested?
- [x] Tested locally with `npm run dev`
- [x] Verified on mobile viewport (375px)
- [x] Verified on desktop viewport (1440px)

## Checklist
- [x] I have tested my changes locally (`npm run dev`)
- [x] My code follows the existing code style (TypeScript, Tailwind, no `any` types)
- [x] I have not introduced unrelated changes (each PR should address one issue)
- [x] I have added comments where necessary
- [x] My branch is up to date with `main`
- [x] I have linked the related issue above
- [ ] Screenshots are included (if this is a UI change)


___

## **CodeAnt-AI Description**
Add graceful error screens for the app, dashboard, ask-ai, and rooms

### What Changed
- Runtime errors now show a themed error screen instead of the default Next.js crash page
- The dashboard, ask-ai, and rooms sections each have a route-specific error screen with a clear message
- Each error screen includes a Try Again button and a safe link back to the app, so users can recover without getting stuck
- Error details are logged for easier troubleshooting while users stay on a usable page

### Impact
`✅ Fewer full-page crash screens`
`✅ Faster recovery from page errors`
`✅ Clearer error messages for users`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Added user-friendly error screens for the dashboard, rooms, AI assistant, and general application areas.
  - Error messages are displayed with helpful fallback text when details are unavailable.
  - Added **Try Again** actions to retry failed operations.
  - Added navigation links to return to the dashboard or classrooms when recovery is unsuccessful.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->