### PR TITLE
fix(notifications): broadcast SSE notifications across server instances

### DIFF
--- a/src/lib/notifications/realtime.ts
+++ b/src/lib/notifications/realtime.ts
@@ -1,3 +1,5 @@
+import { Redis } from "@upstash/redis";
+
 export type NotificationRecord = {
     id: number;
     userEmail: string;
@@ -12,6 +14,7 @@ export type NotificationRecord = {
 type NotificationSubscriber = {
     controller: ReadableStreamDefaultController<Uint8Array>;
     encoder: TextEncoder;
+    redisUnsubscribe?: () => Promise<void>;
 };
 
 type SubscriberBucket = Set<NotificationSubscriber>;
@@ -24,9 +27,135 @@ let heartbeatInterval: ReturnType<typeof setInterval> | null = null;
 
 const encoder = new TextEncoder();
 
+// ── Redis Pub/Sub (cross-instance notification delivery) ──────────────────
+
+let redisClient: Redis | null | undefined = undefined;
+let redisWarningLogged = false;
+
+const REDIS_CHANNEL_PREFIX = "notifications:";
+
+interface RedisSubscriber<T> {
+    on(event: string, listener: (data: unknown) => void): void;
+    unsubscribe(channels?: string[]): Promise<void>;
+}
+
+type RedisSubscriptionState = {
+    subscriber: RedisSubscriber<NotificationRecord>;
+    refCount: number;
+};
+
+const redisSubscriptions = new Map<string, RedisSubscriptionState>();
+
+function getRedisChannel(userEmail: string): string {
+    return `${REDIS_CHANNEL_PREFIX}${userEmail}`;
+}
+
+function ensureRedisClient(): Redis | null {
+    if (redisClient !== undefined) return redisClient;
+
+    try {
+        if (
+            typeof process === "object" &&
+            process.env?.UPSTASH_REDIS_REST_URL &&
+            process.env?.UPSTASH_REDIS_REST_TOKEN
+        ) {
+            redisClient = Redis.fromEnv();
+        } else {
+            if (!redisWarningLogged) {
+                console.warn(
+                    "\x1b[33m%s\x1b[0m",
+                    `⚠️  WARNING: Upstash Redis is not configured.
+    Real-time notifications will only work within a single server instance.
+    Set UPSTASH_REDIS_REST_URL and UPSTASH_REDIS_REST_TOKEN for cross-instance delivery.`,
+                );
+                redisWarningLogged = true;
+            }
+            redisClient = null;
+        }
+    } catch {
+        redisClient = null;
+    }
+
+    return redisClient;
+}
+
+async function subscribeToRedisChannel(
+    userEmail: string,
+): Promise<() => Promise<void>> {
+    const client = ensureRedisClient();
+    if (!client) return async () => {};
+
+    const existing = redisSubscriptions.get(userEmail);
+    if (existing) {
+        existing.refCount++;
+        const unsub = existing.subscriber.unsubscribe.bind(
+            existing.subscriber,
+        );
+        return async () => {
+            existing.refCount--;
+            if (existing.refCount <= 0) {
+                redisSubscriptions.delete(userEmail);
+                try {
+                    await unsub();
+                } catch {
+                    // Ignore unsubscribe errors
+                }
+            }
+        };
+    }
+
+    try {
+        const channel = getRedisChannel(userEmail);
+        const subscriber = client.subscribe<NotificationRecord>(channel);
+
+        subscriber.on("message", ({ message: notification }) => {
+            const bucket = notificationSubscribers.get(userEmail);
+            if (!bucket || bucket.size === 0) return;
+
+            const payload = encoder.encode(
+                formatEvent("notification", notification),
+            );
+
+            for (const sub of Array.from(bucket)) {
+                try {
+                    sub.controller.enqueue(payload);
+                } catch {
+                    removeSubscriber(userEmail, sub);
+                }
+            }
+        });
+
+        subscriber.on("error", () => {
+            // Subscriber will attempt to reconnect automatically.
+        });
+
+        const state: RedisSubscriptionState = { subscriber, refCount: 1 };
+        redisSubscriptions.set(userEmail, state);
+
+        const unsub = subscriber.unsubscribe.bind(subscriber);
+        return async () => {
+            state.refCount--;
+            if (state.refCount <= 0) {
+                redisSubscriptions.delete(userEmail);
+                try {
+                    await unsub();
+                } catch {
+                    // Ignore
+                }
+            }
+        };
+    } catch {
+        return async () => {};
+    }
+}
+
+// ── Event formatting ─────────────────────────────────────────────────────
+
 function formatEvent(eventName: string, data: unknown) {
     return `event: ${eventName}\ndata: ${JSON.stringify(data)}\n\n`;
 }
+
+// ── Heartbeat ────────────────────────────────────────────────────────────
 
 function startHeartbeat() {
     if (heartbeatInterval) return;
@@ -57,6 +186,11 @@ function removeSubscriber(
     userEmail: string,
     subscriber: NotificationSubscriber,
 ) {
+    if (subscriber.redisUnsubscribe) {
+        subscriber.redisUnsubscribe().catch(() => {});
+        subscriber.redisUnsubscribe = undefined;
+    }
+
     const bucket = notificationSubscribers.get(userEmail);
     if (!bucket) return;
 
@@ -87,16 +221,32 @@ export function subscribeToNotifications(
 
     totalSubscribers++;
 
-    startHeartbeat(); // start the heartbeat func
+    startHeartbeat();
 
     controller.enqueue(
         subscriber.encoder.encode(formatEvent("connected", { userEmail })),
     );
 
+    subscribeToRedisChannel(userEmail).then((unsub) => {
+        subscriber.redisUnsubscribe = unsub;
+    });
+
     return () => removeSubscriber(userEmail, subscriber);
 }
 
 export function publishNotification(notification: NotificationRecord) {
+    const client = ensureRedisClient();
+    if (client) {
+        void client
+            .publish(
+                getRedisChannel(notification.userEmail),
+                JSON.stringify(notification),
+            )
+            .catch(() => {
+                // Redis publish failed; local subscribers still receive the notification
+            });
+    }
+
     const bucket = notificationSubscribers.get(notification.userEmail);
     if (!bucket || bucket.size === 0) return;
 

--- a/src/lib/notifications/realtime.ts
+++ b/src/lib/notifications/realtime.ts
@@ -223,9 +223,14 @@ export function subscribeToNotifications(
 
     startHeartbeat();
 
-    controller.enqueue(
-        subscriber.encoder.encode(formatEvent("connected", { userEmail })),
-    );
+    try {
+        controller.enqueue(
+            subscriber.encoder.encode(formatEvent("connected", { userEmail })),
+        );
+    } catch (error) {
+        removeSubscriber(userEmail, subscriber);
+        throw error;
+    }
 
     subscribeToRedisChannel(userEmail).then((unsub) => {
         const bucket = notificationSubscribers.get(userEmail);
@@ -234,7 +239,7 @@ export function subscribeToNotifications(
         } else {
             subscriber.redisUnsubscribe = unsub;
         }
-    });
+    }).catch(() => {});
 
     return () => removeSubscriber(userEmail, subscriber);
 }
@@ -247,8 +252,11 @@ export function publishNotification(notification: NotificationRecord) {
                 getRedisChannel(notification.userEmail),
                 JSON.stringify(notification),
             )
-            .catch(() => {
-                // Redis publish failed; local subscribers still receive the notification
+            .catch((error) => {
+                console.error(
+                    "Failed to publish notification to Redis",
+                    error,
+                );
             });
     }
 

--- a/src/lib/notifications/realtime.ts
+++ b/src/lib/notifications/realtime.ts
@@ -228,7 +228,12 @@ export function subscribeToNotifications(
     );
 
     subscribeToRedisChannel(userEmail).then((unsub) => {
-        subscriber.redisUnsubscribe = unsub;
+        const bucket = notificationSubscribers.get(userEmail);
+        if (!bucket?.has(subscriber)) {
+            void unsub().catch(() => {});
+        } else {
+            subscriber.redisUnsubscribe = unsub;
+        }
     });
 
     return () => removeSubscriber(userEmail, subscriber);


### PR DESCRIPTION
## **User description**
## Description

This PR fixes the real-time notification system to work correctly in multi-instance and serverless deployments.

Previously, active Server-Sent Events (SSE) subscribers were stored only in an in-memory `Map`. As a result, notifications published on one server instance were only delivered to clients connected to that same instance, causing notifications to fail silently in horizontally scaled deployments.

This PR introduces a distributed notification layer using the project's existing Upstash Redis infrastructure while preserving the existing public API and local delivery behavior.

### Changes

* Added Upstash Redis Pub/Sub integration for cross-instance notification delivery.
* Broadcast notifications across server instances using user-specific Redis channels.
* Added ref-counted Redis subscriptions to avoid duplicate subscriptions for multiple tabs of the same user.
* Ensured proper cleanup of Redis subscriptions when the last SSE connection disconnects.
* Preserved immediate local delivery for subscribers connected to the publishing instance.
* Added graceful fallback to the existing in-memory implementation when Redis is not configured.

## Related Issue

Closes #1061

## Type of Change

* [x] Bug fix (non-breaking change that fixes an issue)
* [ ] New feature (non-breaking change that adds functionality)
* [ ] Documentation update (README, guides, comments)
* [ ] Style / UI change (no logic change)
* [ ] Code refactor (no behavior change)
* [ ] Test addition or update
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## How Has This Been Tested?

* [x] Tested locally with `npm run dev`
* [ ] Verified on mobile viewport (375px)
* [x] Verified on desktop viewport (1440px)

Additionally verified:

* Existing single-instance notification flow remains unchanged.
* TypeScript compilation passes (`tsc --noEmit`).
* ESLint passes for the modified file.
* Redis subscription cleanup occurs when SSE clients disconnect.
* Graceful fallback works when Redis is unavailable.

## Checklist

* [x] I have tested my changes locally (`npm run dev`)
* [x] My code follows the existing code style (TypeScript, Tailwind, no `any` types)
* [x] I have not introduced unrelated changes (each PR should address one issue)
* [x] I have added comments where necessary
* [x] My branch is up to date with `main`
* [x] I have linked the related issue above
* [ ] Screenshots are included (if this is a UI change)


___

## **CodeAnt-AI Description**
Deliver real-time notifications across server instances

### What Changed
- Notifications now reach users connected to any server instance when Upstash Redis is configured
- Multiple tabs for the same user share a Redis subscription, and it is removed after the last connection closes
- Single-instance delivery continues to work when Redis is unavailable or a Redis publish fails

### Impact
`✅ Notifications arrive across server instances`
`✅ Reliable multi-tab notification delivery`
`✅ Notifications continue working without Redis`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional Redis Pub/Sub support for real-time notifications across multiple server instances.
  * Notifications can now sync across instances while keeping live in-app updates via streaming connections.

* **Bug Fixes**
  * Improved cleanup of notification subscriptions when live connections are closed.
  * Enhanced streaming connection behavior with immediate heartbeat and initial “connected” status events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->