### PR TITLE
fix: add isHidden visibility check to GET /api/doubts/[id]

### DIFF
--- a/src/app/api/doubts/[id]/route.ts
+++ b/src/app/api/doubts/[id]/route.ts
@@ -41,14 +41,25 @@ export async function GET(
             }
             const membership = await requireMembership(email, doubt.classroomId);
 
+            const isTeacher = ["teacher", "owner", "admin"].includes(membership.role.toLowerCase());
+            const isAuthor = doubt.userEmail === email;
+
             // Teacher doubts visibility guard
             if (doubt.type === "teacher") {
-                const isTeacher = ["teacher", "owner", "admin"].includes(membership.role.toLowerCase());
-                const isAuthor = doubt.userEmail === email;
                 if (!isTeacher && !isAuthor) {
                     return NextResponse.json({ error: "Access denied to this doubt" }, { status: 403 });
                 }
             }
+
+            // Hidden doubts: teachers see all, the author sees their own,
+            // others are blocked from viewing hidden content. Matches the
+            // same filtering logic as the list endpoint (GET /api/doubts).
+            if (doubt.isHidden && !isTeacher && !isAuthor) {
+                return NextResponse.json({ error: "Doubt not found" }, { status: 404 });
+            }
+        } else if (doubt.isHidden && doubt.userEmail !== email) {
+            // Community doubts: only the author can view their own hidden doubt.
+            return NextResponse.json({ error: "Doubt not found" }, { status: 404 });
         }
 
         // Fetch tags


### PR DESCRIPTION
## **User description**
## Description
Added `isHidden` visibility checks to `GET /api/doubts/[id]` matching the same filtering logic already used in the list endpoint (`GET /api/doubts`). Previously, any classroom member could view moderator-hidden or auto-hidden doubts by directly accessing their numeric ID, completely bypassing the content moderation system. The fix applies the same role-based and ownership-based exceptions: teachers see all hidden content for review, the original poster sees their own hidden doubt, and everyone else gets a 404.

## Related Issue
Closes #940 

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Documentation update (README, guides, comments)
- [ ] Style / UI change (no logic change)
- [ ] Code refactor (no behavior change)
- [ ] Test addition or update
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Screenshots (if UI change)
N/A

## How Has This Been Tested?
- [ ] Tested locally with `npm run dev`
- [ ] Verified on mobile viewport (375px)
- [ ] Verified on desktop viewport (1440px)

## Checklist
- [x] I have tested my changes locally (`npm run dev`)
- [x] My code follows the existing code style (TypeScript, Tailwind, no `any` types)
- [x] I have not introduced unrelated changes (each PR should address one issue)
- [ ] I have added comments where necessary
- [x] My branch is up to date with `main`
- [x] I have linked the related issue above
- [ ] Screenshots are included (if this is a UI change)


___

## **CodeAnt-AI Description**
**Hidden doubts now stay private in the doubt detail view**

### What Changed
- Hidden doubts can no longer be opened by other classroom members through a direct link or numeric ID
- Teachers can still view hidden doubts, and authors can still view their own hidden doubts
- Community hidden doubts are only visible to their author; everyone else gets a not found response

### Impact
`✅ Fewer hidden-content leaks`
`✅ Consistent privacy rules between list and detail views`
`✅ Safer classroom moderation`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
