### PR TITLE
fix: exclude soft-deleted doubts from similarity candidates

### DIFF
--- a/src/app/api/doubts/check-duplicate/route.ts
+++ b/src/app/api/doubts/check-duplicate/route.ts
@@ -94,6 +94,7 @@ export async function POST(req: Request) {
             ? eq(doubtsTable.classroomId, classroomId)
             : isNull(doubtsTable.classroomId),
           eq(doubtsTable.type, "community"),
+          isNull(doubtsTable.deletedAt),
         ),
       )
       .orderBy(desc(doubtsTable.createdAt))

--- a/src/app/api/doubts/check-similarity/route.ts
+++ b/src/app/api/doubts/check-similarity/route.ts
@@ -101,6 +101,7 @@ export async function POST(req: Request) {
             ? eq(doubtsTable.classroomId, classroomId)
             : isNull(doubtsTable.classroomId),
           eq(doubtsTable.type, "community"),
+          isNull(doubtsTable.deletedAt),
         ),
       )
       .orderBy(desc(doubtsTable.createdAt))

--- a/src/lib/ai/embeddings.ts
+++ b/src/lib/ai/embeddings.ts
@@ -103,6 +103,7 @@ export async function findSemanticDuplicates(params: {
       ? eq(doubtsTable.classroomId, classroomId)
       : isNull(doubtsTable.classroomId),
     eq(doubtsTable.type, type),
+    isNull(doubtsTable.deletedAt),
     // exclude null embeddings
     sql`${doubtsTable.embedding} IS NOT NULL`,
   );


### PR DESCRIPTION
## **User description**
## Description

This PR fixes the duplicate and similarity detection pipeline by excluding soft-deleted doubts from candidate selection.

Previously, doubts with a non-NULL `deletedAt` value could still be returned by both the semantic vector search and the fallback recent-doubts queries, causing deleted content to appear as "Similar Doubts" or "Possible Duplicates".

### Changes

* Added `isNull(doubtsTable.deletedAt)` to the semantic vector search in `findSemanticDuplicates()`.
* Added `isNull(doubtsTable.deletedAt)` to the fallback query in `check-similarity`.
* Added `isNull(doubtsTable.deletedAt)` to the fallback query in `check-duplicate`.

This keeps duplicate and similarity detection consistent with the rest of the application, where soft-deleted doubts are excluded from user-facing queries.

## Related Issue

Closes #1138

## Type of Change

* [x] Bug fix (non-breaking change that fixes an issue)
* [ ] New feature (non-breaking change that adds functionality)
* [ ] Documentation update (README, guides, comments)
* [ ] Style / UI change (no logic change)
* [ ] Code refactor (no behavior change)
* [ ] Test addition or update
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## How Has This Been Tested?

* [x] TypeScript compilation (`tsc --noEmit`)
* [x] Existing test suite (all applicable tests pass; an unrelated pre-existing test requires `GROQ_API_KEY`)
* [ ] Verified on mobile viewport (not applicable)
* [ ] Verified on desktop viewport (not applicable)

### Manual Verification

* Created a doubt and confirmed it appears in duplicate/similarity suggestions.
* Soft-deleted the doubt.
* Confirmed the deleted doubt no longer appears in duplicate/similarity suggestions.
* Verified that active doubts continue to appear as expected.

## Checklist

* [x] I have tested my changes locally
* [x] My code follows the existing code style (TypeScript, Tailwind, no `any` types)
* [x] I have not introduced unrelated changes (each PR addresses one issue)
* [ ] I have added comments where necessary (not applicable)
* [x] My branch is up to date with `main`
* [x] I have linked the related issue above
* [ ] Screenshots are included (not applicable)


___

## **CodeAnt-AI Description**
Exclude deleted doubts from similarity and duplicate suggestions

### What Changed
- Soft-deleted doubts no longer appear in semantic similarity results
- Soft-deleted doubts are excluded from recent fallback results for similarity and duplicate checks
- Active doubts continue to be eligible for suggestions

### Impact
`✅ No deleted doubts in duplicate suggestions`
`✅ No deleted doubts in similarity results`
`✅ More accurate active-doubt matches`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
