### PR TITLE
fix: add Origin-header CSRF protection to all state-changing API endpoints

### DIFF
--- a/src/middleware.tsx
+++ b/src/middleware.tsx
@@ -126,6 +126,31 @@ export default clerkMiddleware(async (auth, req) => {
         }
     }
 
+    // ── CSRF Protection ────────────────────────────────────────────────────
+    // All state-changing API requests must include an Origin header matching
+    // the application's own origin. Browsers send the Origin header on every
+    // cross-origin POST/PUT/PATCH/DELETE, and JavaScript cannot spoof it for
+    // cross-origin requests. Same-origin fetch requests also include Origin
+    // with the correct value, so they pass through. Requests with no Origin
+    // (direct API calls, older browsers) are allowed as a safe default since
+    // they cannot be cross-origin form submissions without an Origin header.
+    const APP_ORIGIN =
+        process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
+    const STATE_CHANGING_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
+
+    if (
+        path.startsWith('/api') &&
+        STATE_CHANGING_METHODS.has(req.method)
+    ) {
+        const origin = req.headers.get('origin');
+        if (origin && !origin.startsWith(APP_ORIGIN)) {
+            return new NextResponse(
+                JSON.stringify({ error: 'CSRF validation failed' }),
+                { status: 403, headers: { 'Content-Type': 'application/json' } },
+            );
+        }
+    }
+
     const { userId, sessionClaims, redirectToSignIn } = await auth();
     const isPublic = isPublicRoute(req);
     const isApi = req.nextUrl.pathname.startsWith('/api');


### PR DESCRIPTION
## **User description**
## Description
Added Origin-header CSRF protection to all state-changing API endpoints via middleware. Previously, the application relied entirely on Clerk's cookie-based authentication with no CSRF defense beyond `SameSite=Lax`, which is bypassable via subdomain attacks, clickjacking, or any XSS vector on the same origin. The middleware now rejects `POST`/`PUT`/`PATCH`/`DELETE` API requests whose `Origin` header does not match the application's own origin (`NEXT_PUBLIC_APP_URL`). This is a standard defense-in-depth measure — browsers send the `Origin` header on all cross-origin state-changing requests, and JavaScript cannot spoof it for cross-origin requests.

## Related Issue
Closes #932

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Documentation update (README, guides, comments)
- [ ] Style / UI change (no logic change)
- [ ] Code refactor (no behavior change)
- [ ] Test addition or update
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Screenshots (if UI change)
N/A

## How Has This Been Tested?
- [ ] Tested locally with `npm run dev`
- [ ] Verified on mobile viewport (375px)
- [ ] Verified on desktop viewport (1440px)

## Checklist
- [x] I have tested my changes locally (`npm run dev`)
- [x] My code follows the existing code style (TypeScript, Tailwind, no `any` types)
- [x] I have not introduced unrelated changes (each PR should address one issue)
- [ ] I have added comments where necessary
- [x] My branch is up to date with `main`
- [x] I have linked the related issue above
- [ ] Screenshots are included (if this is a UI change)


___

## **CodeAnt-AI Description**
**Block cross-origin writes to API endpoints**

### What Changed
- API requests that create, update, or delete data are now rejected when they come from another site
- Same-site requests still work normally, and requests without an `Origin` header are allowed
- Cross-site attempts now return a clear 403 response instead of reaching the endpoint

### Impact
`✅ Fewer cross-site form attacks`
`✅ Safer account and data changes`
`✅ Clearer blocked-request errors`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
