### PR TITLE
fix(accept): prevent karma farming by locking the accepted reply once solved

### DIFF
--- a/src/app/api/doubts/[id]/accept/route.test.ts
+++ b/src/app/api/doubts/[id]/accept/route.test.ts
@@ -194,3 +194,57 @@ describe("POST /api/doubts/[id]/accept — idempotency (issue #687)", () => {
         expect(JSON.stringify(body)).not.toContain("does not exist");
     });
 });
+
+describe("POST /api/doubts/[id]/accept — accepted-reply lock (issue #1315)", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockInngestSend.mockReset();
+        mockSelectCallCount = 0;
+
+        // Default: unsolved doubt, valid reply, state-changing update
+        mockDoubt = { userEmail: "asker@test.com", isSolved: "unsolved", solvedReplyId: null };
+        mockReply = { userEmail: "answerer@test.com", doubtId: 1 };
+        mockUpdatedDoubt = { id: 1 };
+    });
+
+    it("does not re-award karma when the owner switches to a different reply", async () => {
+        // Doubt is already solved with reply 42; the owner now tries to accept reply 41.
+        // The atomic UPDATE WHERE clause must find no matching row (solved + pinned),
+        // so the state change and the karma event are both skipped.
+        mockDoubt = { userEmail: "asker@test.com", isSolved: "solved", solvedReplyId: 42 };
+        mockUpdatedDoubt = null;
+
+        const res = await callPost(41);
+        const body = await res.json();
+
+        expect(res.status).toBe(200);
+        expect(body.success).toBe(true);
+        expect(body.message).toBe("Answer was already accepted (no-op)");
+        expect(mockInngestSend).not.toHaveBeenCalled();
+    });
+
+    it("grants karma only once across an A → B → A switch cycle", async () => {
+        // First POST — genuine state transition (reply 42 accepted)
+        const res1 = await callPost(42);
+        expect((await res1.json()).message).toBe("Answer accepted successfully");
+        expect(mockInngestSend).toHaveBeenCalledTimes(1);
+
+        // Switch to reply 41 — doubt already solved, must be a no-op (no karma)
+        mockSelectCallCount = 0;
+        mockInngestSend.mockClear();
+        mockDoubt = { userEmail: "asker@test.com", isSolved: "solved", solvedReplyId: 42 };
+        mockUpdatedDoubt = null;
+
+        const res2 = await callPost(41);
+        expect((await res2.json()).message).toBe("Answer was already accepted (no-op)");
+        expect(mockInngestSend).not.toHaveBeenCalled();
+
+        // Switch back to reply 42 — still a no-op (no karma)
+        mockSelectCallCount = 0;
+        mockInngestSend.mockClear();
+
+        const res3 = await callPost(42);
+        expect((await res3.json()).message).toBe("Answer was already accepted (no-op)");
+        expect(mockInngestSend).not.toHaveBeenCalled();
+    });
+});

--- a/src/app/api/doubts/[id]/accept/route.ts
+++ b/src/app/api/doubts/[id]/accept/route.ts
@@ -98,8 +98,7 @@ export async function POST(
                     eq(doubtsTable.userEmail, loggedInUserEmail),
                     or(
                         ne(doubtsTable.isSolved, "solved"),
-                        isNull(doubtsTable.solvedReplyId),
-                        ne(doubtsTable.solvedReplyId, replyId)
+                        isNull(doubtsTable.solvedReplyId)
                     )
                 )
             )


### PR DESCRIPTION
## **User description**
## Description

Fixed a karma-farming exploit in the accepted-answer flow that let a doubt owner mint unlimited +25 karma grants by switching the accepted reply.

During investigation of #1315, the root cause was the atomic `UPDATE` guard in `src/app/api/doubts/[id]/accept/route.ts`. The `WHERE` clause contained a third disjunct `ne(solvedReplyId, replyId)`, which meant that once a doubt was solved, submitting a *different* `replyId` still matched a row and proceeded with the update. Each successful switch re-emitted the `karma/answer.accepted` Inngest event, awarding the new author +25 karma, while the previously accepted author was never debited — so an owner could bounce acceptance `A → B → A → B → ...` and mint +25 on every single bounce (`karma/answer.accepted` grants +25 per event, confirmed in the karma worker).

The fix removes that disjunct. Now the update only proceeds while the doubt is not yet solved (or `solvedReplyId` is still `NULL`). Once a reply has been pinned, every subsequent accept — same reply or different — is a genuine no-op at the database level and no karma event is emitted, keeping the ledger karmically neutral.

### Changes

* Removed the `ne(solvedReplyId, replyId)` branch from the atomic `UPDATE ... WHERE` clause so an already-solved doubt's accepted reply is locked.
* Preserved the existing idempotency guarantee: re-accepting the same reply still returns the `200` no-op response without re-awarding karma.
* Added acceptance-lock coverage to the accept-route test suite:

  * Switching to a different reply on an already-solved doubt is a no-op and emits no karma event.
  * An `A → B → A` switch cycle grants karma exactly once (first accept only).

### Testing

* `npx tsc --noEmit` ✅
* `npx jest accept --watchAll=false --forceExit` ✅
* 7/7 accept-route tests passing (5 existing + 2 new).
* `npx eslint` on changed files ✅
* `git diff --check` ✅

### Related Issue

Closes #1315

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Lock the accepted reply after a doubt is solved

### What Changed
- Once an answer is accepted, attempts to switch to another answer or re-accept the same one now have no effect
- Only the first acceptance triggers the karma award, preventing repeated rewards from switching answers
- Added coverage for switching answers and repeating an A → B → A cycle

### Impact
`✅ Prevented repeated karma awards`
`✅ Locked accepted answers after resolution`
`✅ Preserved safe no-op responses for repeated acceptance`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented solved doubts from being reassigned to a different accepted reply.
  * Ensured accepting another reply after a doubt is solved completes safely without awarding additional karma.
  * Preserved correct karma behavior when switching acceptance attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->