### PR TITLE
fix(streak): correct daysDiff branching in updateStreak

### DIFF
--- a/src/lib/karma/karma-utils.ts
+++ b/src/lib/karma/karma-utils.ts
@@ -162,14 +162,13 @@ export async function updateStreak(userEmail: string): Promise<void> {
     const activeTimestamp = new Date(user.lastActiveDate).getTime();
     const daysDiff = Math.floor((todayMidnight - activeTimestamp) / oneDayMs);
 
-    if (daysDiff === 0) {
+    if (daysDiff === 1) {
+        // Consecutive day: last active yesterday → extend streak
         const nextStreakVal = user.currentStreak + 1;
 
         await db.transaction(async (tx) => {
-            // Compute the target score inline to resolve level scaling factors
             const nextScoreSql = sql`${usersTable.karmaScore} + 5`;
 
-            // Recompute tier level thresholds instantly during the same write lock sequence
             const atomicLevelCaseSql = sql`CASE 
                 WHEN ${nextScoreSql} >= 1500 THEN 5
                 WHEN ${nextScoreSql} >= 700  THEN 4
@@ -178,14 +177,13 @@ export async function updateStreak(userEmail: string): Promise<void> {
                 ELSE 1
             END`;
 
-            // ✅ Native Date assignment applied safely inside the transaction payload
             await tx
                 .update(usersTable)
                 .set({ 
                     karmaScore: nextScoreSql,
                     karmaLevel: atomicLevelCaseSql, 
                     currentStreak: nextStreakVal,
-                    lastActiveDate: now, // Advancing the marker prevents double-dipping
+                    lastActiveDate: now,
                 })
                 .where(eq(usersTable.email, userEmail));
 


### PR DESCRIPTION
## **User description**
## Description

Fixed inverted `daysDiff` branching in `updateStreak` that caused same-day activity to double-count streaks while consecutive-day activity was never rewarded.

During investigation of #1313, `src/lib/karma/karma-utils.ts:updateStreak` was found to branch on `daysDiff === 0` to fire the streak increment and +5 bonus. Because `daysDiff` is computed as `Math.floor((todayMidnight - activeTimestamp) / oneDayMs)`, a value of `0` means the user's last active timestamp fell on the same calendar day (i.e. the user posted for a second time today), not a new consecutive day. The function was therefore:

* **Incorrectly awarding** +5 karma and incrementing `currentStreak` on every same-day re-visit (`daysDiff === 0`), double-counting daily activity.
* **Skipping the correct case** — `daysDiff === 1` (last active yesterday) — which is the genuine consecutive-day milestone that should extend a streak, but had no matching branch at all.
* **Correctly resetting** the streak when `daysDiff >= 2` (one or more full days missed).

The fix re-roots the increment branch on `daysDiff === 1` and lets `daysDiff === 0` fall through as a no-op, matching the intended semantic: a streak grows only when a user becomes active on a new calendar day after being absent the previous day.

The `updateStreak` function is currently dead code (not imported by any route or worker), but is exported as part of the karma utilities and will be wired in future. The fix corrects the logic in anticipation of that integration.

### Changes

* Changed the guard from `daysDiff === 0` to `daysDiff === 1` so the streak increment and +5 bonus fire only on consecutive-day activity.
* Left `daysDiff === 0` as a silent no-op (same-day re-visits do not re-award the streak bonus).
* Preserved the existing `daysDiff >= 2` reset branch unchanged.
* Removed stale inline comments that described the now-corrected behavior.

### Testing

* `npx tsc --noEmit` ✅
* `npx eslint src/lib/karma/karma-utils.ts` ✅
* `git diff --check` ✅
* Full suite: 249/266 passing (17 pre-existing failures from missing env vars / Playwright-in-Jest conflicts — none related to this change).

### Related Issue

Closes #1313

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected streak increment logic so consecutive-day activity extends the streak while same-day re-visits are a no-op.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Correct consecutive-day streak rewards

### What Changed
- Streaks now increase and award 5 karma when users return after being active yesterday
- Repeat activity on the same day no longer increases the streak or awards duplicate bonus karma
- Missed-day streak resets remain unchanged

### Impact
`✅ Accurate daily streak counts`
`✅ No duplicate same-day streak rewards`
`✅ Correct 5-karma consecutive-day bonuses`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
