### PR TITLE
fix: enforce allowedEmailDomains check on token-based invite join

### DIFF
--- a/src/app/api/invites/[token]/join/route.ts
+++ b/src/app/api/invites/[token]/join/route.ts
@@ -49,6 +49,7 @@ export async function POST(
         classroomName: classroomsTable.name,
         university: classroomsTable.university,
         year: classroomsTable.year,
+        allowedEmailDomains: classroomsTable.allowedEmailDomains,
       })
       .from(classroomInvitesTable)
       .innerJoin(
@@ -76,6 +77,16 @@ export async function POST(
         { error: "This invite link has expired" },
         { status: 410 },
       );
+    }
+
+    // 2b. Check email domain restrictions if set (mirrors rooms/join/route.ts)
+    if (inviteData.allowedEmailDomains && inviteData.allowedEmailDomains.length > 0) {
+      const emailDomain = email.split('@')[1]?.toLowerCase();
+      if (!emailDomain || !inviteData.allowedEmailDomains.some(d => emailDomain === d.toLowerCase())) {
+        return NextResponse.json({
+          error: `Only email addresses from ${inviteData.allowedEmailDomains.join(', ')} domains can join this classroom`
+        }, { status: 403 });
+      }
     }
 
     // IMPORTANT: the neon-http driver Drizzle is configured with (see


### PR DESCRIPTION
## **User description**
## Description
Adds the missing `allowedEmailDomains` check to the token-based invite link join route (`POST /api/invites/[token]/join`). Previously this check only existed on the invite-code join path (`POST /api/rooms/join`); any authenticated user could bypass a classroom's domain restriction by joining via a shareable invite link instead of a code.

The fix adds `allowedEmailDomains` to the existing `classroomsTable` join in the invite lookup query (no extra DB round trip), then rejects the request with a `403` if the joining user's email domain isn't in the allowed list — mirroring the exact logic already used in `rooms/join/route.ts`. The check runs after the revoked/expired checks but **before** the atomic slot-claiming CTE, so a rejected join never consumes a `maxUses` slot.

## Related Issue
Closes #960 

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Screenshots (if UI change)
N/A — backend authorization fix, no UI change.

## How Has This Been Tested?
- [x] Tested locally with `npm run dev`
- [ ] Verified on mobile viewport (375px)
- [ ] Verified on desktop viewport (1440px)

Manual test steps:
1. Created a classroom and set `allowedEmailDomains` to a specific domain.
2. Generated a shareable invite link via `POST /api/classrooms/[id]/invites`.
3. Attempted `POST /api/invites/[token]/join` with a user email outside the allowed domain → confirmed `403` with the expected error message, no membership created.
4. Attempted the same with a user email inside the allowed domain → confirmed success and membership created as before.
5. Re-verified revoked/expired/usage-limit responses on this route are unaffected by the new check's placement.

## Checklist
- [x] I have tested my changes locally (`npm run dev`)
- [x] My code follows the existing code style (TypeScript, Tailwind, no `any` types)
- [x] I have not introduced unrelated changes (each PR should address one issue)
- [x] I have added comments where necessary
- [x] My branch is up to date with `main`
- [x] I have linked the related issue above
- [ ] Screenshots are included (if this is a UI change)


___

## **CodeAnt-AI Description**
Prevent invite links from bypassing classroom email-domain restrictions

### What Changed
- Token-based invite links now reject users whose email domain is not allowed for the classroom
- Allowed-domain checks return a clear error and prevent membership creation
- Rejected users do not consume a limited-use invite slot
- Existing behavior for permitted domains, revoked links, and expired links remains unchanged

### Impact
`✅ Blocked unauthorized invite-link joins`
`✅ Protected limited-use invite slots`
`✅ Clearer domain restriction errors`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added email-domain restrictions for classroom invitations.
  * Users can join only when their email domain matches the classroom’s configured allowed domains.
  * Unauthorized attempts receive a clear error message listing the permitted domains.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->