### PR TITLE
fix: add rate limiting to invite link creation endpoint

### DIFF
--- a/src/app/api/classrooms/[id]/invites/route.ts
+++ b/src/app/api/classrooms/[id]/invites/route.ts
@@ -13,6 +13,8 @@ import { checkUserBlock } from "@/lib/auth/auth-utils";
 import { buildErrorResponse } from "@/lib/errors/error-handler";
 import { parseAndValidateRequest } from "@/lib/validations/validate";
 import { createClassroomInviteSchema } from "@/lib/validations/classroom";
+import { enforceApiRateLimit } from "@/lib/ratelimit/api-rate-limit";
+import { generalLimiter } from "@/lib/ratelimit/ratelimit";
 import {
   generateInviteToken,
   getInviteExpiry,
@@ -40,6 +42,9 @@ export async function POST(
     const { isBlocked, errorResponse: blockErrorResponse } =
       await checkUserBlock(email);
     if (isBlocked) return blockErrorResponse;
+
+    const rateLimitResponse = await enforceApiRateLimit(generalLimiter, email, "general");
+    if (rateLimitResponse) return rateLimitResponse;
 
     const { id } = await params;
     const classroomId = parseInt(id, 10);


### PR DESCRIPTION
## Description
Adds rate limiting to the `POST /api/classrooms/[id]/invites` endpoint using the existing `enforceApiRateLimit` helper with `generalLimiter` (30 req/min), preventing abuse where a teacher could programmatically create unlimited invite links and exhaust database storage.

## Related Issue
Closes #989

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Documentation update (README, guides, comments)
- [ ] Style / UI change (no logic change)
- [ ] Code refactor (no behavior change)
- [ ] Test addition or update
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## How Has This Been Tested?
- [x] Tested locally with `npm run dev`
- [ ] Verified on mobile viewport (375px)
- [ ] Verified on desktop viewport (1440px)

## Checklist
- [x] I have tested my changes locally (`npm run dev`)
- [x] My code follows the existing code style (TypeScript, Tailwind, no `any` types)
- [x] I have not introduced unrelated changes (each PR should address one issue)
- [x] I have added comments where necessary
- [x] My branch is up to date with `main`
- [x] I have linked the related issue above
- [ ] Screenshots are included (if this is a UI change)
