### PR TITLE
fix: prevent IP spoofing in middleware rate limiter

### DIFF
--- a/src/middleware.tsx
+++ b/src/middleware.tsx
@@ -68,8 +68,10 @@ export default clerkMiddleware(async (auth, req) => {
 
     if (path.startsWith('/api') && !hasRouteLevelLimit) {
         const { userId } = await auth();
-        const forwardedFor = req.headers.get("x-forwarded-for");
-        const ip = req.headers.get("x-real-ip") ?? forwardedFor?.split(",")[0]?.trim() ?? "127.0.0.1";
+        const ip = req.ip
+            ?? req.headers.get("x-real-ip")
+            ?? req.headers.get("x-forwarded-for")?.split(",")[0]?.trim()
+            ?? "127.0.0.1";
         const rateLimitKey = userId || ip;
 
         const isAiRoute =


### PR DESCRIPTION
## Description
Fixes IP spoofing vulnerability in the middleware rate limiter. Changed IP extraction to prefer `req.ip` (platform-provided by Next.js/Vercel from the trusted proxy layer) over the `x-real-ip` and `x-forwarded-for` headers, which can be spoofed by clients when no reverse proxy is present to strip them.

## Related Issue
Closes #991

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Documentation update (README, guides, comments)
- [ ] Style / UI change (no logic change)
- [ ] Code refactor (no behavior change)
- [ ] Test addition or update
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## How Has This Been Tested?
- [x] Tested locally with `npm run dev`
- [ ] Verified on mobile viewport (375px)
- [ ] Verified on desktop viewport (1440px)

## Checklist
- [x] I have tested my changes locally (`npm run dev`)
- [x] My code follows the existing code style (TypeScript, Tailwind, no `any` types)
- [x] I have not introduced unrelated changes (each PR should address one issue)
- [x] I have added comments where necessary
- [x] My branch is up to date with `main`
- [x] I have linked the related issue above
- [ ] Screenshots are included (if this is a UI change)
