### PR TITLE
fix: add limit to classroom export query to prevent unbounded memory limiting

### DIFF
--- a/src/app/api/classrooms/[id]/export/route.ts
+++ b/src/app/api/classrooms/[id]/export/route.ts
@@ -59,14 +59,22 @@ export async function GET(
             }
         }
 
-        // 6. Query doubts
+        // 6. Parse optional pagination
+        const limitParam = searchParams.get("limit");
+        const exportLimit = limitParam ? Math.min(Math.max(parseInt(limitParam, 10) || 1000, 1), 5000) : 1000;
+
+        // 7. Query doubts with limit to prevent unbounded memory/time usage
         const doubts = await db
             .select()
             .from(doubtsTable)
             .where(and(...conditions))
-            .orderBy(desc(doubtsTable.createdAt));
+            .orderBy(desc(doubtsTable.createdAt))
+            .limit(exportLimit + 1);
 
-        // 7. Fetch reply counts for these doubts
+        const hasMore = doubts.length > exportLimit;
+        if (hasMore) doubts.pop();
+
+        // 8. Fetch reply counts for these doubts
         const doubtIds = doubts.map((d: any) => d.id);
         const replyCounts = doubtIds.length > 0
             ? await db
@@ -90,6 +98,7 @@ export async function GET(
         return NextResponse.json({
             classroomName: classroom.name,
             doubts: doubtsWithReplies,
+            hasMore,
         });
     } catch (error: unknown) {
         const { status, body } = buildErrorResponse(error);


### PR DESCRIPTION
## Description
Adds a `limit` query parameter (default 1000, max 5000) to the `GET /api/classrooms/[id]/export` endpoint to prevent unbounded memory/time usage when exporting classrooms with thousands of doubts. The query over-fetches by one row to accurately return a `hasMore` flag, consistent with the existing cursor pagination pattern in the codebase.

## Related Issue
Closes #986

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Documentation update (README, guides, comments)
- [ ] Style / UI change (no logic change)
- [ ] Code refactor (no behavior change)
- [ ] Test addition or update
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## How Has This Been Tested?
- [x] Tested locally with `npm run dev`
- [ ] Verified on mobile viewport (375px)
- [ ] Verified on desktop viewport (1440px)

## Checklist
- [x] I have tested my changes locally (`npm run dev`)
- [x] My code follows the existing code style (TypeScript, Tailwind, no `any` types)
- [x] I have not introduced unrelated changes (each PR should address one issue)
- [x] I have added comments where necessary
- [x] My branch is up to date with `main`
- [x] I have linked the related issue above
- [ ] Screenshots are included (if this is a UI change)
