### PR TITLE
fix(deeplink): align similar-doubt query param from ?doubt= to ?doubtId=

### DIFF
--- a/src/components/classroom/AskDoubt.tsx
+++ b/src/components/classroom/AskDoubt.tsx
@@ -731,7 +731,7 @@ export default function AskDoubt({ defaultSubject = "", isOpen, onClose, onSucce
                                                         </div>
                                                     </div>
                                                     <a
-                                                        href={classroomId ? `/rooms/${classroomId}?doubt=${d.id}` : `/?doubt=${d.id}`}
+                                                        href={classroomId ? `/rooms/${classroomId}?doubtId=${d.id}` : `/?doubtId=${d.id}`}
                                                         target="_blank"
                                                         rel="noopener noreferrer"
                                                         className="shrink-0 flex items-center gap-1 text-[9px] font-black uppercase tracking-widest text-blue-400 hover:text-blue-300 px-2 py-1 rounded-lg bg-blue-500/10 hover:bg-blue-500/20 transition-colors"


### PR DESCRIPTION
## **User description**
## Description

Aligned the similar-doubt deep-link query parameter so the auto-open highlight actually triggers in DoubtCard.

During investigation of #1321, `AskDoubt.tsx` was found to build similar-doubt links as `/rooms/${classroomId}?doubt=${d.id}` (line 734), while `DoubtCard.tsx` reads the deep-link via `searchParams.get("doubtId")` (line 93). The query key mismatch (`doubt` vs `doubtId`) meant the `deepLinkedDoubtId` value was always `null`, so the auto-open `useEffect` never matched the target doubt and the replies panel never opened.

The fix changes the link builder in AskDoubt to use `?doubtId=${d.id}` — the key that DoubtCard already expects — so clicking a similar-doubt suggestion correctly deep-links to and auto-opens the target doubt's reply thread.

### Changes

* Changed the `href` in `AskDoubt.tsx` from `?doubt=${d.id}` to `?doubtId=${d.id}` for both the classroom and root routes.

### Testing

* `npx tsc --noEmit` ✅
* `npx eslint src/components/classroom/AskDoubt.tsx` ✅
* `git diff --check` ✅

### Related Issue

Closes #1321

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated similar-doubt links to use the correct query parameter, ensuring they open the intended doubt in both classroom and non-classroom views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Open similar doubts directly to their reply thread

### What Changed
- Links from similar-doubt suggestions now identify the selected doubt correctly in both classroom and main-room views
- Opening a similar doubt now automatically highlights and opens its replies panel

### Impact
`✅ Working similar-doubt deep links`
`✅ Faster access to reply threads`
`✅ Fewer navigation dead ends`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
