### PR TITLE
fix(marketing): correct testimonial CTA route from /auth/sign-up to /sign-up

### DIFF
--- a/src/components/marketing/TestimonialsMarquee.tsx
+++ b/src/components/marketing/TestimonialsMarquee.tsx
@@ -102,7 +102,7 @@ export default function TestimonialsMarquee({
           </p>
 
           <Link
-            href="/auth/sign-up"
+            href="/sign-up"
             className="inline-flex items-center justify-center px-6 py-3 rounded-xl bg-blue-600 text-white hover:bg-blue-700 transition-colors font-medium"
           >
             Get Started with DoubtDesk →


### PR DESCRIPTION
Updated the testimonial marquee CTA link from `/auth/sign-up` to `/sign-up`, matching the actual Clerk sign-up page route at `src/app/(auth)/sign-up/[[...sign-up]]/page.tsx`. The `(auth)` route group is not part of the public URL path.

Fixes #1173

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the testimonials section’s call-to-action link to direct visitors to the correct sign-up page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->