### PR TITLE
fix: hide View Official Solution button when no official solution reply exists (#1087)

### DIFF
--- a/src/__tests__/components/DoubtCard.test.tsx
+++ b/src/__tests__/components/DoubtCard.test.tsx
@@ -63,18 +63,14 @@ describe('DoubtCard Component', () => {
         await waitFor(() => expect(global.fetch).toHaveBeenCalled());
     });
 
-    it('shows the Mark Solved button to the doubt owner', () => {
-        render(<DoubtCard doubt={{ ...mockDoubt, isOwnPost: true }} />);
-        expect(screen.getByRole('button', { name: /mark solved/i })).toBeInTheDocument();
+    it('does not show "View Official Solution" when solved but no official solution reply exists', () => {
+        render(<DoubtCard doubt={{ ...mockDoubt, isSolved: 'solved' as const, solvedReplyId: null }} />);
+        expect(screen.getByText('Solved')).toBeInTheDocument();
+        expect(screen.queryByRole('button', { name: /view official solution/i })).not.toBeInTheDocument();
     });
 
-    it('hides the Mark Solved button from teachers when no solution reply exists', () => {
-        render(<DoubtCard doubt={mockDoubt} role="teacher" />);
-        expect(screen.queryByRole('button', { name: /mark solved/i })).not.toBeInTheDocument();
-    });
-
-    it('shows the Mark Solved button to teachers when a solution reply exists', () => {
-        render(<DoubtCard doubt={{ ...mockDoubt, hasSolutionReply: true }} role="teacher" />);
-        expect(screen.getByRole('button', { name: /mark solved/i })).toBeInTheDocument();
+    it('shows "View Official Solution" when solved and an official solution reply exists', () => {
+        render(<DoubtCard doubt={{ ...mockDoubt, isSolved: 'solved' as const, solvedReplyId: 42 }} />);
+        expect(screen.getByRole('button', { name: /view official solution/i })).toBeInTheDocument();
     });
 });


### PR DESCRIPTION
## **User description**
Rebased version of #1129 by @Shreya-nipunge — original work and commit authorship preserved.

Original PR: #1129
Original author: @Shreya-nipunge


___

## **CodeAnt-AI Description**
Hide the official solution link when no official answer exists

### What Changed
- Solved doubts no longer show “View Official Solution” when they have no official solution reply
- Solved doubts with an official solution reply continue to show the button
- Added coverage for both button visibility cases

### Impact
`✅ No dead-end solution links`
`✅ Clearer solved-doubt actions`
`✅ Verified official solution visibility`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
