### PR TITLE
fix(devops): ship and run the complete migration set in production

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,14 @@ ENV NEXT_TELEMETRY_DISABLED=1 \
 
 RUN npm run build
 
+# Bundle the migration runner so the production image can apply the full
+# tracked Drizzle set without shipping the entire node_modules tree.
+RUN npx esbuild drizzle/migrate.ts \
+    --bundle \
+    --platform=node \
+    --format=cjs \
+    --outfile=scripts/run-migrations.js
+
 FROM node:20-alpine AS runner
 WORKDIR /app
 
@@ -39,11 +47,17 @@ COPY --from=builder /app/public ./public
 COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
 COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
 
-RUN mkdir -p public/temp-assets public/videos && \
-    chown -R nextjs:nodejs public/temp-assets public/videos
+# Ship the complete migration journal/SQL set and the bundled runner.
+COPY --from=builder --chown=nextjs:nodejs /app/drizzle ./drizzle
+COPY --from=builder --chown=nextjs:nodejs /app/scripts/run-migrations.js ./scripts/run-migrations.js
+COPY --from=builder --chown=nextjs:nodejs /app/scripts/docker-entrypoint.sh ./docker-entrypoint.sh
+
+RUN mkdir -p public/temp-assets public/videos scripts && \
+    chown -R nextjs:nodejs public/temp-assets public/videos scripts drizzle && \
+    chmod +x ./docker-entrypoint.sh
 
 USER nextjs
 
 EXPOSE 3000
 
-CMD ["node", "server.js"]
+CMD ["./docker-entrypoint.sh"]

--- a/drizzle/0012_fulltext_search.sql
+++ b/drizzle/0012_fulltext_search.sql
@@ -1,3 +1,3 @@
 ALTER TABLE "doubts" ADD COLUMN IF NOT EXISTS "search_vector" tsvector GENERATED ALWAYS AS (to_tsvector('english', coalesce("content", '') || ' ' || coalesce("subject", '') || ' ' || coalesce("subTopic", ''))) STORED;
 --> statement-breakpoint
-CREATE INDEX CONCURRENTLY IF NOT EXISTS "idx_doubts_search_vector" ON "doubts" USING GIN ("search_vector");
+CREATE INDEX IF NOT EXISTS "idx_doubts_search_vector" ON "doubts" USING GIN ("search_vector");

--- a/drizzle/0013_identity_system_update.sql
+++ b/drizzle/0013_identity_system_update.sql
@@ -1,0 +1,18 @@
+ALTER TABLE "likes" RENAME COLUMN "userName" TO "userEmail";
+ALTER TABLE "reply_likes" RENAME COLUMN "userName" TO "userEmail";
+
+ALTER TABLE "likes" DROP CONSTRAINT IF EXISTS "likes_userName_doubtId_unique";
+ALTER TABLE "likes" ADD CONSTRAINT "likes_userEmail_doubtId_unique" UNIQUE("userEmail","doubtId");
+
+ALTER TABLE "reply_likes" DROP CONSTRAINT IF EXISTS "reply_likes_userName_replyId_unique";
+ALTER TABLE "reply_likes" ADD CONSTRAINT "reply_likes_userEmail_replyId_unique" UNIQUE("userEmail","replyId");
+
+-- Clean orphaned records before adding foreign key constraints
+DELETE FROM "likes" WHERE "userEmail" NOT IN (SELECT "email" FROM "users");
+DELETE FROM "reply_likes" WHERE "userEmail" NOT IN (SELECT "email" FROM "users");
+
+ALTER TABLE "likes" DROP CONSTRAINT IF EXISTS "likes_userName_users_email_fk";
+ALTER TABLE "likes" ADD CONSTRAINT "likes_userEmail_users_email_fk" FOREIGN KEY ("userEmail") REFERENCES "public"."users"("email") ON DELETE cascade ON UPDATE no action;
+
+ALTER TABLE "reply_likes" DROP CONSTRAINT IF EXISTS "reply_likes_userName_users_email_fk";
+ALTER TABLE "reply_likes" ADD CONSTRAINT "reply_likes_userEmail_users_email_fk" FOREIGN KEY ("userEmail") REFERENCES "public"."users"("email") ON DELETE cascade ON UPDATE no action;

--- a/drizzle/0013_identity_system_update.sql
+++ b/drizzle/0013_identity_system_update.sql
@@ -10,7 +10,41 @@ ALTER TABLE "reply_likes" DROP CONSTRAINT IF EXISTS "reply_likes_userName_replyI
 --> statement-breakpoint
 ALTER TABLE "reply_likes" ADD CONSTRAINT "reply_likes_userEmail_replyId_unique" UNIQUE("userEmail","replyId");
 --> statement-breakpoint
--- Backfill renamed userEmail values that still hold display names, then clean orphans
+-- Fail fast when a legacy identity matches multiple users (nondeterministic UPDATE FROM).
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM (
+            SELECT lower(l."userEmail") AS ident
+            FROM "likes" l
+            JOIN "users" u
+              ON lower(l."userEmail") = lower(u."name")
+              OR lower(l."userEmail") = lower(u."email")
+            GROUP BY lower(l."userEmail")
+            HAVING count(DISTINCT u."email") > 1
+        ) ambiguous
+    ) THEN
+        RAISE EXCEPTION 'Ambiguous likes identity mapping: resolve duplicate user names before migrating';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1
+        FROM (
+            SELECT lower(rl."userEmail") AS ident
+            FROM "reply_likes" rl
+            JOIN "users" u
+              ON lower(rl."userEmail") = lower(u."name")
+              OR lower(rl."userEmail") = lower(u."email")
+            GROUP BY lower(rl."userEmail")
+            HAVING count(DISTINCT u."email") > 1
+        ) ambiguous
+    ) THEN
+        RAISE EXCEPTION 'Ambiguous reply_likes identity mapping: resolve duplicate user names before migrating';
+    END IF;
+END $$;
+--> statement-breakpoint
+-- Backfill renamed userEmail values that still hold display names (one-to-one matches only)
 UPDATE "likes" SET "userEmail" = u."email" FROM "users" u WHERE lower("likes"."userEmail") = lower(u."name") OR lower("likes"."userEmail") = lower(u."email");
 --> statement-breakpoint
 UPDATE "reply_likes" SET "userEmail" = u."email" FROM "users" u WHERE lower("reply_likes"."userEmail") = lower(u."name") OR lower("reply_likes"."userEmail") = lower(u."email");

--- a/drizzle/0013_identity_system_update.sql
+++ b/drizzle/0013_identity_system_update.sql
@@ -1,21 +1,28 @@
 ALTER TABLE "likes" RENAME COLUMN "userName" TO "userEmail";
+--> statement-breakpoint
 ALTER TABLE "reply_likes" RENAME COLUMN "userName" TO "userEmail";
-
+--> statement-breakpoint
 ALTER TABLE "likes" DROP CONSTRAINT IF EXISTS "likes_userName_doubtId_unique";
+--> statement-breakpoint
 ALTER TABLE "likes" ADD CONSTRAINT "likes_userEmail_doubtId_unique" UNIQUE("userEmail","doubtId");
-
+--> statement-breakpoint
 ALTER TABLE "reply_likes" DROP CONSTRAINT IF EXISTS "reply_likes_userName_replyId_unique";
+--> statement-breakpoint
 ALTER TABLE "reply_likes" ADD CONSTRAINT "reply_likes_userEmail_replyId_unique" UNIQUE("userEmail","replyId");
-
+--> statement-breakpoint
 -- Backfill renamed userEmail values that still hold display names, then clean orphans
 UPDATE "likes" SET "userEmail" = u."email" FROM "users" u WHERE lower("likes"."userEmail") = lower(u."name") OR lower("likes"."userEmail") = lower(u."email");
+--> statement-breakpoint
 UPDATE "reply_likes" SET "userEmail" = u."email" FROM "users" u WHERE lower("reply_likes"."userEmail") = lower(u."name") OR lower("reply_likes"."userEmail") = lower(u."email");
-
+--> statement-breakpoint
 DELETE FROM "likes" WHERE "userEmail" NOT IN (SELECT "email" FROM "users");
+--> statement-breakpoint
 DELETE FROM "reply_likes" WHERE "userEmail" NOT IN (SELECT "email" FROM "users");
-
+--> statement-breakpoint
 ALTER TABLE "likes" DROP CONSTRAINT IF EXISTS "likes_userName_users_email_fk";
+--> statement-breakpoint
 ALTER TABLE "likes" ADD CONSTRAINT "likes_userEmail_users_email_fk" FOREIGN KEY ("userEmail") REFERENCES "public"."users"("email") ON DELETE cascade ON UPDATE no action;
-
+--> statement-breakpoint
 ALTER TABLE "reply_likes" DROP CONSTRAINT IF EXISTS "reply_likes_userName_users_email_fk";
+--> statement-breakpoint
 ALTER TABLE "reply_likes" ADD CONSTRAINT "reply_likes_userEmail_users_email_fk" FOREIGN KEY ("userEmail") REFERENCES "public"."users"("email") ON DELETE cascade ON UPDATE no action;

--- a/drizzle/0013_identity_system_update.sql
+++ b/drizzle/0013_identity_system_update.sql
@@ -7,7 +7,10 @@ ALTER TABLE "likes" ADD CONSTRAINT "likes_userEmail_doubtId_unique" UNIQUE("user
 ALTER TABLE "reply_likes" DROP CONSTRAINT IF EXISTS "reply_likes_userName_replyId_unique";
 ALTER TABLE "reply_likes" ADD CONSTRAINT "reply_likes_userEmail_replyId_unique" UNIQUE("userEmail","replyId");
 
--- Clean orphaned records before adding foreign key constraints
+-- Backfill renamed userEmail values that still hold display names, then clean orphans
+UPDATE "likes" SET "userEmail" = u."email" FROM "users" u WHERE lower("likes"."userEmail") = lower(u."name") OR lower("likes"."userEmail") = lower(u."email");
+UPDATE "reply_likes" SET "userEmail" = u."email" FROM "users" u WHERE lower("reply_likes"."userEmail") = lower(u."name") OR lower("reply_likes"."userEmail") = lower(u."email");
+
 DELETE FROM "likes" WHERE "userEmail" NOT IN (SELECT "email" FROM "users");
 DELETE FROM "reply_likes" WHERE "userEmail" NOT IN (SELECT "email" FROM "users");
 

--- a/drizzle/0014_practice_attempts.sql
+++ b/drizzle/0014_practice_attempts.sql
@@ -1,0 +1,29 @@
+CREATE TABLE IF NOT EXISTS "practice_attempts" (
+    "id" integer PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+    "user_email" varchar(255) NOT NULL,
+    "original_doubt_id" integer NOT NULL,
+    "generated_question" text NOT NULL,
+    "user_answer" text,
+    "is_correct" boolean,
+    "ai_feedback" text,
+    "created_at" timestamp DEFAULT now() NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS "practice_attempts_userEmail_idx" ON "practice_attempts" ("user_email");
+CREATE INDEX IF NOT EXISTS "practice_attempts_doubtId_idx" ON "practice_attempts" ("original_doubt_id");
+
+DO $$ BEGIN
+    ALTER TABLE "practice_attempts"
+        ADD CONSTRAINT "practice_attempts_user_email_users_email_fk"
+        FOREIGN KEY ("user_email") REFERENCES "users"("email")
+        ON DELETE CASCADE ON UPDATE NO ACTION;
+EXCEPTION WHEN duplicate_object THEN null;
+END $$;
+
+DO $$ BEGIN
+    ALTER TABLE "practice_attempts"
+        ADD CONSTRAINT "practice_attempts_original_doubt_id_doubts_id_fk"
+        FOREIGN KEY ("original_doubt_id") REFERENCES "doubts"("id")
+        ON DELETE CASCADE ON UPDATE NO ACTION;
+EXCEPTION WHEN duplicate_object THEN null;
+END $$;

--- a/drizzle/0014_practice_attempts.sql
+++ b/drizzle/0014_practice_attempts.sql
@@ -7,19 +7,16 @@ CREATE TABLE IF NOT EXISTS "practice_attempts" (
     "is_correct" boolean,
     "ai_feedback" text,
     "created_at" timestamp DEFAULT now() NOT NULL
-);
-
-CREATE INDEX IF NOT EXISTS "practice_attempts_userEmail_idx" ON "practice_attempts" ("user_email");
-CREATE INDEX IF NOT EXISTS "practice_attempts_doubtId_idx" ON "practice_attempts" ("original_doubt_id");
-
+);--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "practice_attempts_userEmail_idx" ON "practice_attempts" ("user_email");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "practice_attempts_doubtId_idx" ON "practice_attempts" ("original_doubt_id");--> statement-breakpoint
 DO $$ BEGIN
     ALTER TABLE "practice_attempts"
         ADD CONSTRAINT "practice_attempts_user_email_users_email_fk"
         FOREIGN KEY ("user_email") REFERENCES "users"("email")
         ON DELETE CASCADE ON UPDATE NO ACTION;
 EXCEPTION WHEN duplicate_object THEN null;
-END $$;
-
+END $$;--> statement-breakpoint
 DO $$ BEGIN
     ALTER TABLE "practice_attempts"
         ADD CONSTRAINT "practice_attempts_original_doubt_id_doubts_id_fk"

--- a/drizzle/0015_add_onboarding_fields.sql
+++ b/drizzle/0015_add_onboarding_fields.sql
@@ -1,0 +1,7 @@
+ALTER TABLE "users" ADD COLUMN "interests" text;
+--> statement-breakpoint
+ALTER TABLE "users" ADD COLUMN "learningGoals" text;
+--> statement-breakpoint
+ALTER TABLE "users" ADD COLUMN "subjects" text;
+--> statement-breakpoint
+ALTER TABLE "users" ADD COLUMN "instituteInfo" text;

--- a/drizzle/migrate.ts
+++ b/drizzle/migrate.ts
@@ -1,46 +1,189 @@
-import { drizzle } from 'drizzle-orm/neon-http';
-import { neon } from '@neondatabase/serverless';
-import { sql } from 'drizzle-orm';
-import 'dotenv/config';
-import { getDatabaseUrl } from '../src/configs/database-url';
-import fs from 'fs';
-import path from 'path';
+import { createHash, randomUUID } from "crypto";
+import fs from "fs";
+import path from "path";
+import { drizzle } from "drizzle-orm/neon-http";
+import { migrate } from "drizzle-orm/neon-http/migrator";
+import { neon } from "@neondatabase/serverless";
+import { sql } from "drizzle-orm";
+import "dotenv/config";
+import { getDatabaseUrl } from "../src/configs/database-url";
 
-const neonSql = neon(getDatabaseUrl());
-const db = drizzle(neonSql);
+const LOCK_ID = 1;
+const LOCK_TTL_MINUTES = 15;
+const MIGRATIONS_SCHEMA = "drizzle";
+const LOCK_TABLE = "migration_lock";
 
-async function main() {
-    // Read and execute 0007_replies_anonymization.sql manually
-    console.log("Running manual migration 0007_replies_anonymization.sql...");
-    const migration6 = fs.readFileSync(path.join(__dirname, '0007_replies_anonymization.sql'), 'utf-8').split('--> statement-breakpoint');
-    for (const q of migration6) {
-        if (q.trim()) {
-            await db.execute(sql.raw(q.trim()));
-        }
-    }
+export type MigrationFile = {
+  tag: string;
+  when: number;
+  hash: string;
+  statements: string[];
+};
 
-    // Read and execute 0008_environment_cascades.sql manually
-    console.log("Running manual migration 0008_environment_cascades.sql...");
-    const migration7 = fs.readFileSync(path.join(__dirname, '0008_environment_cascades.sql'), 'utf-8').split('--> statement-breakpoint');
-    for (const q of migration7) {
-        if (q.trim()) {
-            await db.execute(sql.raw(q.trim()));
-        }
-    }
+export type JournalEntry = {
+  idx: number;
+  version: string;
+  when: number;
+  tag: string;
+  breakpoints: boolean;
+};
 
-    // Read and execute 0012_fulltext_search.sql manually
-    console.log("Running manual migration 0012_fulltext_search.sql...");
-    const migration9 = fs.readFileSync(path.join(__dirname, '0012_fulltext_search.sql'), 'utf-8').split('--> statement-breakpoint');
-    for (const q of migration9) {
-        if (q.trim()) {
-            await db.execute(sql.raw(q.trim()));
-        }
-    }
-
-    console.log("Migration complete!");
+export function resolveMigrationsFolder(cwd = process.cwd()) {
+  return path.join(cwd, "drizzle");
 }
 
-main().catch((e) => {
-    console.error(e);
+export function readJournal(migrationsFolder: string): JournalEntry[] {
+  const journalPath = path.join(migrationsFolder, "meta", "_journal.json");
+  if (!fs.existsSync(journalPath)) {
+    throw new Error(`Can't find meta/_journal.json in ${migrationsFolder}`);
+  }
+
+  const journal = JSON.parse(fs.readFileSync(journalPath, "utf-8")) as {
+    entries: JournalEntry[];
+  };
+
+  return journal.entries;
+}
+
+export function readMigrationFiles(migrationsFolder: string): MigrationFile[] {
+  const entries = readJournal(migrationsFolder);
+
+  return entries.map((entry) => {
+    const migrationPath = path.join(migrationsFolder, `${entry.tag}.sql`);
+    if (!fs.existsSync(migrationPath)) {
+      throw new Error(`No file ${migrationPath} found in ${migrationsFolder}`);
+    }
+
+    const query = fs.readFileSync(migrationPath, "utf-8");
+    return {
+      tag: entry.tag,
+      when: entry.when,
+      hash: createHash("sha256").update(query).digest("hex"),
+      statements: query
+        .split("--> statement-breakpoint")
+        .map((statement) => statement.trim())
+        .filter(Boolean),
+    };
+  });
+}
+
+export function selectPendingMigrations(
+  migrations: MigrationFile[],
+  lastAppliedWhen: number | null,
+) {
+  if (lastAppliedWhen == null) return migrations;
+  return migrations.filter((migration) => migration.when > lastAppliedWhen);
+}
+
+type DbClient = ReturnType<typeof drizzle>;
+
+async function ensureLockTable(db: DbClient) {
+  await db.execute(sql`CREATE SCHEMA IF NOT EXISTS ${sql.identifier(MIGRATIONS_SCHEMA)}`);
+  await db.execute(sql`
+    CREATE TABLE IF NOT EXISTS ${sql.identifier(MIGRATIONS_SCHEMA)}.${sql.identifier(LOCK_TABLE)} (
+      id integer PRIMARY KEY,
+      holder text NOT NULL,
+      acquired_at timestamptz NOT NULL DEFAULT now()
+    )
+  `);
+}
+
+function extractRows<T>(result: unknown): T[] {
+  if (Array.isArray(result)) return result as T[];
+  if (result && typeof result === "object" && "rows" in result) {
+    const rows = (result as { rows?: T[] }).rows;
+    return Array.isArray(rows) ? rows : [];
+  }
+  return [];
+}
+
+export async function acquireMigrationLock(db: DbClient, holder: string) {
+  await ensureLockTable(db);
+
+  const result = await db.execute(sql`
+    INSERT INTO ${sql.identifier(MIGRATIONS_SCHEMA)}.${sql.identifier(LOCK_TABLE)} (id, holder, acquired_at)
+    VALUES (${LOCK_ID}, ${holder}, now())
+    ON CONFLICT (id) DO UPDATE
+      SET holder = EXCLUDED.holder,
+          acquired_at = EXCLUDED.acquired_at
+      WHERE ${sql.identifier(MIGRATIONS_SCHEMA)}.${sql.identifier(LOCK_TABLE)}.acquired_at
+        < now() - make_interval(mins => ${LOCK_TTL_MINUTES})
+    RETURNING holder
+  `);
+
+  const rows = extractRows<{ holder: string }>(result);
+  if (!rows.some((row) => row.holder === holder)) {
+    throw new Error(
+      "Could not acquire migration lock. Another deploy is likely applying migrations.",
+    );
+  }
+}
+
+export async function releaseMigrationLock(db: DbClient, holder: string) {
+  await db.execute(sql`
+    DELETE FROM ${sql.identifier(MIGRATIONS_SCHEMA)}.${sql.identifier(LOCK_TABLE)}
+    WHERE id = ${LOCK_ID} AND holder = ${holder}
+  `);
+}
+
+export async function runMigrations(options?: {
+  migrationsFolder?: string;
+  databaseUrl?: string;
+}) {
+  const migrationsFolder =
+    options?.migrationsFolder ?? resolveMigrationsFolder();
+  const envUrl = process.env.DATABASE_URL?.trim();
+  const databaseUrl = options?.databaseUrl ?? envUrl;
+
+  if (!databaseUrl) {
+    throw new Error("DATABASE_URL is required to run migrations");
+  }
+
+  // Validate the tracked migration set before touching the database.
+  const migrations = readMigrationFiles(migrationsFolder);
+  if (migrations.length === 0) {
+    throw new Error(`No migrations found in ${migrationsFolder}`);
+  }
+
+  const neonSql = neon(databaseUrl);
+  const db = drizzle(neonSql);
+  const holder = `migrate-${process.pid}-${randomUUID()}`;
+
+  await acquireMigrationLock(db, holder);
+
+  try {
+    console.log(
+      `Running ${migrations.length} tracked migration(s) from ${migrationsFolder}...`,
+    );
+    await migrate(db, { migrationsFolder });
+    console.log("Migration complete!");
+    return { total: migrations.length, tags: migrations.map((m) => m.tag) };
+  } finally {
+    await releaseMigrationLock(db, holder).catch((error) => {
+      console.error("Failed to release migration lock:", error);
+    });
+  }
+}
+
+async function main() {
+  // Prefer explicit env; fall back to shared helper only when set.
+  if (!process.env.DATABASE_URL?.trim()) {
+    // Touch helper for consistent messaging in app contexts, but still fail closed.
+    getDatabaseUrl();
+    throw new Error("DATABASE_URL is required to run migrations");
+  }
+
+  await runMigrations();
+}
+
+const invokedPath = process.argv[1] ? path.resolve(process.argv[1]) : "";
+if (
+  invokedPath.endsWith(`${path.sep}migrate.ts`) ||
+  invokedPath.endsWith(`${path.sep}migrate.js`) ||
+  invokedPath.endsWith(`${path.sep}run-migrations.js`)
+) {
+  main().catch((error) => {
+    console.error(error);
     process.exit(1);
-});
+  });
+}

--- a/drizzle/migrate.ts
+++ b/drizzle/migrate.ts
@@ -119,6 +119,22 @@ export async function acquireMigrationLock(db: DbClient, holder: string) {
   }
 }
 
+export async function renewMigrationLock(db: DbClient, holder: string) {
+  const result = await db.execute(sql`
+    UPDATE ${sql.identifier(MIGRATIONS_SCHEMA)}.${sql.identifier(LOCK_TABLE)}
+    SET acquired_at = now()
+    WHERE id = ${LOCK_ID} AND holder = ${holder}
+    RETURNING holder
+  `);
+
+  const rows = extractRows<{ holder: string }>(result);
+  if (!rows.some((row) => row.holder === holder)) {
+    throw new Error(
+      "Lost migration lock ownership while migrations were still running.",
+    );
+  }
+}
+
 export async function releaseMigrationLock(db: DbClient, holder: string) {
   await db.execute(sql`
     DELETE FROM ${sql.identifier(MIGRATIONS_SCHEMA)}.${sql.identifier(LOCK_TABLE)}
@@ -151,14 +167,28 @@ export async function runMigrations(options?: {
 
   await acquireMigrationLock(db, holder);
 
+  // Renew the lease while migrations run so a healthy holder cannot be stolen
+  // solely because LOCK_TTL_MINUTES elapsed.
+  const renewEveryMs = Math.floor((LOCK_TTL_MINUTES * 60 * 1000) / 3);
+  let renewFailed: Error | undefined;
+  const renewTimer = setInterval(() => {
+    void renewMigrationLock(db, holder).catch((error) => {
+      renewFailed =
+        error instanceof Error ? error : new Error(String(error));
+    });
+  }, renewEveryMs);
+  renewTimer.unref?.();
+
   try {
     console.log(
       `Running ${migrations.length} tracked migration(s) from ${migrationsFolder}...`,
     );
     await migrate(db, { migrationsFolder });
+    if (renewFailed) throw renewFailed;
     console.log("Migration complete!");
     return { total: migrations.length, tags: migrations.map((m) => m.tag) };
   } finally {
+    clearInterval(renewTimer);
     await releaseMigrationLock(db, holder).catch((error) => {
       console.error("Failed to release migration lock:", error);
     });

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test": "jest --watchAll=false --forceExit",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
+    "db:migrate": "tsx drizzle/migrate.ts",
     "prepare": "husky"
   },
   "dependencies": {

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -eu
+
+echo "[entrypoint] Applying database migrations..."
+node ./scripts/run-migrations.js
+
+echo "[entrypoint] Starting application..."
+exec node server.js

--- a/src/__tests__/drizzle/migrate-runner.test.ts
+++ b/src/__tests__/drizzle/migrate-runner.test.ts
@@ -1,0 +1,87 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import {
+  readMigrationFiles,
+  selectPendingMigrations,
+  type MigrationFile,
+} from "../../../drizzle/migrate";
+
+const drizzleDir = path.join(process.cwd(), "drizzle");
+
+describe("migration runner coverage", () => {
+  it("reads every journal entry including late schema migrations", () => {
+    const migrations = readMigrationFiles(drizzleDir);
+    const tags = migrations.map((migration) => migration.tag);
+
+    expect(tags).toContain("0000_bitter_tyger_tiger");
+    expect(tags).toContain("0016_video_jobs");
+    expect(tags).toContain("0019_doubts_composite_indexes");
+    expect(migrations.length).toBeGreaterThanOrEqual(20);
+    expect(migrations.every((migration) => migration.statements.length > 0)).toBe(
+      true,
+    );
+  });
+
+  it("treats an empty database as needing the full migration set", () => {
+    const migrations = readMigrationFiles(drizzleDir);
+    const pending = selectPendingMigrations(migrations, null);
+
+    expect(pending).toHaveLength(migrations.length);
+    expect(pending[0]?.tag).toBe(migrations[0]?.tag);
+  });
+
+  it("only schedules migrations newer than an older database watermark", () => {
+    const migrations: MigrationFile[] = [
+      {
+        tag: "0000_base",
+        when: 100,
+        hash: "a",
+        statements: ["SELECT 1"],
+      },
+      {
+        tag: "0016_video_jobs",
+        when: 200,
+        hash: "b",
+        statements: ["SELECT 2"],
+      },
+      {
+        tag: "0019_indexes",
+        when: 300,
+        hash: "c",
+        statements: ["SELECT 3"],
+      },
+    ];
+
+    const pending = selectPendingMigrations(migrations, 100);
+    expect(pending.map((migration) => migration.tag)).toEqual([
+      "0016_video_jobs",
+      "0019_indexes",
+    ]);
+  });
+
+  it("fails fast when a journal entry is missing its SQL file", () => {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "doubtdesk-migrate-"));
+    const metaDir = path.join(tempRoot, "meta");
+    fs.mkdirSync(metaDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(metaDir, "_journal.json"),
+      JSON.stringify({
+        version: "7",
+        dialect: "postgresql",
+        entries: [
+          {
+            idx: 0,
+            version: "7",
+            when: 1,
+            tag: "0000_missing",
+            breakpoints: true,
+          },
+        ],
+      }),
+    );
+
+    expect(() => readMigrationFiles(tempRoot)).toThrow(/0000_missing\.sql/);
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  });
+});

--- a/src/__tests__/drizzle/migrate-runner.test.ts
+++ b/src/__tests__/drizzle/migrate-runner.test.ts
@@ -10,16 +10,59 @@ import {
 const drizzleDir = path.join(process.cwd(), "drizzle");
 
 describe("migration runner coverage", () => {
+  it("keeps _journal.json indexes contiguous and files present", () => {
+    const journalPath = path.join(drizzleDir, "meta", "_journal.json");
+    const journal = JSON.parse(fs.readFileSync(journalPath, "utf-8")) as {
+      entries: Array<{ idx: number; tag: string; breakpoints: boolean }>;
+    };
+
+    const idxs = journal.entries.map((entry) => entry.idx);
+    expect(idxs).toEqual([...Array(journal.entries.length).keys()]);
+    expect(journal.entries.every((entry) => entry.breakpoints === true)).toBe(
+      true,
+    );
+
+    for (const entry of journal.entries) {
+      expect(
+        fs.existsSync(path.join(drizzleDir, `${entry.tag}.sql`)),
+      ).toBe(true);
+    }
+  });
+
   it("reads every journal entry including late schema migrations", () => {
     const migrations = readMigrationFiles(drizzleDir);
     const tags = migrations.map((migration) => migration.tag);
 
     expect(tags).toContain("0000_bitter_tyger_tiger");
+    expect(tags).toContain("0013_identity_system_update");
+    expect(tags).toContain("0014_practice_attempts");
+    expect(tags).toContain("0015_add_onboarding_fields");
     expect(tags).toContain("0016_video_jobs");
     expect(tags).toContain("0019_doubts_composite_indexes");
     expect(migrations.length).toBeGreaterThanOrEqual(20);
     expect(migrations.every((migration) => migration.statements.length > 0)).toBe(
       true,
+    );
+  });
+
+  it("splits Neon HTTP-critical migrations into single-statement groups", () => {
+    const migrations = readMigrationFiles(drizzleDir);
+    const byTag = Object.fromEntries(
+      migrations.map((migration) => [migration.tag, migration]),
+    );
+
+    // 0012 must not use CREATE INDEX CONCURRENTLY (forbidden in Neon HTTP txs).
+    expect(byTag["0012_fulltext_search"].statements.join("\n")).not.toMatch(
+      /CREATE INDEX CONCURRENTLY/i,
+    );
+
+    // Multi-statement migrations must be breakpoint-split for Neon HTTP.
+    expect(byTag["0013_identity_system_update"].statements.length).toBeGreaterThan(
+      1,
+    );
+    expect(byTag["0014_practice_attempts"].statements.length).toBeGreaterThan(1);
+    expect(byTag["0015_add_onboarding_fields"].statements.length).toBeGreaterThan(
+      1,
     );
   });
 


### PR DESCRIPTION
## **User description**
## Description
The production image started `node server.js` without `drizzle/` and the manual migrate script only ran a few early SQL files. Restored the missing 0013–0015 migration files, rewrote the runner to apply the full journal (with a deploy lock), bundled it into the image, and run it from the container entrypoint before the app starts.

## Related Issue
Closes #1177

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Documentation update (README, guides, comments)
- [ ] Style / UI change (no logic change)
- [ ] Code refactor (no behavior change)
- [ ] Test addition or update
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## How Has This Been Tested?
- [x] Tested locally with `npm run dev`
- [ ] Verified on mobile viewport (375px)
- [ ] Verified on desktop viewport (1440px)

- `npx tsc --noEmit` passes
- `npm test -- src/__tests__/drizzle/` — 7 passing (integrity + empty/older DB pending selection)
- Verified esbuild can bundle `drizzle/migrate.ts` and read all 20 tracked migrations

## Checklist
- [x] I have tested my changes locally (`npm run dev`)
- [x] My code follows the existing code style (TypeScript, Tailwind, no `any` types)
- [x] I have not introduced unrelated changes (each PR should address one issue)
- [x] I have added comments where necessary
- [x] My branch is up to date with `main`
- [x] I have linked the related issue above
- [ ] Screenshots are included (if this is a UI change)

Made with [Cursor](https://cursor.com)


___

## **CodeAnt-AI Description**
Run the complete database migration set safely before production starts

### What Changed
- Production containers now validate and apply every tracked database migration before starting the application
- Deploys stop before changing the database when a migration file is missing, and prevent overlapping migration runs with a deploy lock
- Migrations now work with Neon HTTP by splitting multi-statement changes and avoiding unsupported concurrent index creation
- Added coverage for migration completeness, ordering, missing files, pending migrations, and Neon-compatible statement splitting

### Impact
`✅ Fewer production startup failures from incomplete migrations`
`✅ Safer concurrent deploys`
`✅ Reliable Neon HTTP migrations`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for saving practice attempts, including questions, answers, correctness, feedback, and timestamps.
  * Added onboarding fields for interests, learning goals, subjects, and institute information.

* **Bug Fixes**
  * Improved full-text search setup and data consistency for saved likes.

* **Improvements**
  * Database updates now run automatically and reliably when the application starts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->