### PR TITLE
fix(notifications): keep pending digests when email delivery is simulated

### DIFF
--- a/src/__tests__/inngest/digest-functions.test.ts
+++ b/src/__tests__/inngest/digest-functions.test.ts
@@ -1,6 +1,8 @@
 import { db } from "@/configs/db";
 import { sendDigestEmail } from "@/lib/email/email";
 
+process.env.GROQ_API_KEY = process.env.GROQ_API_KEY || "mock-groq-key";
+
 // ── Mocks ─────────────────────────────────────────────────────────────────────
 
 jest.mock("@/configs/db", () => ({
@@ -15,10 +17,28 @@ jest.mock("@/lib/email/email", () => ({
   sendDigestEmail: jest.fn(),
 }));
 
+jest.mock("@/lib/video/pipeline", () => ({
+  runVideoPipeline: jest.fn(),
+}));
+
+jest.mock("@/lib/ratelimit/ratelimit", () => ({
+  emailNotificationLimiter: { limit: jest.fn() },
+  redisClient: {},
+}));
+
+jest.mock("../../app/api/inngest/ConfusionSpikeDetector", () => ({
+  detectConfusionSpikes: {},
+}));
+
+jest.mock("../../app/api/inngest/UrgentActivityDetector", () => ({
+  checkUrgentClassroomActivity: {},
+  notifyFlaggedContentHidden: {},
+}));
+
 // Mock inngest client
 jest.mock("@/inngest/client", () => ({
   inngest: {
-    createFunction: jest.fn((config, handler) => handler),
+    createFunction: jest.fn((_config, handler) => ({ fn: handler })),
   },
 }));
 
@@ -123,9 +143,8 @@ describe("sendDailyDigest — per-user step isolation", () => {
 
     // Alice succeeds, Bob throws
     mockSendDigestEmail
-      .mockResolvedValueOnce({ success: true })            // alice: ok
-      .mockResolvedValueOnce({ success: false, error: "SMTP timeout" }); // bob: failmockSendDigestEmail
-      
+      .mockResolvedValueOnce({ success: true, simulated: false })            // alice: ok
+      .mockResolvedValueOnce({ success: false, error: "SMTP timeout" }); // bob: fail
     // Import the function under test after mocks are set.
     // We simulate the Inngest function invocation directly.
     const { sendDailyDigest } = await import("@/inngest/functions");
@@ -161,7 +180,7 @@ describe("sendDailyDigest — per-user step isolation", () => {
 
     const deleteChain = { where: jest.fn().mockResolvedValue(undefined) };
     (dbMock.delete as jest.Mock).mockReturnValue(deleteChain);
-    mockSendDigestEmail.mockResolvedValue({ success: true });
+    mockSendDigestEmail.mockResolvedValue({ success: true, simulated: false });
 
     const { sendDailyDigest } = await import("@/inngest/functions");
 
@@ -174,5 +193,38 @@ describe("sendDailyDigest — per-user step isolation", () => {
     await runHandler(sendDailyDigest, step);
     // sendDigestEmail must NOT be called again.
     expect(mockSendDigestEmail).toHaveBeenCalledTimes(1);
+  });
+
+  it("retains pending rows when digest delivery is only simulated", async () => {
+    const users = [{ email: "dana@test.com" }];
+    const danaPending: PendingRow[] = [
+      { id: 4, doubtId: 40, doubtSubject: "Q4", doubtContent: "...", replyId: 400, replierName: "w@t.com", replyContent: "ans" },
+    ];
+
+    const dbMock = db as jest.Mocked<typeof db>;
+    let selectCallCount = 0;
+    (dbMock.select as jest.Mock).mockImplementation(() => {
+      selectCallCount++;
+      const chain = { from: jest.fn().mockReturnThis(), where: jest.fn().mockReturnThis(), innerJoin: jest.fn().mockReturnThis() } as Record<string, jest.Mock>;
+      if (selectCallCount === 1) chain.where = jest.fn().mockResolvedValue(users);
+      else chain.where = jest.fn().mockResolvedValue(danaPending);
+      return chain;
+    });
+
+    const deleteChain = { where: jest.fn().mockResolvedValue(undefined) };
+    (dbMock.delete as jest.Mock).mockReturnValue(deleteChain);
+    mockSendDigestEmail.mockResolvedValue({
+      success: false,
+      simulated: true,
+      error: "Email delivery unavailable: RESEND_API_KEY is not configured",
+    });
+
+    const { sendDailyDigest } = await import("@/inngest/functions");
+    const step = makeStep();
+
+    await expect(runHandler(sendDailyDigest, step)).rejects.toThrow(
+      /RESEND_API_KEY is not configured/,
+    );
+    expect(dbMock.delete).not.toHaveBeenCalled();
   });
 });

--- a/src/__tests__/inngest/digest-functions.test.ts
+++ b/src/__tests__/inngest/digest-functions.test.ts
@@ -107,7 +107,7 @@ describe("sendDailyDigest — per-user step isolation", () => {
   });
 
   it("deletes pending rows only for users whose email succeeded", async () => {
-    // Two users: alice succeeds, bob's email throws.
+    // Two users: alice succeeds, bob's email fails (retained, does not block batch).
     const users = [{ email: "alice@test.com" }, { email: "bob@test.com" }];
 
     const alicePending: PendingRow[] = [
@@ -141,7 +141,7 @@ describe("sendDailyDigest — per-user step isolation", () => {
     const deleteChain = { where: jest.fn().mockResolvedValue(undefined) };
     (dbMock.delete as jest.Mock).mockReturnValue(deleteChain);
 
-    // Alice succeeds, Bob throws
+    // Alice succeeds, Bob fails permanently — step must not throw so batch continues.
     mockSendDigestEmail
       .mockResolvedValueOnce({ success: true, simulated: false })            // alice: ok
       .mockResolvedValueOnce({ success: false, error: "SMTP timeout" }); // bob: fail
@@ -150,14 +150,17 @@ describe("sendDailyDigest — per-user step isolation", () => {
     const { sendDailyDigest } = await import("@/inngest/functions");
 
     const step = makeStep();
-    await expect(runHandler(sendDailyDigest, step)).rejects.toThrow("SMTP timeout");
+    await expect(runHandler(sendDailyDigest, step)).resolves.toEqual({
+      message: "Successfully sent daily digest to 1 users.",
+    });
 
     // Alice's row MUST have been deleted (email succeeded).
     expect(dbMock.delete).toHaveBeenCalledTimes(1);
     expect(deleteChain.where).toHaveBeenCalledTimes(1);
 
-    // Bob's row must NOT have been deleted (email failed, step threw).
-    // The delete call count would be 2 if bob's rows were removed — confirm it's 1.
+    // Bob's row must NOT have been deleted (email failed; pending retained).
+    // Both users were processed (alice + bob send attempts).
+    expect(mockSendDigestEmail).toHaveBeenCalledTimes(2);
     const deleteCalls = (dbMock.delete as jest.Mock).mock.calls.length;
     expect(deleteCalls).toBe(1);
   });
@@ -222,9 +225,9 @@ describe("sendDailyDigest — per-user step isolation", () => {
     const { sendDailyDigest } = await import("@/inngest/functions");
     const step = makeStep();
 
-    await expect(runHandler(sendDailyDigest, step)).rejects.toThrow(
-      /RESEND_API_KEY is not configured/,
-    );
+    await expect(runHandler(sendDailyDigest, step)).resolves.toEqual({
+      message: "Successfully sent daily digest to 0 users.",
+    });
     expect(dbMock.delete).not.toHaveBeenCalled();
   });
 });

--- a/src/inngest/functions.ts
+++ b/src/inngest/functions.ts
@@ -217,10 +217,9 @@ export const sendDailyDigest = inngest.createFunction(
           });
         }
 
-        // Send first; only delete on confirmed success.
-        // If sendDigestEmail throws, the catch lets the step fail so Inngest
-        // retries it — pending rows are intentionally NOT deleted.
-          const emailResult = await sendDigestEmail({
+        // Send first; only delete on confirmed provider acceptance.
+        // Simulated / unconfigured delivery must NOT clear the queue.
+        const emailResult = await sendDigestEmail({
           toEmail: user.email,
           subject: "[DoubtDesk] Your Daily Doubt Updates Digest",
           totalReplies: pending.length,
@@ -228,9 +227,10 @@ export const sendDailyDigest = inngest.createFunction(
           doubts: Array.from(doubtsMap.values()),
         });
 
-        if (!emailResult?.success) {
-          // Email failed — throw so the step is retried and pending rows are preserved.
-          throw new Error(`Daily digest email failed for user: ${emailResult?.error ?? "unknown error"}`);
+        if (!emailResult?.success || emailResult.simulated) {
+          throw new Error(
+            `Daily digest email failed for user: ${emailResult?.error ?? "unknown error"}`,
+          );
         }
         
         // Delete only after confirmed send.
@@ -305,17 +305,18 @@ export const sendWeeklyDigest = inngest.createFunction(
           });
         }
 
-        try {
-          await sendDigestEmail({
-            toEmail: user.email,
-            subject: "[DoubtDesk] Your Weekly Doubt Updates Digest",
-            totalReplies: pending.length,
-            totalDoubts: doubtsMap.size,
-            doubts: Array.from(doubtsMap.values()),
-          });
-        } catch (emailErr) {
-          console.error(`[sendWeeklyDigest] Email failed for ${user.email}:`, emailErr);
-          throw emailErr;
+        const emailResult = await sendDigestEmail({
+          toEmail: user.email,
+          subject: "[DoubtDesk] Your Weekly Doubt Updates Digest",
+          totalReplies: pending.length,
+          totalDoubts: doubtsMap.size,
+          doubts: Array.from(doubtsMap.values()),
+        });
+
+        if (!emailResult?.success || emailResult.simulated) {
+          throw new Error(
+            `Weekly digest email failed for user: ${emailResult?.error ?? "unknown error"}`,
+          );
         }
 
         const notificationIds = pending.map(p => p.id);

--- a/src/inngest/functions.ts
+++ b/src/inngest/functions.ts
@@ -228,11 +228,14 @@ export const sendDailyDigest = inngest.createFunction(
         });
 
         if (!emailResult?.success || emailResult.simulated) {
-          throw new Error(
-            `Daily digest email failed for user: ${emailResult?.error ?? "unknown error"}`,
+          const error = emailResult?.error ?? "unknown error";
+          console.error(
+            `Daily digest email failed for ${user.email}; retaining pending rows: ${error}`,
           );
+          // Do not throw — isolate failure so later users in the batch still run.
+          return { skipped: true, retained: true, error };
         }
-        
+
         // Delete only after confirmed send.
         const notificationIds = pending.map(p => p.id);
         await db
@@ -314,9 +317,12 @@ export const sendWeeklyDigest = inngest.createFunction(
         });
 
         if (!emailResult?.success || emailResult.simulated) {
-          throw new Error(
-            `Weekly digest email failed for user: ${emailResult?.error ?? "unknown error"}`,
+          const error = emailResult?.error ?? "unknown error";
+          console.error(
+            `Weekly digest email failed for ${user.email}; retaining pending rows: ${error}`,
           );
+          // Do not throw — isolate failure so later users in the batch still run.
+          return { skipped: true, retained: true, error };
         }
 
         const notificationIds = pending.map(p => p.id);

--- a/src/lib/email/email.ts
+++ b/src/lib/email/email.ts
@@ -474,7 +474,11 @@ export async function sendDigestEmail(params: {
     const apiKey = process.env.RESEND_API_KEY;
     if (!apiKey || apiKey === "re_your_actual_key_here") {
         console.log("[EMAIL SIMULATION] Skipping real delivery. Resend API Key is not configured.");
-        return { success: true, simulated: true };
+        return {
+            success: false,
+            simulated: true,
+            error: "Email delivery unavailable: RESEND_API_KEY is not configured",
+        };
     }
 
     try {


### PR DESCRIPTION
## **User description**
## Description
`sendDigestEmail` was returning `{ success: true, simulated: true }` when `RESEND_API_KEY` was missing, so the daily digest job deleted pending notification rows even though nothing was sent. Simulated sends now fail with an actionable error, and both daily/weekly digest jobs only delete pending rows after a real provider acceptance.

## Related Issue
Closes #1175

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Documentation update (README, guides, comments)
- [ ] Style / UI change (no logic change)
- [ ] Code refactor (no behavior change)
- [ ] Test addition or update
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## How Has This Been Tested?
- [x] Tested locally with `npm run dev`
- [ ] Verified on mobile viewport (375px)
- [ ] Verified on desktop viewport (1440px)

- `npx tsc --noEmit` passes
- `npm test -- src/__tests__/inngest/digest-functions.test.ts` — 3 passing, including simulated-delivery retention

## Checklist
- [x] I have tested my changes locally (`npm run dev`)
- [x] My code follows the existing code style (TypeScript, Tailwind, no `any` types)
- [x] I have not introduced unrelated changes (each PR should address one issue)
- [x] I have added comments where necessary
- [x] My branch is up to date with `main`
- [x] I have linked the related issue above
- [ ] Screenshots are included (if this is a UI change)

Made with [Cursor](https://cursor.com)


___

## **CodeAnt-AI Description**
Preserve pending digest notifications when delivery is unavailable

### What Changed
- Daily and weekly digest items are removed only after a real email provider accepts the message.
- Simulated or failed delivery keeps that user's pending notifications queued without stopping other users' digests.
- Added coverage for failed, simulated, successful, and retry scenarios.

### Impact
`✅ No lost digest notifications when email is unconfigured`
`✅ Other users still receive digests when one delivery fails`
`✅ Pending notifications remain available for retry`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
