### PR TITLE
fix(replies): clear solvedReplyId when pinned solution reply is deleted

### DIFF
--- a/src/__tests__/api/replies-action.test.ts
+++ b/src/__tests__/api/replies-action.test.ts
@@ -30,6 +30,7 @@ jest.mock('@/configs/db', () => ({
                     })),
                 })),
             })),
+            transaction: jest.fn().mockImplementation(async (callback) => callback(db)),
         };
 
         (globalThis as any).__repliesActionDbMock = db;

--- a/src/app/api/replies/action/[id]/route.ts
+++ b/src/app/api/replies/action/[id]/route.ts
@@ -14,6 +14,7 @@ import { parseAndValidateRequest } from "@/lib/validations/validate";
 import { updateReplyActionSchema } from "@/lib/validations/reply";
 import { auditLog, AUDIT_ACTIONS } from "@/lib/audit/audit";
 import { canTeach } from "@/lib/auth/membership-guard";
+import { DOUBT_STATUS } from "@/lib/doubts/doubtStatus";
 
 export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
     try {
@@ -156,7 +157,26 @@ export async function DELETE(req: NextRequest, { params }: { params: Promise<{ i
             return NextResponse.json({ error: "Forbidden: not allowed to delete this reply" }, { status: 403 });
         }
 
-        await db.delete(repliesTable).where(eq(repliesTable.id, replyId));
+        // Delete the reply and, if it was pinned as a doubt's official solution,
+        // clear that reference (and reset the doubt status) so doubts never hold
+        // a dangling solvedReplyId pointing at a deleted row. Done atomically.
+        await db.transaction(async (tx) => {
+            await tx.delete(repliesTable).where(eq(repliesTable.id, replyId));
+
+            if (reply.doubtId) {
+                await tx.update(doubtsTable)
+                    .set({
+                        solvedReplyId: null,
+                        isSolved: DOUBT_STATUS.UNSOLVED,
+                    })
+                    .where(
+                        and(
+                            eq(doubtsTable.id, reply.doubtId),
+                            eq(doubtsTable.solvedReplyId, replyId)
+                        )
+                    );
+            }
+        });
 
         void auditLog({
             actorEmail: email,


### PR DESCRIPTION
## **User description**
## Description
Fixes a dangling reference when a reply that is pinned as a doubt's official solution (`doubtsTable.solvedReplyId`) is deleted. `DELETE /api/replies/action/[id]` performed a hard `db.delete()` with no cleanup, so the doubt kept pointing at a non-existent reply row, breaking any UI that renders the "official solution". The delete now runs inside a transaction that, when the deleted reply matches a doubt's `solvedReplyId`, clears the reference (`solvedReplyId: null`) and resets the doubt status to `unsolved`, so doubts never hold a dangling pointer. The existing test mock was updated to support `db.transaction`.

## Related Issue
Closes #1102

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Documentation update (README, guides, comments)
- [ ] Style / UI change (no logic change)
- [ ] Code refactor (no behavior change)
- [ ] Test addition or update
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## How Has This Been Tested?
- [x] Tested locally with `npm run dev`
- [x] Ran `jest src/__tests__/api/replies-action.test.ts` (all 4 tests pass)
- [ ] Verified on mobile viewport (375px)
- [ ] Verified on desktop viewport (1440px)

## Checklist
- [x] I have tested my changes locally (`npm run dev`)
- [x] My code follows the existing code style (TypeScript, Tailwind, no `any` types)
- [x] I have not introduced unrelated changes (each PR should address one issue)
- [x] I have added comments where necessary
- [x] My branch is up to date with `main`
- [x] I have linked the related issue above
- [ ] Screenshots are included (if this is a UI change)


___

## **CodeAnt-AI Description**
Keep doubts consistent when their pinned solution reply is deleted

### What Changed
- Deleting a reply that is pinned as a doubt’s official solution now removes that reference
- The doubt is reset to unsolved after its pinned solution is deleted
- Reply deletion and doubt cleanup happen together, preventing broken official-solution links

### Impact
`✅ No dangling official-solution references`
`✅ Correct unsolved status after solution deletion`
`✅ Consistent doubt data after reply removal`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
