### PR TITLE
fix: add checkUserBlock to doubt restore endpoint

### DIFF
--- a/src/app/api/doubts/restore/route.ts
+++ b/src/app/api/doubts/restore/route.ts
@@ -4,12 +4,16 @@ import { and, eq, isNull } from "drizzle-orm";
 import { NextResponse } from "next/server";
 import { currentUser } from "@clerk/nextjs/server";
 import { canTeach } from "@/lib/auth/membership-guard";
+import { checkUserBlock } from "@/lib/auth/auth-utils";
 
 export async function POST(req: Request) {
     try {
         const user = await currentUser();
         const email = user?.primaryEmailAddress?.emailAddress;
         if (!email) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+        const { isBlocked, errorResponse: blockResponse } = await checkUserBlock(email);
+        if (isBlocked) return blockResponse;
 
         const { doubtId } = await req.json();
         if (!doubtId) return NextResponse.json({ error: "Doubt ID required" }, { status: 400 });


### PR DESCRIPTION
## **User description**
## Description
Added the missing `checkUserBlock(email)` call to the `POST /api/doubts/restore` endpoint. Previously, blocked/suspended users could restore their soft-deleted doubts and re-expose questionable content. The fix adds the same guard used by all other content-modifying endpoints (create doubt, create reply, join classroom, etc.), rejecting the request immediately if the user is currently blocked.

## Related Issue
Closes #939 

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Documentation update (README, guides, comments)
- [ ] Style / UI change (no logic change)
- [ ] Code refactor (no behavior change)
- [ ] Test addition or update
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Screenshots (if UI change)
N/A

## How Has This Been Tested?
- [ ] Tested locally with `npm run dev`
- [ ] Verified on mobile viewport (375px)
- [ ] Verified on desktop viewport (1440px)

## Checklist
- [x] I have tested my changes locally (`npm run dev`)
- [x] My code follows the existing code style (TypeScript, Tailwind, no `any` types)
- [x] I have not introduced unrelated changes (each PR should address one issue)
- [ ] I have added comments where necessary
- [x] My branch is up to date with `main`
- [ ] I have linked the related issue above
- [ ] Screenshots are included (if this is a UI change)


___

## **CodeAnt-AI Description**
**Blocked users can no longer restore doubts**

### What Changed
- The restore doubt action now stops blocked or suspended users before any restore happens
- Users without a valid email still get an unauthorized response
- Requests without a doubt ID still return a clear validation error

### Impact
`✅ Prevented blocked users from restoring content`
`✅ Consistent access checks across content actions`
`✅ Fewer policy bypasses on restored doubts`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Blocked accounts can no longer restore previously deleted doubts.
  - Restoration requests now stop immediately when account restrictions apply.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->