### PR TITLE
fix(teacher): authorize insights via active membership instead of teacherEmail

### DIFF
--- a/src/app/api/teacher/insights/route.ts
+++ b/src/app/api/teacher/insights/route.ts
@@ -2,11 +2,13 @@
 export const dynamic = "force-dynamic";
 
 import { db } from "@/configs/db";
-import { classroomsTable, doubtsTable } from "@/configs/schema";
+import { doubtsTable } from "@/configs/schema";
 import { and, eq, sql } from "drizzle-orm";
 import { currentUser } from "@clerk/nextjs/server";
 import { NextResponse } from "next/server";
 import { generateRecommendations, WeakTopic } from "@/lib/ai/recommendations";
+import { requireTeacher } from "@/lib/auth/membership-guard";
+import { ApiError } from "@/lib/errors/error-handler";
 
 export async function GET(req: Request) {
     try {
@@ -28,14 +30,10 @@ export async function GET(req: Request) {
 
         const classroomId = Number(classroomIdStr);
 
-        const [classroom] = await db
-            .select({ id: classroomsTable.id })
-            .from(classroomsTable)
-            .where(and(eq(classroomsTable.id, classroomId), eq(classroomsTable.teacherEmail, email)));
-
-        if (!classroom) {
-            return NextResponse.json({ error: "Access denied to this classroom" }, { status: 403 });
-        }
+        // Authorization: verify the caller is an active teacher/owner member of the
+        // classroom via membershipsTable (not just a potentially stale teacherEmail
+        // field on the classrooms table). See requireTeacher / requireMembership.
+        await requireTeacher(email, classroomId);
 
         const classroomFilter = eq(doubtsTable.classroomId, classroomId);
 
@@ -143,6 +141,9 @@ export async function GET(req: Request) {
 
     } catch (error) {
         console.error("Teacher Insights failed:", error);
+        if (error instanceof ApiError) {
+            return NextResponse.json({ error: error.message }, { status: error.statusCode });
+        }
         return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
     }
 }


### PR DESCRIPTION
## **User description**
## Description
Fixes the authorization check on `GET /api/teacher/insights`. Previously the route only verified the calling user against the potentially stale `classroomsTable.teacherEmail` field, which blocked legitimate teacher/owner members who hold their role through `membershipsTable` and relied on an email that could become outdated. The route now authorizes via `requireTeacher(email, classroomId)` (the same active-membership utility already used by `/api/teacher/analytics`, and backed by `requireMembership` checking `membershipsTable`). `ApiError`s are surfaced with their proper status instead of being swallowed into a generic `500`.

## Related Issue
Closes #1107

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Documentation update (README, guides, comments)
- [ ] Style / UI change (no logic change)
- [ ] Code refactor (no behavior change)
- [ ] Test addition or update
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## How Has This Been Tested?
- [x] Tested locally with `npm run dev`
- [x] Ran `jest src/__tests__/api/teacher-insights.test.ts` (all 5 tests pass)
- [ ] Verified on mobile viewport (375px)
- [ ] Verified on desktop viewport (1440px)

## Checklist
- [x] I have tested my changes locally (`npm run dev`)
- [x] My code follows the existing code style (TypeScript, Tailwind, no `any` types)
- [x] I have not introduced unrelated changes (each PR should address one issue)
- [x] I have added comments where necessary
- [x] My branch is up to date with `main`
- [x] I have linked the related issue above
- [ ] Screenshots are included (if this is a UI change)


___

## **CodeAnt-AI Description**
Authorize teacher insights using active classroom membership

### What Changed
- Teacher insights access is now granted to active teacher or owner members of the classroom, even when the stored teacher email is outdated
- Authorization errors now return their appropriate status and message instead of being reported as a generic server error
- Existing unauthorized, missing, and invalid classroom ID responses remain unchanged

### Impact
`✅ Fewer valid teachers blocked from classroom insights`
`✅ Accurate access control for classroom members`
`✅ Clearer authorization error responses`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
