### PR TITLE
fix(doubts): make pin count check and update atomic via FOR UPDATE transaction

### DIFF
--- a/src/app/api/doubts/[id]/pin/route.ts
+++ b/src/app/api/doubts/[id]/pin/route.ts
@@ -4,7 +4,7 @@ import {
     classroomsTable,
     membershipsTable,
     } from "@/configs/schema";
-import { and, eq, count, isNull } from "drizzle-orm";
+import { and, eq, count, isNull, sql } from "drizzle-orm";
 import { canTeach } from "@/lib/auth/membership-guard";
 import { NextResponse } from "next/server";
 import { currentUser } from "@clerk/nextjs/server";
@@ -45,19 +45,42 @@ export async function POST(req: Request, { params }: { params: Promise<{ id: str
             );
         }
             
-        // Check pin count
-        const [pinCount] = await db.select({ value: count() })
-            .from(doubtsTable)
-            .where(and(eq(doubtsTable.classroomId, doubt.classroomId), eq(doubtsTable.isPinned, true)));
+        // Check pin count and pin the doubt atomically. Locking the classroom
+        // row (SELECT ... FOR UPDATE) serializes concurrent pin requests for
+        // the same classroom, preventing a TOCTOU race where two requests both
+        // read a count below 3 and both proceed to exceed the 3-pin limit.
+        const result = await db.transaction(async (tx) => {
+            const locked = await tx.execute(
+                sql`SELECT ${classroomsTable.id} FROM ${classroomsTable} WHERE ${classroomsTable.id} = ${doubt.classroomId} FOR UPDATE`
+            );
 
-        if (pinCount.value >= 3) {
-            return NextResponse.json({ error: "Maximum of 3 pinned doubts allowed per classroom" }, { status: 400 });
+            if (!locked.rows.length) {
+                return null;
+            }
+
+            const [pinCount] = await tx.select({ value: count() })
+                .from(doubtsTable)
+                .where(and(eq(doubtsTable.classroomId, doubt.classroomId), eq(doubtsTable.isPinned, true)));
+
+            if (pinCount.value >= 3) {
+                return { error: "Maximum of 3 pinned doubts allowed per classroom", status: 400 };
+            }
+
+            const updated = await tx.update(doubtsTable)
+                .set({ isPinned: true })
+                .where(eq(doubtsTable.id, doubtId))
+                .returning();
+
+            return { updated };
+        });
+
+        if (!result) {
+            return NextResponse.json({ error: "Classroom not found" }, { status: 404 });
         }
 
-        const updated = await db.update(doubtsTable)
-            .set({ isPinned: true })
-            .where(eq(doubtsTable.id, doubtId))
-            .returning();
+        if ('error' in result) {
+            return NextResponse.json({ error: result.error }, { status: result.status });
+        }
 
         void auditLog({
             actorEmail: email,
@@ -69,7 +92,7 @@ export async function POST(req: Request, { params }: { params: Promise<{ id: str
             },
         });
 
-        return NextResponse.json(updated[0]);
+        return NextResponse.json(result.updated[0]);
     } catch (error) {
         console.error("Error pinning doubt:", error);
         return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });


### PR DESCRIPTION
## **User description**
## Description
Fixes the TOCTOU (time-of-check-time-of-use) race condition in `POST /api/doubts/[id]/pin`. Previously the pin-count check (SELECT COUNT) and the `isPinned` UPDATE ran as two separate, non-atomic operations, so two concurrent requests could both read a count below 3 and both proceed, resulting in more than 3 pinned doubts per classroom. The count check and the update now run inside a single `db.transaction`, and the classroom row is locked with `SELECT ... FOR UPDATE`. Locking the classroom row serializes concurrent pin requests for that classroom (including the zero-pinned case, which `SELECT COUNT ... FOR UPDATE` would not lock), guaranteeing the 3-pin limit is never exceeded.

## Related Issue
Closes #1105

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Documentation update (README, guides, comments)
- [ ] Style / UI change (no logic change)
- [ ] Code refactor (no behavior change)
- [ ] Test addition or update
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## How Has This Been Tested?
- [x] Tested locally with `npm run dev`
- [ ] Verified on mobile viewport (375px)
- [ ] Verified on desktop viewport (1440px)

## Checklist
- [x] I have tested my changes locally (`npm run dev`)
- [x] My code follows the existing code style (TypeScript, Tailwind, no `any` types)
- [x] I have not introduced unrelated changes (each PR should address one issue)
- [x] I have added comments where necessary
- [x] My branch is up to date with `main`
- [x] I have linked the related issue above
- [ ] Screenshots are included (if this is a UI change)


___

## **CodeAnt-AI Description**
Enforce the three-pinned-doubts limit during concurrent pin requests

### What Changed
- Pin-count checks and doubt updates now happen as one serialized operation per classroom
- Concurrent requests can no longer bypass the three-pinned-doubts limit
- Requests for a missing classroom return a clear not-found response

### Impact
`✅ Never more than 3 pinned doubts per classroom`
`✅ Consistent results for simultaneous pin requests`
`✅ Clearer missing-classroom errors`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
