### PR TITLE
fix(privacy): strip userEmail from vote and reply-edit API responses

### DIFF
--- a/src/app/api/replies/action/[id]/route.ts
+++ b/src/app/api/replies/action/[id]/route.ts
@@ -101,7 +101,10 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
             },
         });
 
-        return NextResponse.json(updated[0]);
+        // Strip the author's real email before returning — identity must
+        // stay server-side only (see src/lib/anonymity/anonymity.ts).
+        const { userEmail: _, ...safeRow } = updated[0];
+        return NextResponse.json(safeRow);
     } catch (error) {
         console.error("Error updating reply:", error);
         return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });

--- a/src/app/api/replies/vote/route.ts
+++ b/src/app/api/replies/vote/route.ts
@@ -147,7 +147,10 @@ export async function POST(req: Request) {
             }
         }
 
-        return NextResponse.json(result);
+        // Strip the author's real email before returning — identity must
+        // stay server-side only (see src/lib/anonymity/anonymity.ts).
+        const { userEmail: _, ...safeResult } = result ?? {};
+        return NextResponse.json(safeResult);
     } catch (error) {
         const { status, body } = buildErrorResponse(error);
         return NextResponse.json(body, { status });


### PR DESCRIPTION
## **User description**
## Description

Stripped the author's real `userEmail` from the vote and reply-edit API responses to stop leaking PII across the API boundary.

During investigation of #1322, two write-response endpoints were found to return the raw DB row from `returning()` without anonymizing author identity:

* **`POST /api/replies/vote`** (`src/app/api/replies/vote/route.ts`) — the transaction returns `{ ...updated[0], hasUpvoted }` where `updated[0]` is the full replies row including `userEmail`.
* **`PATCH /api/replies/action/[id]`** (`src/app/api/replies/action/[id]/route.ts`) — the edit handler returns `updated[0]` directly, which is the raw replies row with `userEmail`.

Every other doubt/reply read path in the application routes through `toPublicReply` / `toPublicAuthored` from `src/lib/anonymity/anonymity.ts`, which strips `userEmail` and attaches a safe `author` handle. These two endpoints bypassed that contract entirely, so any authenticated upvoter or editor received the reply author's real email address in the JSON response.

The fix destructures `userEmail` out of the response payload in both endpoints, preventing the author's real address from crossing the API boundary. The server continues to use `userEmail` internally for karma, audit logs, and authorization checks — only the serialized response is sanitized.

### Changes

* Destructured `userEmail` out of the response in `POST /api/replies/vote` before calling `NextResponse.json`.
* Destructured `userEmail` out of `updated[0]` in `PATCH /api/replies/action/[id]` before calling `NextResponse.json`.

### Testing

* `npx tsc --noEmit` ✅
* `npx eslint src/app/api/replies/vote/route.ts "src/app/api/replies/action/[id]/route.ts"` ✅
* `git diff --check` ✅

### Related Issue

Closes #1322

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented reply author email addresses from being exposed in reply update responses.
  * Prevented reply author email addresses from being exposed in voting responses.
  * Preserved all other response data and existing audit behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Prevent reply author emails from appearing in vote and edit responses

### What Changed
- Vote responses no longer include the reply author's real email address
- Reply-edit responses no longer include the reply author's real email address
- Server-side voting, auditing, and authorization continue to use the email internally

### Impact
`✅ Prevented email exposure through reply APIs`
`✅ Safer voting responses`
`✅ Safer reply editing`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
