### PR TITLE
fix(bookmarks): anonymize doubts through toPublicDoubt

### DIFF
--- a/src/__tests__/api/bookmarks.test.ts
+++ b/src/__tests__/api/bookmarks.test.ts
@@ -1,0 +1,235 @@
+/**
+ * Unit test for GET /api/bookmarks: verifying that bookmarked doubts pass
+ * through toPublicDoubt so author emails and internal fields are never leaked.
+ * Addresses issue #1101 — privacy leak in bookmarks endpoint.
+ */
+import { GET } from '@/app/api/bookmarks/route';
+import { currentUser } from '@clerk/nextjs/server';
+import { getAnonymousHandle } from '@/lib/anonymity/anonymity';
+
+jest.mock('@clerk/nextjs/server', () => ({
+    currentUser: jest.fn(),
+}));
+
+jest.mock('next/server', () => ({
+    NextResponse: {
+        json: jest.fn((body: any, init?: { status?: number }) => ({
+            status: init?.status ?? 200,
+            json: async () => body,
+        })),
+    },
+}));
+
+jest.mock('@/lib/errors/error-handler', () => ({
+    buildErrorResponse: jest.fn().mockReturnValue({ status: 500, body: { error: 'Internal Server Error' } }),
+    errorResponse: jest.fn((message: string, status = 500) => ({
+        status,
+        json: async () => ({ error: message }),
+    })),
+    ApiError: class ApiError extends Error {
+        constructor(public statusCode: number, message: string) {
+            super(message);
+        }
+    },
+}));
+
+jest.mock('@/lib/utils/utils', () => ({
+    parsePositiveInt: jest.fn((val: string, fallback: number) => {
+        const n = parseInt(val, 10);
+        return isNaN(n) ? fallback : n;
+    }),
+}));
+
+// Queue of results returned by successive db.select().from().where().* chains.
+const selectResultQueue: any[] = [];
+
+const createQueryMock = (data: any) => {
+    const chain: any = {
+        from: () => chain,
+        where: () => chain,
+        limit: () => chain,
+        offset: () => chain,
+        orderBy: () => chain,
+        groupBy: () => chain,
+        select: jest.fn().mockImplementation(() => createQueryMock(selectResultQueue.shift() ?? data)),
+        then: (resolve: any) => Promise.resolve(resolve(data)),
+    };
+    return chain;
+};
+
+jest.mock('@/configs/db', () => ({
+    db: {
+        select: jest.fn().mockImplementation(() => createQueryMock(selectResultQueue.shift() ?? [])),
+    },
+}));
+
+const AUTHOR_EMAIL = 'author@example.com';
+
+const rawBookmarkedDoubt = {
+    id: 42,
+    userEmail: AUTHOR_EMAIL,
+    classroomId: 10,
+    subject: 'Linear Algebra',
+    content: 'What are eigenvalues?',
+    likes: 5,
+    isSolved: 'unsolved',
+    type: 'community',
+    isPinned: false,
+    embedding: [0.1, 0.2, 0.3],
+    deletedAt: null,
+    createdAt: '2026-01-01T00:00:00.000Z',
+};
+
+const makeRequest = (page = '1', limit = '20') =>
+    GET(new Request(`http://localhost/api/bookmarks?page=${page}&limit=${limit}`)) as Promise<Response>;
+
+const assertNoIdentityLeak = (json: any) => {
+    const serialized = JSON.stringify(json);
+    expect(serialized).not.toContain(AUTHOR_EMAIL);
+    expect(serialized).not.toContain('author@');
+    expect(json).not.toHaveProperty('userEmail');
+    expect(json).not.toHaveProperty('embedding');
+    expect(json).not.toHaveProperty('deletedAt');
+};
+
+describe('GET /api/bookmarks — anonymity (issue #1101)', () => {
+    beforeEach(() => {
+        (currentUser as jest.Mock).mockReset();
+        selectResultQueue.length = 0;
+        jest.clearAllMocks();
+    });
+
+    it('returns 401 when the user is not authenticated', async () => {
+        (currentUser as jest.Mock).mockResolvedValue(null);
+        const res = await makeRequest();
+        expect(res.status).toBe(401);
+    });
+
+    it('returns empty data when the user has no bookmarks', async () => {
+        (currentUser as jest.Mock).mockResolvedValue({
+            primaryEmailAddress: { emailAddress: 'bob@example.com' },
+        });
+        // select 1: total count => 0
+        selectResultQueue.push([{ total: 0 }]);
+
+        const res = await makeRequest();
+        const json = await res.json();
+
+        expect(res.status).toBe(200);
+        expect(json.data).toEqual([]);
+        expect(json.pagination.total).toBe(0);
+    });
+
+    it('strips userEmail and internal fields from bookmarked doubts', async () => {
+        (currentUser as jest.Mock).mockResolvedValue({
+            primaryEmailAddress: { emailAddress: 'bob@example.com' },
+        });
+
+        // select chain 1: total count => 1
+        selectResultQueue.push([{ total: 1 }]);
+        // select chain 2: bookmarks => [{ doubtId: 42 }]
+        selectResultQueue.push([{ doubtId: 42 }]);
+        // select chain 3: doubts => [rawBookmarkedDoubt]
+        selectResultQueue.push([rawBookmarkedDoubt]);
+        // select chain 4: user likes => []
+        selectResultQueue.push([]);
+        // select chain 5: reply counts => []
+        selectResultQueue.push([]);
+
+        const res = await makeRequest();
+        const json = await res.json();
+
+        expect(res.status).toBe(200);
+        expect(json.data).toHaveLength(1);
+
+        const doubt = json.data[0];
+        assertNoIdentityLeak(doubt);
+    });
+
+    it('adds anonymized author handle, authorInitial, and isOwnPost', async () => {
+        (currentUser as jest.Mock).mockResolvedValue({
+            primaryEmailAddress: { emailAddress: 'bob@example.com' },
+        });
+
+        selectResultQueue.push([{ total: 1 }]);
+        selectResultQueue.push([{ doubtId: 42 }]);
+        selectResultQueue.push([rawBookmarkedDoubt]);
+        selectResultQueue.push([]);
+        selectResultQueue.push([]);
+
+        const res = await makeRequest();
+        const json = await res.json();
+        const doubt = json.data[0];
+
+        expect(doubt.author).toBe(getAnonymousHandle(AUTHOR_EMAIL));
+        expect(doubt.authorInitial).toHaveLength(1);
+        expect(typeof doubt.isOwnPost).toBe('boolean');
+        expect(doubt.isOwnPost).toBe(false);
+    });
+
+    it('sets isOwnPost true when the viewer is the author', async () => {
+        (currentUser as jest.Mock).mockResolvedValue({
+            primaryEmailAddress: { emailAddress: AUTHOR_EMAIL },
+        });
+
+        selectResultQueue.push([{ total: 1 }]);
+        selectResultQueue.push([{ doubtId: 42 }]);
+        selectResultQueue.push([rawBookmarkedDoubt]);
+        selectResultQueue.push([]);
+        selectResultQueue.push([]);
+
+        const res = await makeRequest();
+        const json = await res.json();
+        const doubt = json.data[0];
+
+        expect(doubt.isOwnPost).toBe(true);
+        expect(doubt.author).toBe(getAnonymousHandle(AUTHOR_EMAIL));
+    });
+
+    it('preserves hasLiked, hasBookmarked, and replyCount', async () => {
+        (currentUser as jest.Mock).mockResolvedValue({
+            primaryEmailAddress: { emailAddress: 'bob@example.com' },
+        });
+
+        selectResultQueue.push([{ total: 1 }]);
+        selectResultQueue.push([{ doubtId: 42 }]);
+        selectResultQueue.push([rawBookmarkedDoubt]);
+        // user likes: doubt 42 is liked
+        selectResultQueue.push([{ doubtId: 42 }]);
+        // reply counts: 3 replies
+        selectResultQueue.push([{ doubtId: 42, count: 3 }]);
+
+        const res = await makeRequest();
+        const json = await res.json();
+        const doubt = json.data[0];
+
+        expect(doubt.hasLiked).toBe(true);
+        expect(doubt.hasBookmarked).toBe(true);
+        expect(doubt.replyCount).toBe(3);
+        // Non-identifying content is still present
+        expect(doubt.subject).toBe('Linear Algebra');
+        expect(doubt.content).toBe('What are eigenvalues?');
+        expect(doubt.id).toBe(42);
+    });
+
+    it('never serializes the author email anywhere in the JSON response', async () => {
+        (currentUser as jest.Mock).mockResolvedValue({
+            primaryEmailAddress: { emailAddress: 'bob@example.com' },
+        });
+
+        selectResultQueue.push([{ total: 1 }]);
+        selectResultQueue.push([{ doubtId: 42 }]);
+        selectResultQueue.push([rawBookmarkedDoubt]);
+        selectResultQueue.push([]);
+        selectResultQueue.push([]);
+
+        const res = await makeRequest();
+        const json = await res.json();
+        const serialized = JSON.stringify(json);
+
+        expect(serialized).not.toContain(AUTHOR_EMAIL);
+        expect(serialized).not.toContain('author@');
+        expect(serialized).not.toContain('embedding');
+        expect(serialized).not.toContain('deletedAt');
+    });
+});

--- a/src/app/api/bookmarks/route.ts
+++ b/src/app/api/bookmarks/route.ts
@@ -7,6 +7,7 @@ import { NextResponse } from "next/server";
 import { currentUser } from "@clerk/nextjs/server";
 import { buildErrorResponse, errorResponse } from "@/lib/errors/error-handler";
 import { parsePositiveInt } from "@/lib/utils/utils";
+import { toPublicDoubt } from "@/lib/anonymity/anonymity";
 
 export async function GET(req: Request) {
     try {
@@ -63,7 +64,7 @@ export async function GET(req: Request) {
         const doubtIds = bookmarks.map((b: any) => b.doubtId);
 
       
-        let doubts = await db.select().from(doubtsTable)
+        const doubts = await db.select().from(doubtsTable)
             .where(and(inArray(doubtsTable.id, doubtIds), isNull(doubtsTable.deletedAt)))
             .orderBy(desc(doubtsTable.createdAt));
 
@@ -87,16 +88,16 @@ export async function GET(req: Request) {
         const countsMap = Object.fromEntries(replyCounts.map((r: any) => [r.doubtId, r.count]));
 
         
-        doubts = doubts.map((doubt: any) => ({
+        const publicDoubts = doubts.map((doubt: any) => toPublicDoubt({
             ...doubt,
             hasLiked: likedIds.has(doubt.id),
             hasBookmarked: bookmarkedIds.has(doubt.id),
             replyCount: countsMap[doubt.id] || 0
-        }));
+        }, email));
 
        
         return NextResponse.json({
-            data: doubts,
+            data: publicDoubts,
             pagination: {
                 page,
                 limit,


### PR DESCRIPTION
## **User description**
## Description
Fixes a privacy leak in `GET /api/bookmarks`. The route was serializing raw `doubtsTable` records (via a plain `...doubt` spread), exposing each bookmarked doubt's author `userEmail`, the internal `embedding` pgvector, and `deletedAt` to authenticated clients, bypassing the anonymity system entirely. Bookmarked doubts are now passed through `toPublicDoubt(doubt, email)` — the same chokepoint used by `GET /api/doubts`, `GET /api/doubts/[id]`, and the classroomexport route — so responses only expose the anonymized `author` handle, `authorInitial`, and `isOwnPost` flag, while preserving `hasLiked`, `hasBookmarked`, and `replyCount`.

## Related Issue
Closes #1101

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Documentation update (README, guides, comments)
- [ ] Style / UI change (no logic change)
- [ ] Code refactor (no behavior change)
- [ ] Test addition or update
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## How Has This Been Tested?
- [x] Tested locally with `npm run dev`
- [ ] Ran existing test suite
- [ ] Verified on mobile viewport (375px)
- [ ] Verified on desktop viewport (1440px)

## Checklist
- [x] I have tested my changes locally (`npm run dev`)
- [x] My code follows the existing code style (TypeScript, Tailwind, no `any` types)
- [x] I have not introduced unrelated changes (each PR should address one issue)
- [x] I have added comments where necessary
- [x] My branch is up to date with `main`
- [x] I have linked the related issue above
- [ ] Screenshots are included (if this is a UI change)


___

## **CodeAnt-AI Description**
Protect author privacy in bookmarked doubts

### What Changed
- Bookmarked doubts now hide author emails and internal fields such as embeddings and deletion timestamps
- Anonymous doubts show a consistent author handle and initial, while identifying the viewer's own posts
- Like, bookmark, reply count, and doubt content details remain available
- Added coverage for authentication, privacy filtering, author ownership, and preserved bookmark metadata

### Impact
`✅ No author email leaks from bookmarked doubts`
`✅ Consistent anonymous author display`
`✅ Preserved likes, bookmarks, and reply counts`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
