### PR TITLE
fix: cache personal analytics with invalidation on doubt creation

### DIFF
--- a/src/app/api/analytics/personal/route.ts
+++ b/src/app/api/analytics/personal/route.ts
@@ -11,6 +11,10 @@ import {
     requireAuth,
     requireMembership,
 } from '@/lib/auth/membership-guard';
+import {
+    readAnalyticsCache,
+    writeAnalyticsCache,
+} from '@/lib/cache/analytics-cache';
 
 const GROQ_TIMEOUT_MS = 15_000;
 
@@ -54,6 +58,12 @@ export async function GET(req: Request) {
             });
         }
 
+        const cacheKey = `analytics:personal:${email}:${classroomId}`;
+        const cached = await readAnalyticsCache<Record<string, unknown>>(cacheKey);
+        if (cached.status === 'fresh' || cached.status === 'stale') {
+            return NextResponse.json({ isEngaged: true, ...cached.data });
+        }
+
         // Prepare doubt summaries for AI analysis
         const doubtContext = userDoubts.map((d: any) => `- [${d.subject}]: ${d.content}`).join('\n');
 
@@ -86,6 +96,8 @@ export async function GET(req: Request) {
         }).finally(() => clearTimeout(timeoutId));
 
         const result = JSON.parse(response.choices[0].message.content || "{}");
+
+        await writeAnalyticsCache(cacheKey, result);
 
         return NextResponse.json({
             isEngaged: true,

--- a/src/app/api/doubts/route.ts
+++ b/src/app/api/doubts/route.ts
@@ -34,7 +34,7 @@ import { createDoubtSchema } from "@/lib/validations/doubt";
 import { createClassroomDoubtNotifications } from "@/lib/notifications/service";
 import { inngest } from "@/inngest/client";
 import { enforceApiRateLimit } from "@/lib/ratelimit/api-rate-limit";
-import { generalLimiter } from "@/lib/ratelimit/ratelimit";
+import { generalLimiter, redisClient } from "@/lib/ratelimit/ratelimit";
 import { buildRankOrder } from "@/lib/search/search";
 import { canTeach } from "@/lib/auth/membership-guard";
 import { currentUser } from "@clerk/nextjs/server";
@@ -433,6 +433,10 @@ export async function POST(req: Request) {
         authorName: user.fullName || email,
         doubtType,
       }).catch((err) => console.error("Notification trigger async failure:", err));
+
+      redisClient.del(`analytics:personal:${email}:${parsedClassroomId}`).catch((err) =>
+        console.error("Failed to invalidate personal analytics cache:", err)
+      );
     }
 
     const normalizedTags: string[] = Array.from(


### PR DESCRIPTION
## Description
Adds Redis-backed caching to the `/api/analytics/personal` endpoint using a stale-while-revalidate pattern, preventing redundant LLM (Groq) calls when analytics are requested multiple times for the same user and classroom. The cache key is `analytics:personal:{email}:{classroomId}` with a 5-minute fresh TTL and 10-minute stale TTL (15 minutes total). Cache is invalidated automatically when the user creates a new doubt in that classroom via `POST /api/doubts`.

## Related Issue
Closes #992

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Documentation update (README, guides, comments)
- [ ] Style / UI change (no logic change)
- [ ] Code refactor (no behavior change)
- [ ] Test addition or update
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## How Has This Been Tested?
- [x] Tested locally with `npm run dev`
- [ ] Verified on mobile viewport (375px)
- [ ] Verified on desktop viewport (1440px)

## Checklist
- [x] I have tested my changes locally (`npm run dev`)
- [x] My code follows the existing code style (TypeScript, Tailwind, no `any` types)
- [x] I have not introduced unrelated changes (each PR should address one issue)
- [x] I have added comments where necessary
- [x] My branch is up to date with `main`
- [x] I have linked the related issue above
- [ ] Screenshots are included (if this is a UI change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Personalized analytics can now load faster by using recently cached results.
  * Analytics refresh automatically after new classroom doubts are submitted, helping keep insights current.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->