### PR TITLE
fix(ratelimit): check mock limiter limit before incrementing counter

### DIFF
--- a/src/lib/ratelimit/ratelimit.ts
+++ b/src/lib/ratelimit/ratelimit.ts
@@ -140,13 +140,21 @@ if (isRedisConfigured) {
         record.reset = now + windowMs;
       }
 
+      // Check the limit against the current (pre-increment) count first, so the
+      // first allowed request reports `remaining === limit` and the (limit+1)-th
+      // request is the first to be rejected. Previously the counter was
+      // incremented before the check, silently allowing only `limit - 1`
+      // successful requests.
+      const success = record.count < limit;
+      const remaining = Math.max(0, limit - record.count);
+
       record.count++;
       memoryMap.set(identifier, record);
 
       return {
-        success: record.count <= limit,
+        success,
         limit,
-        remaining: Math.max(0, limit - record.count),
+        remaining,
         reset: record.reset,
       };
     },


### PR DESCRIPTION
## **User description**
## Description
Fixes an off-by-one bug in the in-memory mock rate limiter used when UPSTASH_REDIS is not configured. The mock limiter incremented the request counter *before* evaluating the limit and `remaining` value, so a user was effectively allowed only `limit - 1` successful requests and the first response reported `remaining: limit - 1` instead of `remaining: limit`. The limit is now checked against the pre-increment count before the counter is advanced, so the first allowed request reports `remaining: limit`, and the `(limit+1)`-th request is the first to be rejected — matching the intended semantics.

## Related Issue
Closes #1103

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Documentation update (README, guides, comments)
- [ ] Style / UI change (no logic change)
- [ ] Code refactor (no behavior change)
- [ ] Test addition or update
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## How Has This Been Tested?
- [x] Tested locally with `npm run dev`
- [ ] Verified on mobile viewport (375px)
- [ ] Verified on desktop viewport (1440px)

## Checklist
- [x] I have tested my changes locally (`npm run dev`)
- [x] My code follows the existing code style (TypeScript, Tailwind, no `any` types)
- [x] I have not introduced unrelated changes (each PR should address one issue)
- [x] I have added comments where necessary
- [x] My branch is up to date with `main`
- [x] I have linked the related issue above
- [ ] Screenshots are included (if this is a UI change)


___

## **CodeAnt-AI Description**
Correct mock rate-limit counts and request allowance

### What Changed
- The first request now reports the full number of remaining requests
- Users can make exactly the configured number of successful requests before the next request is rejected
- Rate-limit behavior resets correctly when the time window expires

### Impact
`✅ Accurate remaining-request counts`
`✅ Fewer prematurely rejected requests`
`✅ Consistent mock rate-limit behavior`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
