### PR TITLE
fix: isolate mock rate limiter namespaces (#1275)

### DIFF
--- a/src/__tests__/lib/ratelimit-namespace.test.ts
+++ b/src/__tests__/lib/ratelimit-namespace.test.ts
@@ -1,0 +1,81 @@
+import type { Ratelimit } from "@upstash/ratelimit";
+
+// @upstash/redis pulls in ESM-only deps Jest cannot parse, so stub the Upstash
+// packages to allow loading the real ratelimit module below.
+jest.mock("@upstash/ratelimit", () => ({
+  Ratelimit: class {
+    limit = jest.fn();
+  },
+}));
+
+jest.mock("@upstash/redis", () => ({
+  Redis: {
+    fromEnv: jest.fn(),
+  },
+}));
+
+type LimiterLike = Pick<
+  Ratelimit | { limit(identifier: string): Promise<unknown> },
+  "limit"
+>;
+
+// jest.setup.ts registers a global mock for this module, so load the real
+// implementation to verify its namespace isolation.
+const loadRealModule = () => {
+  jest.resetModules();
+  return jest.requireActual("@/lib/ratelimit/ratelimit") as typeof import("@/lib/ratelimit/ratelimit");
+};
+
+const limit = async (limiter: LimiterLike, identifier: string) =>
+  (await limiter.limit(identifier)) as {
+    success: boolean;
+    limit: number;
+    remaining: number;
+    reset: number;
+  };
+
+describe("mock rate limiter namespace isolation", () => {
+  beforeAll(() => {
+    process.env.UPSTASH_REDIS_REST_URL = "";
+    process.env.UPSTASH_REDIS_REST_TOKEN = "";
+  });
+
+  it("keeps AI and General counters independent for the same identifier", async () => {
+    const { aiLimiter, generalLimiter } = loadRealModule();
+
+    for (let i = 0; i < 10; i++) {
+      const ai = await limit(aiLimiter, "user@example.com");
+      expect(ai.success).toBe(true);
+    }
+
+    const aiExhausted = await limit(aiLimiter, "user@example.com");
+    expect(aiExhausted.success).toBe(false);
+    expect(aiExhausted.remaining).toBe(0);
+
+    const general = await limit(generalLimiter, "user@example.com");
+    expect(general.success).toBe(true);
+    expect(general.remaining).toBe(29);
+  });
+
+  it("produces different keys for different limiter namespaces", async () => {
+    const { aiLimiter, videoLimiter } = loadRealModule();
+
+    const ai = await limit(aiLimiter, "user@example.com");
+    const video = await limit(videoLimiter, "user@example.com");
+
+    expect(ai.remaining).toBe(9);
+    expect(video.remaining).toBe(2);
+  });
+
+  it("preserves existing behavior within a single limiter", async () => {
+    const { generalLimiter } = loadRealModule();
+
+    const first = await limit(generalLimiter, "user@example.com");
+    const second = await limit(generalLimiter, "user@example.com");
+
+    expect(first.remaining).toBe(29);
+    expect(first.success).toBe(true);
+    expect(second.remaining).toBe(28);
+    expect(second.success).toBe(true);
+  });
+});

--- a/src/__tests__/lib/ratelimit-namespace.test.ts
+++ b/src/__tests__/lib/ratelimit-namespace.test.ts
@@ -78,4 +78,25 @@ describe("mock rate limiter namespace isolation", () => {
     expect(second.remaining).toBe(28);
     expect(second.success).toBe(true);
   });
+
+  it("does not collide when identifiers contain ':' characters", async () => {
+    const { aiLimiter, aiDailyLimiter } = loadRealModule();
+
+    // aiLimiter with identifier "daily:user@example.com"
+    const ai = await limit(aiLimiter, "daily:user@example.com");
+    expect(ai.success).toBe(true);
+    expect(ai.remaining).toBe(9);
+
+    // aiDailyLimiter with identifier "user@example.com" should be independent
+    // Default aiDailyLimit is 100 when env var is not set
+    const expectedAiDailyLimit = 100;
+    const aiDaily = await limit(aiDailyLimiter, "user@example.com");
+    expect(aiDaily.success).toBe(true);
+    expect(aiDaily.remaining).toBe(expectedAiDailyLimit - 1);
+
+    // Consuming aiLimiter should not affect aiDailyLimiter
+    const aiDailyAfter = await limit(aiDailyLimiter, "user@example.com");
+    expect(aiDailyAfter.success).toBe(true);
+    expect(aiDailyAfter.remaining).toBe(expectedAiDailyLimit - 2);
+  });
 });

--- a/src/lib/ratelimit/ratelimit.ts
+++ b/src/lib/ratelimit/ratelimit.ts
@@ -133,7 +133,7 @@ if (isRedisConfigured) {
   const createMockLimiter = (name: string, limit: number, windowMs: number) => ({
     limit: async (identifier: string) => {
       const now = Date.now();
-      const key = `${name}:${identifier}`;
+      const key = JSON.stringify([name, identifier]);
       const record = memoryMap.get(key) || { count: 0, reset: now + windowMs };
 
       if (now > record.reset) {

--- a/src/lib/ratelimit/ratelimit.ts
+++ b/src/lib/ratelimit/ratelimit.ts
@@ -130,10 +130,11 @@ if (isRedisConfigured) {
     return entry;
   };
 
-  const createMockLimiter = (limit: number, windowMs: number) => ({
+  const createMockLimiter = (name: string, limit: number, windowMs: number) => ({
     limit: async (identifier: string) => {
       const now = Date.now();
-      const record = memoryMap.get(identifier) || { count: 0, reset: now + windowMs };
+      const key = `${name}:${identifier}`;
+      const record = memoryMap.get(key) || { count: 0, reset: now + windowMs };
 
       if (now > record.reset) {
         record.count = 0;
@@ -141,7 +142,7 @@ if (isRedisConfigured) {
       }
 
       record.count++;
-      memoryMap.set(identifier, record);
+      memoryMap.set(key, record);
 
       return {
         success: record.count <= limit,
@@ -152,12 +153,12 @@ if (isRedisConfigured) {
     },
   });
 
-  aiLimiter = createMockLimiter(10, 60 * 1000);
-  aiDailyLimiter = createMockLimiter(aiDailyLimit, 24 * 60 * 60 * 1000);
-  generalLimiter = createMockLimiter(30, 60 * 1000);
-  emailNotificationLimiter = createMockLimiter(1, 5 * 60 * 1000); // 1 per 5 mins
-  videoLimiter = createMockLimiter(3, 60 * 60 * 1000); // 3 per hour
-  inviteCodeLimiter = createMockLimiter(5, 60 * 1000); // 5 per minute
+  aiLimiter = createMockLimiter("ai", 10, 60 * 1000);
+  aiDailyLimiter = createMockLimiter("ai:daily", aiDailyLimit, 24 * 60 * 60 * 1000);
+  generalLimiter = createMockLimiter("general", 30, 60 * 1000);
+  emailNotificationLimiter = createMockLimiter("email_notify", 1, 5 * 60 * 1000); // 1 per 5 mins
+  videoLimiter = createMockLimiter("video", 3, 60 * 60 * 1000); // 3 per hour
+  inviteCodeLimiter = createMockLimiter("invite_code", 5, 60 * 1000); // 5 per minute
 
   // Provide a mock redis client for locks
   redisClient = {


### PR DESCRIPTION
## **User description**
## Description

This PR isolates the in-memory mock rate limiter state across limiter instances by introducing namespaced keys in the mock implementation.

Previously, all mock limiters (`aiLimiter`, `generalLimiter`, `videoLimiter`, etc.) shared the same in-memory `Map` and stored entries using only the user identifier as the key. This allowed counters from different limiters to overlap when the same identifier was used.

This change updates the mock limiter to namespace keys by limiter type (for example, `ai:user@example.com` and `general:user@example.com`), ensuring each limiter maintains independent state while preserving existing behavior.

A focused regression test suite has also been added to verify:

* AI and General limiters maintain independent counters.
* Different limiter namespaces do not interfere with one another.
* Existing single-limiter rate limiting behavior remains unchanged.

## Related Issue

Closes #1275

## Type of Change

* [x] Bug fix (non-breaking change that fixes an issue)
* [ ] New feature (non-breaking change that adds functionality)
* [ ] Documentation update (README, guides, comments)
* [ ] Style / UI change (no logic change)
* [ ] Code refactor (no behavior change)
* [x] Test addition or update
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Screenshots (if UI change)

N/A – No UI changes.

## How Has This Been Tested?

* [x] Targeted Jest regression tests (`npx jest src/__tests__/lib/ratelimit-namespace.test.ts`)
* [x] ESLint validation on modified files
* [ ] Tested locally with `npm run dev`
* [ ] Verified on mobile viewport (375px)
* [ ] Verified on desktop viewport (1440px)

## Checklist

* [x] My code follows the existing code style (TypeScript, Tailwind, no `any` types)
* [x] I have not introduced unrelated changes (each PR should address one issue)
* [ ] I have added comments where necessary
* [x] My branch is up to date with `main`
* [x] I have linked the related issue above
* [x] No screenshots are required because this PR does not introduce UI changes


___

## **CodeAnt-AI Description**
Isolate rate limits between limiter types in the mock environment

### What Changed
- Rate-limit counters now remain independent for each limiter, even when they use the same user identifier
- Existing counting and reset behavior within a single limiter is preserved
- Added regression coverage for independent AI, General, and Video limiter counters

### Impact
`✅ Prevented cross-feature rate-limit interference`
`✅ Independent quotas for the same user`
`✅ Preserved existing single-limiter limits`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rate-limit isolation so separate application features no longer share counters unintentionally.
  * Preserved independent limits for AI, video, and general usage.
  * Added validation to ensure repeated requests correctly decrement the appropriate limiter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->