### PR TITLE
fix: reject client-supplied createdAt in POST /api/replies

### DIFF
--- a/src/app/api/replies/route.ts
+++ b/src/app/api/replies/route.ts
@@ -193,20 +193,6 @@ export async function POST(req: Request) {
       }
     }
 
-    let parsedCreatedAt: Date | undefined = undefined;
-    if (data.createdAt) {
-      const d = new Date(data.createdAt);
-      if (isNaN(d.getTime())) {
-        return errorResponse("Invalid createdAt date format", 400);
-      }
-      const now = new Date();
-      const age = now.getTime() - d.getTime();
-      const maxOfflineDuration = 30 * 24 * 60 * 60 * 1000;
-      if (age >= -300000 && age <= maxOfflineDuration) {
-        parsedCreatedAt = d;
-      }
-    }
-
     const newReply = await db
       .insert(repliesTable)
       .values({
@@ -215,7 +201,7 @@ export async function POST(req: Request) {
         type,
         content: content || null,
         imageUrl: imageUrl || null,
-        createdAt: parsedCreatedAt,
+        createdAt: new Date(),
       })
       .returning();
 

--- a/src/lib/validations/reply.ts
+++ b/src/lib/validations/reply.ts
@@ -7,7 +7,6 @@ export const createReplySchema = z.object({
   type: trimmedString.min(1),
   content: trimmedString.max(5000).optional().nullable(),
   imageUrl: safeUrl.optional().nullable(),
-  createdAt: z.string().datetime().optional().nullable(),
 }).refine((data) => data.content || data.imageUrl, {
   message: "Either content or imageUrl is required",
   path: ["content"]


### PR DESCRIPTION
## Description
Removes the client-supplied `createdAt` field from the `POST /api/replies` endpoint. The server now always sets `createdAt` to the current time, preventing users from manipulating reply ordering by submitting arbitrary timestamps.

## Related Issue
Closes #993 

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Documentation update (README, guides, comments)
- [ ] Style / UI change (no logic change)
- [ ] Code refactor (no behavior change)
- [ ] Test addition or update
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## How Has This Been Tested?
- [x] Tested locally with `npm run dev`
- [ ] Verified on mobile viewport (375px)
- [ ] Verified on desktop viewport (1440px)

## Checklist
- [x] I have tested my changes locally (`npm run dev`)
- [x] My code follows the existing code style (TypeScript, Tailwind, no `any` types)
- [x] I have not introduced unrelated changes (each PR should address one issue)
- [x] I have added comments where necessary
- [x] My branch is up to date with `main`
- [x] I have linked the related issue above
- [ ] Screenshots are included (if this is a UI change)
