### PR TITLE
fix: escape LIKE wildcards in doubt search

### DIFF
--- a/src/app/api/doubts/route.ts
+++ b/src/app/api/doubts/route.ts
@@ -38,7 +38,7 @@ import { generalLimiter } from "@/lib/ratelimit/ratelimit";
 import { buildRankOrder } from "@/lib/search/search";
 import { canTeach } from "@/lib/auth/membership-guard";
 import { currentUser } from "@clerk/nextjs/server";
-import { parsePositiveInt } from "@/lib/utils/utils";
+import { parsePositiveInt, escapeLike } from "@/lib/utils/utils";
 import { toPublicDoubt } from "@/lib/anonymity/anonymity";
 import { decodeCursor, encodeCursor } from "@/lib/pagination";
 
@@ -109,8 +109,8 @@ export async function GET(req: Request) {
       // email here would let a caller probe email fragments and infer which
       // anonymized posts belong to a given author from result presence/counts.
       const searchCondition = or(
-        ilike(doubtsTable.content, `%${search}%`),
-        ilike(doubtsTable.subject, `%${search}%`),
+        ilike(doubtsTable.content, `%${escapeLike(search)}%`),
+        ilike(doubtsTable.subject, `%${escapeLike(search)}%`),
       );
       if (searchCondition) conditions.push(searchCondition);
     }


### PR DESCRIPTION
## **User description**
## Description

This PR fixes the doubts search endpoint by escaping SQL `LIKE` wildcard characters before constructing `ILIKE` patterns.

Previously, user input containing `%` or `_` was interpreted as SQL wildcard characters, resulting in overly broad and inaccurate search results. This change reuses the existing `escapeLike()` utility already used by the tags search endpoint, ensuring consistent search behavior across the application.

### Changes

* Imported the existing `escapeLike()` helper into `src/app/api/doubts/route.ts`.
* Escaped the search term before constructing the `ILIKE` pattern for both `content` and `subject` searches.

This preserves existing search behavior while ensuring `%`, `_`, and `\` are treated as literal characters when entered by users.

## Related Issue

Closes #1139

## Type of Change

* [x] Bug fix (non-breaking change that fixes an issue)
* [ ] New feature (non-breaking change that adds functionality)
* [ ] Documentation update (README, guides, comments)
* [ ] Style / UI change (no logic change)
* [ ] Code refactor (no behavior change)
* [ ] Test addition or update
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## How Has This Been Tested?

* [x] Tested locally with `npm run dev`
* [ ] Verified on mobile viewport (375px)
* [ ] Verified on desktop viewport (1440px)

### Manual Verification

* Verified that searching for `%` matches only doubts containing a literal `%`.
* Verified that searching for `_` matches only doubts containing a literal `_`.
* Verified that normal text searches continue to behave as before.
* Confirmed the project passes linting after the changes.

## Checklist

* [x] I have tested my changes locally (`npm run dev`)
* [x] My code follows the existing code style (TypeScript, Tailwind, no `any` types)
* [x] I have not introduced unrelated changes (each PR should address one issue)
* [ ] I have added comments where necessary (not applicable)
* [x] My branch is up to date with `main`
* [x] I have linked the related issue above
* [ ] Screenshots are included (if this is a UI change)


___

## **CodeAnt-AI Description**
Ensure doubt searches treat `%`, `_`, and `\` as literal characters

### What Changed
- Search terms containing `%`, `_`, or `\` now match those exact characters instead of acting as pattern wildcards
- Searches across doubt content and subjects return narrower, more accurate results while normal text searches continue to work

### Impact
`✅ Accurate searches for literal wildcard characters`
`✅ Fewer unrelated doubts in search results`
`✅ Consistent matching across doubt fields`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
