### PR TITLE
fix: hide Mark Solved button for teachers when no solution reply exists (#1089)

### DIFF
--- a/src/__tests__/api/doubts-scoped-likes.test.ts
+++ b/src/__tests__/api/doubts-scoped-likes.test.ts
@@ -16,7 +16,7 @@ jest.mock('@clerk/nextjs/server', () => ({
 
 jest.mock('@/configs/schema', () => ({
     doubtsTable: { id: 'doubts.id', deletedAt: 'doubts.deletedAt', classroomId: 'doubts.classroomId', type: 'doubts.type', subject: 'doubts.subject', content: 'doubts.content', userEmail: 'doubts.userEmail', isSolved: 'doubts.isSolved', isPinned: 'doubts.isPinned', likes: 'doubts.likes', createdAt: 'doubts.createdAt' },
-    repliesTable: { doubtId: 'replies.doubtId' },
+    repliesTable: { doubtId: 'replies.doubtId', type: 'replies.type' },
     likesTable: { doubtId: 'likes.doubtId', userEmail: 'likes.userEmail' },
     bookmarksTable: { doubtId: 'bookmarks.doubtId', userEmail: 'bookmarks.userEmail' },
     doubtTagsTable: { doubtId: 'doubtTags.doubtId', tagId: 'doubtTags.tagId' },
@@ -73,8 +73,8 @@ jest.mock('@/lib/anonymity/anonymity', () => ({ toPublicDoubt: (d: any) => ({ ..
 import { GET } from '@/app/api/doubts/route';
 
 const pageOfDoubts = [
-    { id: 1, subject: 'Physics', content: 'What is speed of light?', createdAt: '2026-01-01T00:00:00.000Z', likes: 4, isSolved: 'unsolved', isPinned: false, classroomId: null, type: 'community', userEmail: 'student@example.com', hasLiked: true, hasBookmarked: false },
-    { id: 2, subject: 'Chemistry', content: 'What is pH?', createdAt: '2026-01-02T00:00:00.000Z', likes: 10, isSolved: 'solved', isPinned: false, classroomId: null, type: 'community', userEmail: 'other@example.com', hasLiked: false, hasBookmarked: true },
+    { id: 1, subject: 'Physics', content: 'What is speed of light?', createdAt: '2026-01-01T00:00:00.000Z', likes: 4, isSolved: 'unsolved', isPinned: false, classroomId: null, type: 'community', userEmail: 'student@example.com', hasLiked: true, hasBookmarked: false, hasSolutionReply: false },
+    { id: 2, subject: 'Chemistry', content: 'What is pH?', createdAt: '2026-01-02T00:00:00.000Z', likes: 10, isSolved: 'solved', isPinned: false, classroomId: null, type: 'community', userEmail: 'other@example.com', hasLiked: false, hasBookmarked: true, hasSolutionReply: true },
 ];
 
 describe('Doubts GET endpoint — inline EXISTS for likes/bookmarks (PR #725)', () => {
@@ -134,5 +134,27 @@ describe('Doubts GET endpoint — inline EXISTS for likes/bookmarks (PR #725)', 
         // Anonymous users get false for both fields via the sql`false` fallback
         expect(json.doubts[0].hasLiked).toBe(false);
         expect(json.doubts[0].hasBookmarked).toBe(false);
+    });
+
+    it('returns hasSolutionReply inline from the main query (issue #1089)', async () => {
+        selectQueue.push(
+            [{ count: 2 }],
+            pageOfDoubts,
+            [],
+        );
+
+        const res = await GET(new Request('http://localhost/api/doubts?subject=Physics'));
+        const json = await res.json();
+
+        expect(res.status).toBe(200);
+        // The flag is a property of the doubt (not the viewer) and must reach the
+        // client so the UI can gate the teacher "Mark Solved" action on it.
+        expect(json.doubts[0].hasSolutionReply).toBe(false);
+        expect(json.doubts[1].hasSolutionReply).toBe(true);
+
+        const mainSelectCall = mockSelectCalls.find(
+            (call) => call[0] && 'hasSolutionReply' in call[0]
+        );
+        expect(mainSelectCall).toBeDefined();
     });
 });

--- a/src/__tests__/components/DoubtCard.test.tsx
+++ b/src/__tests__/components/DoubtCard.test.tsx
@@ -20,6 +20,12 @@ global.fetch = jest.fn(() =>
     } as any)
 ) as jest.Mock;
 
+global.EventSource = jest.fn(() => ({
+    onmessage: null,
+    onerror: null,
+    close: jest.fn(),
+})) as unknown as typeof EventSource;
+
 const mockDoubt = {
     id: 1,
     author: 'Student_7F3Q2',
@@ -55,5 +61,20 @@ describe('DoubtCard Component', () => {
         const likeButton = screen.getByRole('button', { name: /like this doubt/i });
         fireEvent.click(likeButton);
         await waitFor(() => expect(global.fetch).toHaveBeenCalled());
+    });
+
+    it('shows the Mark Solved button to the doubt owner', () => {
+        render(<DoubtCard doubt={{ ...mockDoubt, isOwnPost: true }} />);
+        expect(screen.getByRole('button', { name: /mark solved/i })).toBeInTheDocument();
+    });
+
+    it('hides the Mark Solved button from teachers when no solution reply exists', () => {
+        render(<DoubtCard doubt={mockDoubt} role="teacher" />);
+        expect(screen.queryByRole('button', { name: /mark solved/i })).not.toBeInTheDocument();
+    });
+
+    it('shows the Mark Solved button to teachers when a solution reply exists', () => {
+        render(<DoubtCard doubt={{ ...mockDoubt, hasSolutionReply: true }} role="teacher" />);
+        expect(screen.getByRole('button', { name: /mark solved/i })).toBeInTheDocument();
     });
 });

--- a/src/app/api/doubts/route.ts
+++ b/src/app/api/doubts/route.ts
@@ -196,6 +196,12 @@ export async function GET(req: Request) {
         : sql<boolean>`false`
     ).mapWith(Boolean);
 
+    // Whether at least one solution-typed reply exists. Mirrors the backend rule
+    // in /api/doubts/action/[id] that a non-owner teacher can only mark a doubt
+    // as solved when an official solution reply has been posted, so the UI can
+    // avoid offering an action the API would reject (issue #1089).
+    const hasSolutionReplySql = sql<boolean>`EXISTS (SELECT 1 FROM ${repliesTable} WHERE ${repliesTable.doubtId} = ${doubtsTable.id} AND ${repliesTable.type} = 'solution')`.mapWith(Boolean);
+
     const [totalCountRow] = await db
       .select({ count: count() })
       .from(doubtsTable)
@@ -208,6 +214,7 @@ export async function GET(req: Request) {
         replyCount: replyCountSql,
         hasLiked: hasLikedSql,
         hasBookmarked: hasBookmarkedSql,
+        hasSolutionReply: hasSolutionReplySql,
       })
       .from(doubtsTable);
 

--- a/src/components/classroom/DoubtCard.tsx
+++ b/src/components/classroom/DoubtCard.tsx
@@ -44,6 +44,7 @@ interface DoubtCardProps {
         hasBookmarked?: boolean;
         hasLiked?: boolean;
         replyCount?: number;
+        hasSolutionReply?: boolean;
     };
     onUpdate?: () => void;
     onViewAISolution?: (
@@ -52,6 +53,7 @@ interface DoubtCardProps {
             hasBookmarked?: boolean;
             hasLiked?: boolean;
             replyCount?: number;
+            hasSolutionReply?: boolean;
         },
     ) => void;
     role?: string;
@@ -417,7 +419,7 @@ export default function DoubtCard({ doubt, onUpdate, onViewAISolution, role, ope
                                 </DropdownMenuContent>
                             </DropdownMenu>
 
-                            {((isOwner && doubt.type !== 'ai') || isTeacher) && doubt.isSolved !== "solved" && (
+                            {((isOwner && doubt.type !== 'ai') || (isTeacher && (isOwner || doubt.hasSolutionReply))) && doubt.isSolved !== "solved" && (
                                 <button
                                     onClick={() => handleAction("solve")}
                                     disabled={isSolving}


### PR DESCRIPTION
## **User description**
## What changed

Hide the "Mark Solved" action for teachers when the doubt has no solution-typed reply, aligning the UI with the backend rule in `/api/doubts/action/[id]` that already rejects the action in that case.

### Root cause
The backend only lets a non-owner teacher mark a doubt as solved once a solution reply exists (error: "Teacher can only mark as solved if at least one official solution exists..."). The frontend rendered the button based on `role === 'teacher'` + `doubt.isSolved` alone, so teachers were offered an action the API would reject.

### Fix
- `src/app/api/doubts/route.ts`: add `hasSolutionReply` to the GET list query via an inline `EXISTS` subquery (same pattern as `hasLiked` / `hasBookmarked`). No extra round-trip.
- `src/components/classroom/DoubtCard.tsx`: gate the button on `isTeacher && (isOwner || doubt.hasSolutionReply)`.
- `toPublicDoubt` preserves the field during serialization; no shared type changes required (consistent with existing derived flags).

### Tests
- Component: owner still sees the action; teacher hidden when no solution reply; teacher shown when one exists.
- API: asserts `hasSolutionReply` is returned inline from the main query.
- Also adds a local `EventSource` mock to `DoubtCard.test.tsx` (the suite was already failing at HEAD with `EventSource is not defined` because `DoubtRepliesModal` always mounts and `usePresence` opens an SSE connection).

### Validation
- `npm run lint` clean
- `npx tsc --noEmit` clean
- Targeted suites pass (8/8)

Fixes #1089


___

## **CodeAnt-AI Description**
Prevent teachers from starting unsupported “Mark Solved” actions

### What Changed
- Teachers only see “Mark Solved” when the doubt has an official solution reply; doubt owners can still use the action.
- Doubt data now includes whether a solution reply exists so the interface can apply this rule.
- Added coverage for owner, teacher-without-solution, and teacher-with-solution cases, plus API response validation.

### Impact
`✅ Fewer rejected Mark Solved actions`
`✅ Clearer teacher action availability`
`✅ Consistent UI and backend solving rules`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added solution-status information to doubts.
  * Teachers can now mark doubts as solved when they own them or when a solution reply exists.

* **Bug Fixes**
  * Updated doubt cards to correctly display the “Mark Solved” action based on ownership and available solutions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->