### PR TITLE
fix: add timeout and rate limiting to personal analytics Groq call

### DIFF
--- a/src/app/api/analytics/personal/route.ts
+++ b/src/app/api/analytics/personal/route.ts
@@ -4,11 +4,15 @@ import { doubtsTable } from '@/configs/schema';
 import { and, eq, desc, isNull } from 'drizzle-orm';
 import { groq } from '@/lib/ai/groq-client';
 import { buildErrorResponse } from '@/lib/errors/error-handler';
+import { enforceApiRateLimit } from '@/lib/ratelimit/api-rate-limit';
+import { aiLimiter } from '@/lib/ratelimit/ratelimit';
 import {
     parseClassroomId,
     requireAuth,
     requireMembership,
 } from '@/lib/auth/membership-guard';
+
+const GROQ_TIMEOUT_MS = 15_000;
 
 export async function GET(req: Request) {
     try {
@@ -20,6 +24,10 @@ export async function GET(req: Request) {
         }
         const classroomId = parseClassroomId(classroomIdStr);
         await requireMembership(email, classroomId);
+
+        // Rate limit: this endpoint makes an expensive LLM call per request.
+        const rateLimitResponse = await enforceApiRateLimit(aiLimiter, email, "ai");
+        if (rateLimitResponse) return rateLimitResponse;
 
         // Fetch user's doubts in this classroom
         const userDoubts = await db.select({
@@ -64,14 +72,18 @@ export async function GET(req: Request) {
             }
         }`;
 
+        const controller = new AbortController();
+        const timeoutId = setTimeout(() => controller.abort(), GROQ_TIMEOUT_MS);
+
         const response = await groq.chat.completions.create({
             messages: [
                 { role: "system", content: systemPrompt },
                 { role: "user", content: `Analyze these doubts asked by the student in this classroom:\n\n${doubtContext}` }
             ],
             model: "llama-3.3-70b-versatile",
-            response_format: { type: "json_object" }
-        });
+            response_format: { type: "json_object" },
+            signal: controller.signal,
+        }).finally(() => clearTimeout(timeoutId));
 
         const result = JSON.parse(response.choices[0].message.content || "{}");
 


### PR DESCRIPTION
## **User description**
## Description
Added a 15-second `AbortController` timeout and per-user rate limiting (10 req/min via `aiLimiter`) to the Groq LLM call in `GET /api/analytics/personal`. Previously, the endpoint made an unbounded HTTP call to the Groq API — if the provider became unresponsive, the serverless function would block until the platform-enforced timeout (10–60s), consuming billable execution time and potentially exhausting concurrent function slots. An attacker with a valid session could repeatedly call this endpoint to degrade availability for other users.

## Related Issue
Closes #936 

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Documentation update (README, guides, comments)
- [ ] Style / UI change (no logic change)
- [ ] Code refactor (no behavior change)
- [ ] Test addition or update
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Screenshots (if UI change)
N/A

## How Has This Been Tested?
- [ ] Tested locally with `npm run dev`
- [ ] Verified on mobile viewport (375px)
- [ ] Verified on desktop viewport (1440px)

## Checklist
- [x] I have tested my changes locally (`npm run dev`)
- [x] My code follows the existing code style (TypeScript, Tailwind, no `any` types)
- [x] I have not introduced unrelated changes (each PR should address one issue)
- [ ] I have added comments where necessary
- [x] My branch is up to date with `main`
- [x] I have linked the related issue above
- [ ] Screenshots are included (if this is a UI change)


___

## **CodeAnt-AI Description**
**Prevent the personal analytics request from hanging or being overused**

### What Changed
- The personal analytics page now stops waiting for the AI response after 15 seconds, so stalled requests return sooner instead of tying up the server.
- The endpoint now limits how often a user can make this AI-powered request, reducing repeated calls that could slow things down for others.

### Impact
`✅ Fewer analytics request timeouts`
`✅ Less server blockage from slow AI responses`
`✅ Lower risk of one user overloading personal analytics`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
