### PR TITLE
fix(csrf): reject null Origin header on state-changing API requests

### DIFF
--- a/src/middleware.tsx
+++ b/src/middleware.tsx
@@ -134,6 +134,9 @@ export default clerkMiddleware(async (auth, req) => {
     // with the correct value, so they pass through. Requests with no Origin
     // (direct API calls, older browsers) are allowed as a safe default since
     // they cannot be cross-origin form submissions without an Origin header.
+    // The literal "null" origin (sent by sandboxed iframes, file:// and
+    // data: URIs, and certain browser extensions) is NOT a valid application
+    // origin and is rejected explicitly.
     const APP_ORIGIN =
         process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
     const STATE_CHANGING_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
@@ -143,7 +146,7 @@ export default clerkMiddleware(async (auth, req) => {
         STATE_CHANGING_METHODS.has(req.method)
     ) {
         const origin = req.headers.get('origin');
-        if (origin && origin !== APP_ORIGIN) {
+        if (origin === 'null' || (origin && origin !== APP_ORIGIN)) {
             return new NextResponse(
                 JSON.stringify({ error: 'CSRF validation failed' }),
                 { status: 403, headers: { 'Content-Type': 'application/json' } },


### PR DESCRIPTION
## **User description**
## Description
Closes the CSRF bypass in the middleware's origin check. Previously, state-changing API requests whose `Origin` header was missing or the literal value `null` (sent by sandboxed iframes, `file://` and `data:` URIs, and certain browser extensions) skipped the origin check entirely and were allowed through. The middleware now explicitly rejects `Origin: null` on `POST`/`PUT`/`PATCH`/`DELETE` `/api` requests with a `403`, since a `null` origin cannot be validated against `APP_ORIGIN`. Requests with no `Origin` header (direct API calls, non-browser clients) remain allowed, preserving the existing safe-default behavior.

## Related Issue
Closes #1106

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Documentation update (README, guides, comments)
- [ ] Style / UI change (no logic change)
- [ ] Code refactor (no behavior change)
- [ ] Test addition or update
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## How Has This Been Tested?
- [x] Tested locally with `npm run dev`
- [x] Ran `jest src/__tests__/middleware` (all 10 tests pass)
- [ ] Verified on mobile viewport (375px)
- [ ] Verified on desktop viewport (1440px)

## Checklist
- [x] I have tested my changes locally (`npm run dev`)
- [x] My code follows the existing code style (TypeScript, Tailwind, no `any` types)
- [x] I have not introduced unrelated changes (each PR should address one issue)
- [x] I have added comments where necessary
- [x] My branch is up to date with `main`
- [x] I have linked the related issue above
- [ ] Screenshots are included (if this is a UI change)


___

## **CodeAnt-AI Description**
Reject untrusted null origins during CSRF validation

### What Changed
- State-changing `/api` requests with an `Origin: null` header now receive a 403 response
- Requests from origins other than the configured application origin remain blocked
- Requests without an `Origin` header continue to be allowed for direct API clients

### Impact
`✅ Blocks null-origin CSRF requests`
`✅ Prevents unauthorized state changes from sandboxed or local browser contexts`
`✅ Preserves direct API client access`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
