### PR TITLE
fix: exclude soft-deleted doubts from detail queries (#1140)

### DIFF
--- a/src/app/(routes)/doubts/[id]/page.tsx
+++ b/src/app/(routes)/doubts/[id]/page.tsx
@@ -1,7 +1,7 @@
 import { notFound, redirect } from "next/navigation";
 import { db } from "@/configs/db";
 import { doubtsTable, classroomsTable, membershipsTable } from "@/configs/schema";
-import { eq, and } from "drizzle-orm";
+import { eq, and, isNull } from "drizzle-orm";
 import { currentUser } from "@clerk/nextjs/server";
 import DoubtPermalinkClient from "./DoubtPermalinkClient";
 import type { Metadata } from "next";
@@ -24,7 +24,7 @@ export async function generateMetadata(
                 content: doubtsTable.content,
             })
             .from(doubtsTable)
-            .where(eq(doubtsTable.id, doubtId))
+            .where(and(eq(doubtsTable.id, doubtId), isNull(doubtsTable.deletedAt)))
             .limit(1);
 
         if (!doubt) {
@@ -66,7 +66,7 @@ export default async function DoubtPermalinkPage(
     const [doubt] = await db
         .select()
         .from(doubtsTable)
-        .where(eq(doubtsTable.id, doubtId))
+        .where(and(eq(doubtsTable.id, doubtId), isNull(doubtsTable.deletedAt)))
         .limit(1);
 
     if (!doubt) {

--- a/src/app/api/doubts/[id]/route.ts
+++ b/src/app/api/doubts/[id]/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { db } from "@/configs/db";
 import { doubtsTable, repliesTable, tagsTable, doubtTagsTable, bookmarksTable, likesTable } from "@/configs/schema";
-import { eq, sql, and, getTableColumns } from "drizzle-orm";
+import { eq, sql, and, isNull, getTableColumns } from "drizzle-orm";
 import { getOptionalAuth, requireMembership } from "@/lib/auth/membership-guard";
 import { buildErrorResponse } from "@/lib/errors/error-handler";
 import { toPublicDoubt } from "@/lib/anonymity/anonymity";
@@ -27,7 +27,7 @@ export async function GET(
                 replyCount: sql<number>`coalesce((SELECT count(*)::int FROM ${repliesTable} WHERE ${repliesTable.doubtId} = ${doubtsTable.id}), 0)`.mapWith(Number),
             })
             .from(doubtsTable)
-            .where(eq(doubtsTable.id, doubtId))
+            .where(and(eq(doubtsTable.id, doubtId), isNull(doubtsTable.deletedAt)))
             .limit(1);
 
         if (!doubt) {


### PR DESCRIPTION
## **User description**
## Description

This PR fixes an inconsistency in the application's soft-delete behavior by preventing soft-deleted doubts from being accessed through the detail API and permalink page.

### Changes

* Added `isNull(doubtsTable.deletedAt)` to the doubt lookup in `src/app/api/doubts/[id]/route.ts`.
* Added the same filter to the metadata query in `src/app/(routes)/doubts/[id]/page.tsx`.
* Added the same filter to the permalink page query in `src/app/(routes)/doubts/[id]/page.tsx`.

With these changes, soft-deleted doubts are treated the same as nonexistent doubts:

* `GET /api/doubts/[id]` now returns **404 Not Found**.
* Visiting `/doubts/[id]` now renders the Next.js **notFound()** page.

This aligns the detail endpoints with the rest of the application, where soft-deleted doubts are already excluded from user-facing queries.

## Related Issue

Closes #1140

## Type of Change

* [x] Bug fix (non-breaking change that fixes an issue)
* [ ] New feature (non-breaking change that adds functionality)
* [ ] Documentation update (README, guides, comments)
* [ ] Style / UI change (no logic change)
* [ ] Code refactor (no behavior change)
* [ ] Test addition or update
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## How Has This Been Tested?

* [x] Tested locally with `npm run dev`
* [ ] Verified on mobile viewport (375px)
* [ ] Verified on desktop viewport (1440px)

### Manual Verification

* Verified that existing (non-deleted) doubts continue to load normally through both the detail API and permalink page.
* Verified that soft-deleted doubts are no longer returned by `GET /api/doubts/[id]` and instead return **404 Not Found**.
* Verified that visiting the permalink of a soft-deleted doubt renders the Next.js **notFound()** page.
* Confirmed the project passes linting after the changes.

## Checklist

* [x] I have tested my changes locally (`npm run dev`)
* [x] My code follows the existing code style (TypeScript, Tailwind, no `any` types)
* [x] I have not introduced unrelated changes (each PR should address one issue)
* [ ] I have added comments where necessary (not applicable)
* [x] My branch is up to date with `main`
* [x] I have linked the related issue above
* [ ] Screenshots are included (if this is a UI change)


___

## **CodeAnt-AI Description**
Hide soft-deleted doubts from detail views and API responses

### What Changed
- Requests for soft-deleted doubts now return a 404 response from the detail API
- Visiting a soft-deleted doubt permalink now shows the not-found page
- Metadata no longer exposes the subject or content of soft-deleted doubts

### Impact
`✅ No access to deleted doubt details`
`✅ Consistent 404 behavior across API and permalink pages`
`✅ No deleted doubt content in page metadata`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
