### PR TITLE
fix(moderation): move email sends outside DB transaction to prevent rollback on email failure

### DIFF
--- a/src/lib/moderation/moderation.ts
+++ b/src/lib/moderation/moderation.ts
@@ -346,9 +346,11 @@ export async function handleModerationViolation(
 ): Promise<string | null> {
     if (moderation.isAllowed) return null;
 
-    return db.transaction(async (tx) => {
-        // Atomically increment violationCount at the DB level — eliminates the
-        // read-modify-write race under concurrent violation processing.
+    // Execute all DB mutations inside the transaction.
+    // Emails are dispatched AFTER the transaction commits so a failed
+    // email delivery (SMTP timeout, invalid API key, etc.) cannot roll back
+    // the block state or violation counter.
+    const emailData = await db.transaction(async (tx) => {
         const [updated] = await tx.update(usersTable).set({
                 violationCount: sql`${usersTable.violationCount} + 1`,
             })
@@ -360,32 +362,28 @@ export async function handleModerationViolation(
             });
 
         if (!updated) {
-            // User row not found — log and bail without crashing the request.
             console.error(`[handleModerationViolation] User not found: ${email}`);
             return null;
         }
 
-       const newViolationCount = updated.violationCount;
-       const isThirdViolation = newViolationCount >= 3;
+        const newViolationCount = updated.violationCount;
+        const isThirdViolation = newViolationCount >= 3;
 
         let blockedUntil: Date | null = updated.blockedUntil || null;
         let newBlockCount = updated.blockCount || 0;
+        let durationDays = 0;
 
         if (isThirdViolation) {
             newBlockCount += 1;
 
-            // Duration: 3 days (1st block), 7 days (2nd), 14*2^n (subsequent)
-            let durationDays = 3;
-            if (newBlockCount === 2) durationDays = 7;
-            else if (newBlockCount >= 3) durationDays = 14 * Math.pow(2, newBlockCount - 3);
+            let days = 3;
+            if (newBlockCount === 2) days = 7;
+            else if (newBlockCount >= 3) days = 14 * Math.pow(2, newBlockCount - 3);
+            durationDays = days;
 
             blockedUntil = new Date();
             blockedUntil.setDate(blockedUntil.getDate() + durationDays);
 
-            // Persist block state in the same transaction. violationCount is reset
-            // to 0 here so the 3-strike counter starts fresh once the user is
-            // unblocked — without this, every violation after the first block
-            // would stay >= 3 and re-trigger an immediate additional block.
             await tx.update(usersTable).set({
                     isBlocked: true,
                     blockedUntil,
@@ -393,11 +391,8 @@ export async function handleModerationViolation(
                     violationCount: 0,
                 })
                 .where(eq(usersTable.email, email));
-
-            await sendBlockEmail(email, durationDays, newBlockCount);
         }
 
-        // Log violation inside transaction — rolls back if the outer update fails.
         await tx.insert(moderationLogsTable).values({
             userEmail: email,
             reason: moderation.reason,
@@ -405,15 +400,36 @@ export async function handleModerationViolation(
             contentSnippet: content.substring(0, 200),
         });
 
-        // Email is outside the transaction (side-effect; non-rollbackable).
-        await sendWarningEmail(email, moderation.reason, newViolationCount);
-
-        let errorMessage = `Content flagged: ${moderation.reason}. This is strike ${newViolationCount}/3. Please stick to academic topics.`;
-
-        if (isThirdViolation && blockedUntil) {
-            errorMessage = `Content flagged. Your account is now blocked for ${newBlockCount > 1 ? 'additional ' : ''}violations. Access restored on ${blockedUntil.toDateString()}.`;
-        }
-
-        return errorMessage;
+        return {
+            newViolationCount,
+            isThirdViolation,
+            blockedUntil,
+            newBlockCount,
+            durationDays,
+        };
     });
+
+    // If user not found, emailData will be null
+    if (!emailData) return null;
+
+    const { newViolationCount, isThirdViolation, blockedUntil, newBlockCount, durationDays } = emailData;
+
+    // Fire-and-forget email sends — failures do NOT affect moderation state.
+    if (isThirdViolation) {
+        sendBlockEmail(email, durationDays, newBlockCount).catch((err) => {
+            console.error("[handleModerationViolation] Failed to send block email:", err);
+        });
+    }
+
+    sendWarningEmail(email, moderation.reason, newViolationCount).catch((err) => {
+        console.error("[handleModerationViolation] Failed to send warning email:", err);
+    });
+
+    let errorMessage = `Content flagged: ${moderation.reason}. This is strike ${newViolationCount}/3. Please stick to academic topics.`;
+
+    if (isThirdViolation && blockedUntil) {
+        errorMessage = `Content flagged. Your account is now blocked for ${newBlockCount > 1 ? 'additional ' : ''}violations. Access restored on ${blockedUntil.toDateString()}.`;
+    }
+
+    return errorMessage;
 }


### PR DESCRIPTION
## **User description**
## Description

Moved email notifications outside the database transaction in `handleModerationViolation` so email delivery failures can no longer roll back moderation state.

During investigation of #1323, `handleModerationViolation` in `src/lib/moderation/moderation.ts` was found to `await sendBlockEmail` and `await sendWarningEmail` **inside** the `db.transaction` block. If the email send threw (e.g., Resend API key missing, SMTP timeout, network error), the entire transaction rolled back — the user's `violationCount` increment, `isBlocked` flag, `blockedUntil` timestamp, and `blockCount` were all reverted, leaving the moderation state unchanged despite the content being flagged.

The fix restructures the function so:
1. The transaction performs **only** DB mutations (increment violation count, update block state, insert moderation log) and returns the computed email parameters.
2. After the transaction commits, the emails are dispatched fire-and-forget using `.catch()` so any delivery failure is logged but does not affect the already-committed moderation state.

### Changes

* Refactored `handleModerationViolation` to return email data from the transaction instead of sending emails inside it.
* Emails (`sendBlockEmail` for strike 3+, `sendWarningEmail` for every violation) are now sent **after** the transaction commits.
* Used `.catch()` for fire-and-forget semantics — email failures are logged but never roll back moderation state.

### Testing

* `npx tsc --noEmit` ✅
* `npx eslint src/lib/moderation/moderation.ts` ✅
* `git diff --check` ✅
* Moderation tests rely on mocked DB/email — pre-existing failure due to missing `GROQ_API_KEY` env var (unrelated to this change).

### Related Issue

Closes #1323

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Moved moderation emails outside the DB transaction so a failed email delivery can no longer roll back user blocks and violation counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Prevent failed moderation emails from undoing account blocks

### What Changed
- Moderation violations, strike counts, account blocks, and moderation logs are saved even when warning or block emails cannot be delivered
- Warning and block emails are sent after moderation changes are committed, with delivery failures logged without interrupting moderation
- Users still receive the appropriate strike or block message when moderation processing completes

### Impact
`✅ Account blocks persist through email failures`
`✅ Violation counts are not lost`
`✅ Fewer moderation processing failures`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
