### PR TITLE
fix: remove client-supplied createdAt from doubt and reply endpoints

### DIFF
--- a/src/app/api/doubts/route.ts
+++ b/src/app/api/doubts/route.ts
@@ -368,20 +368,6 @@ export async function POST(req: Request) {
 
     const subTopic = await categorizeDoubt(content || "", subject, imageUrl);
 
-    let parsedCreatedAt: Date | undefined = undefined;
-    if (data.createdAt) {
-      const d = new Date(data.createdAt);
-      if (isNaN(d.getTime())) {
-        return NextResponse.json({ error: "Invalid createdAt date format" }, { status: 400 });
-      }
-      const now = new Date();
-      const age = now.getTime() - d.getTime();
-      const maxOfflineDuration = 30 * 24 * 60 * 60 * 1000;
-      if (age >= -300000 && age <= maxOfflineDuration) {
-        parsedCreatedAt = d;
-      }
-    }
-
     const [newDoubt] = await db
       .insert(doubtsTable)
       .values({
@@ -392,7 +378,6 @@ export async function POST(req: Request) {
         imageUrl,
         classroomId: parsedClassroomId,
         type: doubtType,
-        createdAt: parsedCreatedAt,
       })
       .returning();
 

--- a/src/app/api/replies/route.ts
+++ b/src/app/api/replies/route.ts
@@ -193,20 +193,6 @@ export async function POST(req: Request) {
       }
     }
 
-    let parsedCreatedAt: Date | undefined = undefined;
-    if (data.createdAt) {
-      const d = new Date(data.createdAt);
-      if (isNaN(d.getTime())) {
-        return errorResponse("Invalid createdAt date format", 400);
-      }
-      const now = new Date();
-      const age = now.getTime() - d.getTime();
-      const maxOfflineDuration = 30 * 24 * 60 * 60 * 1000;
-      if (age >= -300000 && age <= maxOfflineDuration) {
-        parsedCreatedAt = d;
-      }
-    }
-
     const newReply = await db
       .insert(repliesTable)
       .values({
@@ -215,7 +201,6 @@ export async function POST(req: Request) {
         type,
         content: content || null,
         imageUrl: imageUrl || null,
-        createdAt: parsedCreatedAt,
       })
       .returning();
 


### PR DESCRIPTION
## **User description**
## Description
Removed all client-supplied `createdAt` handling from both the doubt creation (`POST /api/doubts`) and reply creation (`POST /api/replies`) endpoints. Previously, the server accepted a `createdAt` field from the client and validated it against a broad 30-day window, allowing users to backdate or forward-date content to manipulate feed ordering, bury content in reverse-chronological views, or distort analytics. Now the server always uses the database default (`defaultNow()`) for the `createdAt` timestamp, making timestamps tamper-proof.

## Related Issue
Closes #941 

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Documentation update (README, guides, comments)
- [ ] Style / UI change (no logic change)
- [ ] Code refactor (no behavior change)
- [ ] Test addition or update
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Screenshots (if UI change)
N/A

## How Has This Been Tested?
- [ ] Tested locally with `npm run dev`
- [ ] Verified on mobile viewport (375px)
- [ ] Verified on desktop viewport (1440px)

## Checklist
- [x] I have tested my changes locally (`npm run dev`)
- [x] My code follows the existing code style (TypeScript, Tailwind, no `any` types)
- [x] I have not introduced unrelated changes (each PR should address one issue)
- [ ] I have added comments where necessary
- [x] My branch is up to date with `main`
- [ ] I have linked the related issue above
- [ ] Screenshots are included (if this is a UI change)


___

## **CodeAnt-AI Description**
**Ignore client-provided timestamps when creating doubts and replies**

### What Changed
- New doubts and replies now always get their timestamp from the server instead of using a time sent by the client
- Requests that tried to set `createdAt` no longer affect when the post appears in feeds or analytics
- Invalid or backdated client timestamps are no longer accepted for these endpoints

### Impact
`✅ Prevented feed order manipulation`
`✅ More reliable reply and doubt timelines`
`✅ Cleaner activity analytics`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * New doubts and replies now use the server/database creation time instead of client-provided timestamps.
  * Prevents invalid or misleading dates from being assigned during creation.
  * Existing moderation, notifications, tagging, and AI processing continue to work as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->