### PR TITLE
fix(bookmarks): exclude soft-deleted doubts from bookmarks total

### DIFF
--- a/src/__tests__/api/bookmarks-deleted-total.test.ts
+++ b/src/__tests__/api/bookmarks-deleted-total.test.ts
@@ -1,0 +1,59 @@
+import { GET } from "@/app/api/bookmarks/route";
+import { currentUser } from "@clerk/nextjs/server";
+import { db } from "@/configs/db";
+
+jest.mock("@clerk/nextjs/server", () => ({
+  currentUser: jest.fn(),
+}));
+
+jest.mock("@/lib/errors/error-handler", () => ({
+  buildErrorResponse: jest.fn().mockReturnValue({
+    status: 500,
+    body: { error: "Internal Server Error" },
+  }),
+  errorResponse: (message: string, status: number) =>
+    Response.json({ error: message }, { status }),
+}));
+
+jest.mock("@/configs/db", () => ({
+  db: {
+    select: jest.fn(),
+  },
+}));
+
+describe("Bookmarks API soft-delete totals", () => {
+  const mockCurrentUser = currentUser as jest.Mock;
+  const dbMock = db as jest.Mocked<typeof db>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCurrentUser.mockResolvedValue({
+      primaryEmailAddress: { emailAddress: "student@example.com" },
+    });
+  });
+
+  it("reports total 0 when every bookmark points at a soft-deleted doubt", async () => {
+    const countWhere = jest.fn().mockResolvedValue([{ total: 0 }]);
+    const countJoin = jest.fn().mockReturnValue({ where: countWhere });
+
+    (dbMock.select as jest.Mock).mockImplementationOnce(() => ({
+      from: jest.fn().mockReturnValue({
+        innerJoin: countJoin,
+      }),
+    }));
+
+    const res = await GET(
+      new Request("http://localhost/api/bookmarks?page=1&limit=20"),
+    );
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(countJoin).toHaveBeenCalled();
+    expect(json).toEqual({
+      data: [],
+      pagination: { page: 1, limit: 20, total: 0 },
+    });
+    // No further queries once the eligible total is zero.
+    expect(dbMock.select).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/app/api/bookmarks/route.ts
+++ b/src/app/api/bookmarks/route.ts
@@ -35,7 +35,11 @@ export async function GET(req: Request) {
         const [totalCountResult] = await db
             .select({ total: count() })
             .from(bookmarksTable)
-            .where(eq(bookmarksTable.userEmail, email));
+            .innerJoin(doubtsTable, eq(bookmarksTable.doubtId, doubtsTable.id))
+            .where(and(
+                eq(bookmarksTable.userEmail, email),
+                isNull(doubtsTable.deletedAt),
+            ));
         const totalBookmarks = totalCountResult?.total || 0;
 
         if (totalBookmarks === 0) {
@@ -49,7 +53,11 @@ export async function GET(req: Request) {
         const bookmarks = await db
             .select({ doubtId: bookmarksTable.doubtId })
             .from(bookmarksTable)
-            .where(eq(bookmarksTable.userEmail, email))
+            .innerJoin(doubtsTable, eq(bookmarksTable.doubtId, doubtsTable.id))
+            .where(and(
+                eq(bookmarksTable.userEmail, email),
+                isNull(doubtsTable.deletedAt),
+            ))
             .limit(limit)
             .offset(offset);
 


### PR DESCRIPTION
## **User description**
## Description
Bookmarks `pagination.total` counted every bookmark row, including ones whose doubt was soft-deleted, so clients could see `data: []` with a non-zero total. Count and page queries now join `doubts` and require `deletedAt IS NULL`, matching the data filter.

## Related Issue
Closes #1179

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Documentation update (README, guides, comments)
- [ ] Style / UI change (no logic change)
- [ ] Code refactor (no behavior change)
- [ ] Test addition or update
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## How Has This Been Tested?
- [x] Tested locally with `npm run dev`
- [ ] Verified on mobile viewport (375px)
- [ ] Verified on desktop viewport (1440px)

- `npx tsc --noEmit` passes
- `npm test -- src/__tests__/api/bookmarks-deleted-total.test.ts` — covers all-deleted bookmarks reporting total 0

## Checklist
- [x] I have tested my changes locally (`npm run dev`)
- [x] My code follows the existing code style (TypeScript, Tailwind, no `any` types)
- [x] I have not introduced unrelated changes (each PR should address one issue)
- [x] I have added comments where necessary
- [x] My branch is up to date with `main`
- [x] I have linked the related issue above
- [ ] Screenshots are included (if this is a UI change)

Made with [Cursor](https://cursor.com)


___

## **CodeAnt-AI Description**
**Exclude soft-deleted doubts from bookmark totals**

### What Changed
- Bookmark totals now include only bookmarks linked to active doubts
- Bookmark results apply the same active-doubt filter, keeping totals and returned data consistent
- Requests with no eligible bookmarks return an empty list with a total of `0` without running an unnecessary data query
- Added coverage for accounts whose bookmarks all reference soft-deleted doubts

### Impact
`✅ Accurate bookmark totals`
`✅ No empty pages with non-zero counts`
`✅ Fewer unnecessary database queries`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
