### PR TITLE
fix(streak): wire lastContributionAt writes so daily streak cron can fire

### DIFF
--- a/src/app/api/doubts/route.ts
+++ b/src/app/api/doubts/route.ts
@@ -8,6 +8,7 @@ import {
   repliesTable,
   tagsTable,
   membershipsTable,
+  usersTable,
 } from "@/configs/schema";
 import { categorizeDoubt } from "@/lib/ai/categorizer";
 import { safeGenerateEmbedding } from "@/lib/ai/embeddings";
@@ -410,6 +411,12 @@ export async function POST(req: Request) {
         createdAt: parsedCreatedAt,
       })
       .returning();
+
+    // Touch the streak heartbeat so the daily cron can award streak bonuses.
+    await db
+      .update(usersTable)
+      .set({ lastContributionAt: new Date() })
+      .where(eq(usersTable.email, email));
 
     try {
       const embeddingInput = `${subject}\n${content || ""}`.trim();

--- a/src/app/api/replies/route.ts
+++ b/src/app/api/replies/route.ts
@@ -205,6 +205,12 @@ export async function POST(req: Request) {
       })
       .returning();
 
+    // Touch the streak heartbeat so the daily cron can award streak bonuses.
+    await db
+      .update(usersTable)
+      .set({ lastContributionAt: new Date() })
+      .where(eq(usersTable.email, email));
+
     createReplyNotification({
       doubtId,
       replyId: newReply[0].id,


### PR DESCRIPTION
## **User description**
## Description

Wired the `lastContributionAt` heartbeat into both contribution routes so the daily streak cron can actually find and process users.

During investigation of #1316, `dailyStreakProcessor` in `src/inngest/karma.ts` was found to query `users WHERE lastContributionAt IS NOT NULL` (line 209), but no code path in the entire application ever wrote to the `lastContributionAt` column. The column is declared in `src/configs/schema.ts:30` and the processor reads it, but every other write site only touches the separate `lastActiveDate` column (used by the separate `updateStreak` utility). Because `lastContributionAt` was always `NULL`, the cron selected zero users on every run, and the entire daily streak system — milestone bonuses, +5 per-day awards, streak_bonus ledger rows, and streak_days badge gating — was a permanent no-op.

The fix adds a `lastContributionAt = now()` touch in both contribution-creation routes so the heartbeat is recorded whenever a user performs a meaningful action:

* **`POST /api/replies`** (`src/app/api/replies/route.ts`) — updates `lastContributionAt` after inserting the new reply.
* **`POST /api/doubts`** (`src/app/api/doubts/route.ts`) — updates `lastContributionAt` after inserting the new doubt.

The daily streak cron now has data to process and will award streak bonuses to active users.

### Changes

* Added `lastContributionAt: new Date()` update in the reply creation route after the reply insert.
* Added `lastContributionAt: new Date()` update in the doubt creation route after the doubt insert.
* Added `usersTable` to the schema import in the doubts route (required for the new update).

### Testing

* `npx tsc --noEmit` ✅
* `npx eslint src/app/api/replies/route.ts src/app/api/doubts/route.ts` ✅
* `git diff --check` ✅
* Full suite: 249/266 passing (17 pre-existing failures from missing env vars / Playwright-in-Jest — none related to this change).

### Related Issue

Closes #1316

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Wired `lastContributionAt` writes into reply and doubt creation so the daily streak cron can find and process active users.
* **Chores**
  * Added missing `usersTable` import in the doubts route.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Enable daily streak rewards for users who contribute

### What Changed
- Posting a reply now records the user's latest contribution time
- Creating a doubt now records the user's latest contribution time
- Daily streak processing can now find active contributors and apply eligible streak bonuses and milestones

### Impact
`✅ Daily streak rewards trigger for active contributors`
`✅ Streak milestones can be awarded`
`✅ Contribution activity is tracked consistently`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
