### PR TITLE
fix: add pagination limits to profile endpoint doubts and replies que…

### DIFF
--- a/src/app/api/profile/route.ts
+++ b/src/app/api/profile/route.ts
@@ -1,7 +1,7 @@
 export const dynamic = "force-dynamic";
 
 import { NextRequest, NextResponse } from "next/server";
-import { eq, or, inArray, isNull, and } from "drizzle-orm";
+import { eq, or, inArray, isNull, and, desc, sql } from "drizzle-orm";
 import { db } from "@/configs/db";
 import { doubtsTable, repliesTable, membershipsTable, classroomsTable, usersTable } from "@/configs/schema";
 import { auth, currentUser } from "@clerk/nextjs/server";
@@ -25,10 +25,18 @@ export async function GET(req: Request) {
             return NextResponse.json({ error: "No email found" }, { status: 400 });
         }
 
-        const [dbUserResults, doubts, replies, memberships] = await Promise.all([
+        const { searchParams } = new URL(req.url);
+        const limitParam = searchParams.get("limit");
+        const activityLimit = limitParam
+            ? Math.min(Math.max(parseInt(limitParam, 10) || 20, 1), 100)
+            : 20;
+
+        const [dbUserResults, totalDoubtsResult, totalRepliesResult, doubts, replies, memberships] = await Promise.all([
             db.select().from(usersTable).where(eq(usersTable.email, email)).limit(1),
-            db.select().from(doubtsTable).where(eq(doubtsTable.userEmail, email)),
-            db.select().from(repliesTable).where(eq(repliesTable.userEmail, email)),
+            db.select({ value: sql<number>`count(*)` }).from(doubtsTable).where(eq(doubtsTable.userEmail, email)),
+            db.select({ value: sql<number>`count(*)` }).from(repliesTable).where(eq(repliesTable.userEmail, email)),
+            db.select().from(doubtsTable).where(eq(doubtsTable.userEmail, email)).orderBy(desc(doubtsTable.createdAt)).limit(activityLimit),
+            db.select().from(repliesTable).where(eq(repliesTable.userEmail, email)).orderBy(desc(repliesTable.createdAt)).limit(activityLimit),
             db.select().from(membershipsTable).where(eq(membershipsTable.userEmail, email))
         ]);
 
@@ -46,8 +54,8 @@ export async function GET(req: Request) {
                 .where(inArray(classroomsTable.id, classroomIds));
         }
 
-        const totalDoubts = doubts?.length || 0;
-        const totalReplies = replies?.length || 0;
+        const totalDoubts = totalDoubtsResult[0]?.value ?? 0;
+        const totalReplies = totalRepliesResult[0]?.value ?? 0;
         const helpfulVotes = doubts ? doubts.reduce((acc, doubt) => acc + (doubt.likes || 0), 0) : 0;
 
         const rawJoinDate = dbUser?.createdAt || (clerkUser?.createdAt ? new Date(clerkUser.createdAt) : new Date());


### PR DESCRIPTION
## **User description**
## Description
Adds a `limit` query parameter (default 20, max 100) to the `GET /api/profile` endpoint to cap the number of doubts and replies returned in the activities section. Stats (`totalDoubts`, `totalReplies`) now use dedicated `count(*)` queries so they remain accurate regardless of the pagination limit. Activities are ordered by `createdAt DESC` to show the most recent first.

## Related Issue
Closes #988

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Documentation update (README, guides, comments)
- [ ] Style / UI change (no logic change)
- [ ] Code refactor (no behavior change)
- [ ] Test addition or update
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## How Has This Been Tested?
- [x] Tested locally with `npm run dev`
- [ ] Verified on mobile viewport (375px)
- [ ] Verified on desktop viewport (1440px)

## Checklist
- [x] I have tested my changes locally (`npm run dev`)
- [x] My code follows the existing code style (TypeScript, Tailwind, no `any` types)
- [x] I have not introduced unrelated changes (each PR should address one issue)
- [x] I have added comments where necessary
- [x] My branch is up to date with `main`
- [x] I have linked the related issue above
- [ ] Screenshots are included (if this is a UI change)


___

## **CodeAnt-AI Description**
Limit profile activity results while preserving accurate totals

### What Changed
- The profile endpoint now returns up to 20 doubts and replies by default, with a configurable limit from 1 to 100
- Activities are shown with the newest doubts and replies first
- Total doubt and reply counts remain accurate even when only a limited activity list is returned

### Impact
`✅ Faster profile loading for users with many activities`
`✅ Accurate activity totals`
`✅ Newest profile activity shown first`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
