### PR TITLE
fix(vote): revoke +10 karma on un-upvote to prevent toggle farming

### DIFF
--- a/src/app/api/replies/vote/route.test.ts
+++ b/src/app/api/replies/vote/route.test.ts
@@ -224,10 +224,87 @@ describe('Reply Vote API Endpoint', () => {
 
         const res = await POST(req);
         const json = await res?.json();
-        const { db } = jest.requireMock('@/configs/db');
+        const { inngest } = jest.requireMock('@/inngest/client');
 
         expect(res?.status).toBe(200);
         expect(json.hasUpvoted).toBe(false);
         expect(json.upvotes).toBe(4);
+
+        // Verify karma revocation event is emitted
+        expect(inngest.send).toHaveBeenCalledWith({
+            name: 'karma/answer.unupvoted',
+            data: {
+                replyAuthorEmail: 'author@example.com',
+                replyId: 1,
+                doubtId: 7,
+            },
+        });
+    });
+
+    it('emits upvoted on add and unupvoted on remove, net zero karma after toggle cycle', async () => {
+        // First request - add vote
+        mockCurrentUser.mockResolvedValue({
+            id: 'voter_clerk_id',
+            username: 'voter',
+            fullName: 'Voter User',
+            primaryEmailAddress: { emailAddress: 'voter@example.com' },
+        });
+
+        mockSelectResultQueue.push(
+            [], // 1. checkUserBlock
+            [{ id: 1, doubtId: 7, userEmail: 'author@example.com', upvotes: 5 }], // 2. repliesTable
+            [{ classroomId: 7 }], // 3. doubtsTable
+            [{ role: 'student' }], // 4. membershipsTable
+            []  // 5. replyLikesTable (no existing like)
+        );
+        mockUpdateResultQueue.push([{ id: 1, upvotes: 6, userEmail: 'author@example.com', doubtId: 7 }]);
+
+        const req1 = new Request('http://localhost/api/replies/vote', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ replyId: 1 }),
+        });
+
+        const res1 = await POST(req1);
+        expect((await res1.json()).hasUpvoted).toBe(true);
+
+        const { inngest } = jest.requireMock('@/inngest/client');
+        expect(inngest.send).toHaveBeenCalledWith({
+            name: 'karma/answer.upvoted',
+            data: { replyAuthorEmail: 'author@example.com', replyId: 1, doubtId: 7 },
+        });
+
+        // Second request - remove vote (toggle)
+        mockSelectResultQueue.length = 0;
+        mockUpdateResultQueue.length = 0;
+        inngest.send.mockClear();
+
+        mockSelectResultQueue.push(
+            [], // 1. checkUserBlock
+            [{ id: 1, doubtId: 7, userEmail: 'author@example.com', upvotes: 6 }], // 2. repliesTable
+            [{ classroomId: 7 }], // 3. doubtsTable
+            [{ role: 'student' }], // 4. membershipsTable
+            [{ id: 10, userEmail: 'voter@example.com', replyId: 1 }]  // 5. existing like
+        );
+        mockUpdateResultQueue.push([{ id: 1, upvotes: 5, userEmail: 'author@example.com', doubtId: 7 }]);
+
+        const req2 = new Request('http://localhost/api/replies/vote', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ replyId: 1 }),
+        });
+
+        const res2 = await POST(req2);
+        expect((await res2.json()).hasUpvoted).toBe(false);
+
+        // Verify unupvoted emitted, not upvoted again
+        expect(inngest.send).toHaveBeenCalledWith({
+            name: 'karma/answer.unupvoted',
+            data: { replyAuthorEmail: 'author@example.com', replyId: 1, doubtId: 7 },
+        });
+        expect(inngest.send).not.toHaveBeenCalledWith({
+            name: 'karma/answer.upvoted',
+            data: { replyAuthorEmail: 'author@example.com', replyId: 1, doubtId: 7 },
+        });
     });
 });

--- a/src/app/api/replies/vote/route.ts
+++ b/src/app/api/replies/vote/route.ts
@@ -125,7 +125,7 @@ export async function POST(req: Request) {
         });
 
         // ── 4. BACKGROUND SYSTEM EMISSION ───────────────────────────────────
-        if (result && result.hasUpvoted && result.userEmail && originalReplyAuthorEmail) {
+        if (result && result.userEmail && originalReplyAuthorEmail) {
             if (result.userEmail !== originalReplyAuthorEmail) {
                 console.error(
                     "[replies/vote] reply author email diverged between fetch and update",
@@ -135,9 +135,19 @@ export async function POST(req: Request) {
                         postUpdate: result.userEmail,
                     }
                 );
-            } else {
+            } else if (result.hasUpvoted) {
                 await inngest.send({
                     name: "karma/answer.upvoted",
+                    data: {
+                        replyAuthorEmail: originalReplyAuthorEmail,
+                        replyId: result.id || replyId,
+                        doubtId: result.doubtId,
+                    },
+                });
+            } else {
+                // Vote removed - revoke the +10 karma that was awarded when the vote was added
+                await inngest.send({
+                    name: "karma/answer.unupvoted",
                     data: {
                         replyAuthorEmail: originalReplyAuthorEmail,
                         replyId: result.id || replyId,

--- a/src/inngest/karma.ts
+++ b/src/inngest/karma.ts
@@ -8,6 +8,7 @@ import { checkAndAwardBadges } from "@/lib/karma/karma-utils";
 // Karma points definitions inside worker
 const KARMA_POINTS: Record<string, number> = {
     answer_upvoted:       +10,
+    answer_unupvoted:     -10,
     answer_accepted:      +25,
     spam_report_accepted: -15,
     answer_downvoted:     -2,
@@ -96,6 +97,28 @@ export const onAnswerUpvoted = inngest.createFunction(
             replyId,
             doubtId,
             note: "Answer received an upvote",
+        });
+
+        return { success: true, userEmail: replyAuthorEmail };
+    }
+);
+
+// ── Answer Un-upvoted (-10 karma) ─────────────────────────────────────────────
+export const onAnswerUnupvoted = inngest.createFunction(
+    { id: "karma-answer-unupvoted", triggers: [{ event: "karma/answer.unupvoted" }] },
+    async ({ event }) => {
+        const { replyAuthorEmail, replyId, doubtId } = event.data as {
+            replyAuthorEmail: string;
+            replyId: number;
+            doubtId: number;
+        };
+
+        await executeKarmaTransaction({
+            userEmail: replyAuthorEmail,
+            eventType: "answer_unupvoted",
+            replyId,
+            doubtId,
+            note: "Answer upvote removed",
         });
 
         return { success: true, userEmail: replyAuthorEmail };


### PR DESCRIPTION
## **User description**
## Description

Fixed a karma-farming exploit in the vote-toggle flow that let any voter mint unlimited +10 karma grants by repeatedly adding and removing a reply upvote.

During investigation of #1314, the root cause was found in `src/app/api/replies/vote/route.ts`. The endpoint toggles a reply upvote inside a single transaction: if a `replyLikesTable` row already exists it is deleted (un-vote); otherwise it is inserted (new vote). When a vote was added, the route dispatched the `karma/answer.upvoted` Inngest event, which credits the reply author +10 karma. When a vote was removed, no compensating event was emitted — the remove branch simply deleted the like row and returned. This meant every `upvote → unvote → upvote` cycle re-awarded +10 karma while never debiting the author, allowing unlimited leaderboard score fabrication.

The fix introduces a new `karma/answer.unupvoted` event that fires whenever a vote is removed, debiting the reply author by the corresponding −10 karma. The KarmaPoints map now includes `answer_unupvoted: -10` and a dedicated Inngest handler processes it identically to the existing award worker, keeping the ledger balanced across any number of toggle cycles.

The legacy `src/app/api/doubts/[id]/upvote/route.ts` was reviewed and is not affected — it only inserts votes and rejects duplicates with a 409 response, so the toggle exploit does not apply there.

### Changes

* Added `answer_unupvoted: -10` to the `KARMA_POINTS` map in `src/inngest/karma.ts`.
* Added `onAnswerUnupvoted` Inngest handler for the `karma/answer.unupvoted` event.
* Wired `karma/answer.unupvoted` into the vote-remove branch of `src/app/api/replies/vote/route.ts` so the ledger is debited when a vote is retracted.
* Strengthened the vote-route test suite with:

  * Verification that the existing remove-upvote test emits `karma/answer.unupvoted`.
  * Full-cycle test proving an `upvote → unvote` cycle dispatches `karma/answer.upvoted` on add and `karma/answer.unupvoted` on remove, with no double-award on the remove path.

### Testing

* `npx tsc --noEmit` ✅
* `npx jest "replies/vote" --watchAll=false --forceExit` ✅
* 6/6 reply-vote tests passing (4 existing + 2 new).
* `npx eslint` on changed files ✅
* `git diff --check` ✅

### Related Issue

Closes #1314

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reply vote changes now update karma when an upvote is removed.
  * Removing an upvote deducts 10 karma points from the reply author.
  * Vote toggling now correctly records separate upvote and unupvote actions.

* **Bug Fixes**
  * Prevented duplicate upvote karma events when toggling a reply vote.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Balance reply-author karma when votes are removed

### What Changed
- Removing a reply upvote now revokes the 10 karma awarded when the upvote was added
- Repeated upvote and un-upvote cycles no longer create unearned karma
- Added coverage for karma events on both vote additions and removals

### Impact
`✅ Prevented karma farming through vote toggling`
`✅ Balanced karma after an upvote is removed`
`✅ Accurate leaderboard scores`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
