### PR TITLE
fix(ui): use canTeach hierarchy for teacher-gated UI instead of exact role string

### DIFF
--- a/src/app/(routes)/rooms/[id]/page.tsx
+++ b/src/app/(routes)/rooms/[id]/page.tsx
@@ -429,7 +429,7 @@ export default function ClassroomPage() {
                 {
                   id: "teacher-doubts",
                   label:
-                    classroom?.role === "teacher"
+                    isTeacherRole(classroom?.role)
                       ? "Students Doubt"
                       : "Ask Teacher",
                   icon: GraduationCap,
@@ -748,7 +748,7 @@ export default function ClassroomPage() {
           <div className="animate-in fade-in slide-in-from-bottom-4 duration-500 space-y-8">
             <div className="flex flex-col sm:flex-row items-center justify-between gap-4 bg-slate-50/50 dark:bg-zinc-950/20 border border-slate-200 dark:border-zinc-900 p-4 rounded-xl shadow-sm">
               <h2 className="text-lg font-bold tracking-tight px-2">
-                {classroom?.role === "teacher" ? (
+                {isTeacherRole(classroom?.role) ? (
                   <>Students Doubts</>
                 ) : (
                   <>Direct Teacher Doubts</>
@@ -792,7 +792,7 @@ export default function ClassroomPage() {
                     Clear
                   </button>
                 )}
-                {classroom?.role !== "teacher" && (
+                {!isTeacherRole(classroom?.role) && (
                   <button
                     onClick={() => setIsAskModalOpen(true)}
                     className="px-5 py-2.5 bg-purple-600 hover:bg-purple-700 text-white rounded-xl font-bold uppercase tracking-wider text-xs transition-all duration-300 shadow-md shadow-purple-600/10 flex items-center gap-2 shrink-0"
@@ -874,11 +874,11 @@ export default function ClassroomPage() {
                         <div className="col-span-full py-24 text-center space-y-4 bg-slate-100 dark:bg-white/5 border border-dashed border-slate-200 dark:border-white/10 rounded-[2.5rem]">
                           <GraduationCap className="w-12 h-12 text-slate-700 mx-auto" />
                           <p className="text-slate-500 dark:text-slate-500 font-bold uppercase tracking-widest text-xs">
-                            {classroom?.role === "teacher"
+                            {isTeacherRole(classroom?.role)
                               ? "No unsolved doubts from students."
                               : "No unsolved teacher doubts."}
                           </p>
-                          {classroom?.role !== "teacher" && (
+                          {!isTeacherRole(classroom?.role) && (
                             <button
                               onClick={() => setIsAskModalOpen(true)}
                               className="text-purple-600 dark:text-purple-400 font-bold uppercase tracking-wider text-xs hover:underline underline-offset-4"
@@ -1252,7 +1252,7 @@ function ClassroomInsightsView({
   const [data, setData] = useState<AnalyticsData | null>(null);
   const [loading, setLoading] = useState(true);
 
-  const isTeacher = role === "teacher";
+  const isTeacher = isTeacherRole(role);
 
   const fetchData = async () => {
     try {

--- a/src/components/classroom/DoubtCard.tsx
+++ b/src/components/classroom/DoubtCard.tsx
@@ -38,6 +38,9 @@ const SHARE_MESSAGES = {
     MENU_TELEGRAM: "Share on Telegram"
 };
 
+const TEACHER_ROLES = new Set(["teacher", "owner", "admin"]);
+const isTeacherRole = (role?: string) => TEACHER_ROLES.has(role ?? "");
+
 interface DoubtCardProps {
     doubt: PublicDoubt & {
         tags?: Tag[];
@@ -79,7 +82,7 @@ export default function DoubtCard({ doubt, onUpdate, onViewAISolution, role, ope
     const searchParams = useSearchParams();
     const lastAutoOpenedThread = useRef<string | null>(null);
 
-    const isTeacher = role === 'teacher';
+    const isTeacher = isTeacherRole(role);
 
     const { isSignedIn } = useUser();
 


### PR DESCRIPTION
## **User description**
## Description

Replaced all frontend `role === 'teacher'` exact-string comparisons with the `TEACHER_ROLES` hierarchy check so classroom owners and admins see teacher-gated UI.

During investigation of #1320, the frontend teacher flag was found to depend on `role === 'teacher'` string comparisons throughout `DoubtCard.tsx` and the `rooms/[id]/page.tsx` classroom page. Meanwhile, the server-side authority in `src/lib/auth/membership-guard.ts` defines `TEACHER_ROLES = { teacher, owner, admin }` and `canTeach()` respects the full hierarchy. Because the frontend only matched the literal string `"teacher"`, classroom owners and admins — who have full server permission to pin, edit, mark-official, and access teacher analytics — were silently locked out of all those UI controls.

The fix replaces every `role === 'teacher'` / `role !== 'teacher'` check in the two affected files with the existing `isTeacherRole()` helper (rooms page, which already defined the correct `TEACHER_ROLES` set locally) or an equivalent `TEACHER_ROLES.has(role)` guard (DoubtCard, which uses a client-component-safe local copy to avoid pulling in the Clerk-dependent server module).

### Changes

* Added a local `TEACHER_ROLES` set and `isTeacherRole()` helper in `DoubtCard.tsx` to avoid importing from the server-only `membership-guard.ts` (which pulls in `@clerk/nextjs/server` and breaks Jest).
* Replaced `role === 'teacher'` with `isTeacherRole(role)` in `DoubtCard.tsx`.
* Replaced six `classroom?.role === "teacher"` / `!== "teacher"` comparisons with `isTeacherRole(classroom?.role)` in `rooms/[id]/page.tsx` (tab labels, section headings, empty states, Ask Teacher button visibility, and the insights sub-component).
* Classroom owners and admins now see Edit, Pin, Mark Official, and Ask Teacher controls.

### Testing

* `npx tsc --noEmit` ✅
* `npx eslint src/components/classroom/DoubtCard.tsx "src/app/(routes)/rooms/[id]/page.tsx"` ✅
* `npx jest "DoubtCard" --watchAll=false --forceExit` ✅ — 4/4 DoubtCard tests passing.
* `git diff --check` ✅

### Related Issue

Closes #1320

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated classroom role recognition to consistently include teachers, owners, and administrators.
  * Corrected classroom tab labels, teacher-doubt headings, Ask Teacher visibility, and empty-state messages for these roles.
  * Improved insights personalization so users with eligible teaching roles see the appropriate experience.
  * Updated doubt cards to display teacher-specific content consistently across supported roles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Let classroom owners and admins use teacher-only classroom features

### What Changed
- Classroom owners and admins now see teacher-gated controls such as Edit, Pin, Mark Official, student doubts, and teacher insights
- Classroom tabs, headings, empty states, and Ask Teacher actions now reflect the full teacher role hierarchy
- Teacher access is recognized consistently for teachers, owners, and admins

### Impact
`✅ Fewer missing classroom controls for owners and admins`
`✅ Consistent teacher access across classroom pages`
`✅ Clearer student-doubt and teacher-doubt views`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
