### PR TITLE
fix: add classroom membership check to reply upvote endpoint

### DIFF
--- a/src/app/api/doubts/[id]/upvote/route.ts
+++ b/src/app/api/doubts/[id]/upvote/route.ts
@@ -1,7 +1,7 @@
 // app/api/doubts/[id]/upvote/route.ts
 import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/configs/db";
-import { repliesTable, replyLikesTable } from "@/configs/schema";
+import { repliesTable, replyLikesTable, doubtsTable, membershipsTable } from "@/configs/schema";
 import { eq, and, sql } from "drizzle-orm";
 import { buildErrorResponse } from "@/lib/errors/error-handler";
 import { inngest } from "@/inngest/client";
@@ -63,7 +63,35 @@ export async function POST(
             return NextResponse.json({ error: "Forbidden: You cannot upvote your own answer." }, { status: 403 });
         }
 
-        // ── 4 & 5. ATOMIC TRANSACTION: INSERT LIKE & INCREMENT COUNTER ───────
+        // ── 4. CLASSROOM MEMBERSHIP GUARD ─────────────────────────────────────
+        const [doubt] = await db
+            .select({ classroomId: doubtsTable.classroomId })
+            .from(doubtsTable)
+            .where(eq(doubtsTable.id, doubtId))
+            .limit(1);
+
+        if (!doubt) {
+            return NextResponse.json({ error: "Doubt not found" }, { status: 404 });
+        }
+
+        if (doubt.classroomId) {
+            const [membership] = await db
+                .select()
+                .from(membershipsTable)
+                .where(
+                    and(
+                        eq(membershipsTable.userEmail, stableUserIdentifier),
+                        eq(membershipsTable.classroomId, doubt.classroomId),
+                    ),
+                )
+                .limit(1);
+
+            if (!membership) {
+                return NextResponse.json({ error: "Access denied to this classroom's doubt" }, { status: 403 });
+            }
+        }
+
+        // ── 5 & 6. ATOMIC TRANSACTION: INSERT LIKE & INCREMENT COUNTER ───────
         let updatedReply;
 
         try {
@@ -118,7 +146,7 @@ export async function POST(
             }, { status: 400 });
         }
 
-        // ── 6. DISPATCH BACKGROUND SYSTEM EVENT VIA INNGEST ─────────────────
+        // ── 7. DISPATCH BACKGROUND SYSTEM EVENT VIA INNGEST ─────────────────
         if (updatedReply.userEmail) {
             await inngest.send({
                 name: "karma/answer.upvoted",


### PR DESCRIPTION
## **User description**
## Description
Added a classroom membership check to `POST /api/doubts/[id]/upvote`. Previously, any authenticated user could upvote any reply on any classroom's doubt without being a member of that classroom — enabling vote manipulation and unfair karma influence. The fix looks up the doubt's `classroomId` and verifies the user is a member of that classroom, matching the same pattern used by the bookmark, reply, and doubt detail endpoints.

## Related Issue
Closes #935 

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Documentation update (README, guides, comments)
- [ ] Style / UI change (no logic change)
- [ ] Code refactor (no behavior change)
- [ ] Test addition or update
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Screenshots (if UI change)
N/A

## How Has This Been Tested?
- [ ] Tested locally with `npm run dev`
- [ ] Verified on mobile viewport (375px)
- [ ] Verified on desktop viewport (1440px)

## Checklist
- [x] I have tested my changes locally (`npm run dev`)
- [x] My code follows the existing code style (TypeScript, Tailwind, no `any` types)
- [x] I have not introduced unrelated changes (each PR should address one issue)
- [ ] I have added comments where necessary
- [x] My branch is up to date with `main`
- [x] I have linked the related issue above
- [ ] Screenshots are included (if this is a UI change)


___

## **CodeAnt-AI Description**
**Block reply upvotes from users outside the classroom**

### What Changed
- Reply upvotes now check whether the user belongs to the classroom before allowing the vote
- Users who are not members of that classroom now get a clear access denied error instead of changing reply karma
- The endpoint still blocks upvotes on your own reply and keeps the existing reply/thread validation in place

### Impact
`✅ Prevented outside users from influencing classroom reply votes`
`✅ Clearer access denied errors for non-members`
`✅ Safer karma counts on classroom discussions`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
