### PR TITLE
fix(rooms): hide teacherEmail, inviteCode from student responses

### DIFF
--- a/src/app/api/rooms/route.ts
+++ b/src/app/api/rooms/route.ts
@@ -45,6 +45,17 @@ export async function GET(req: Request) {
             .leftJoin(organizationsTable, eq(classroomsTable.organizationId, organizationsTable.id))
             .where(eq(membershipsTable.userEmail, email));
 
+        // Strip sensitive fields (teacherEmail, inviteCode, inviteCodeExpiresAt, allowedEmailDomains)
+        // from non-teacher members. Teachers/owners/admins see them; students do not.
+        const sanitizedJoinedRooms = joinedRooms.map((room) => {
+            const isTeacher = ['teacher', 'owner', 'admin'].includes(room.role);
+            if (isTeacher) {
+                return room;
+            }
+            const { teacherEmail, inviteCode, inviteCodeExpiresAt, allowedEmailDomains, ...safe } = room;
+            return safe;
+        });
+
         // Fetch current DB user
         const [dbUser] = await db
             .select()
@@ -73,7 +84,7 @@ export async function GET(req: Request) {
         }
 
         return NextResponse.json({
-            joined: joinedRooms,
+            joined: sanitizedJoinedRooms,
             recommended: recommendedRooms,
         });
     } catch (error) {


### PR DESCRIPTION
## **User description**
## Description

Stripped sensitive teacher and invite fields from student responses in `GET /api/rooms`.

During investigation of #1325, the classroom list endpoint (`src/app/api/rooms/route.ts`) was found to return `teacherEmail`, `inviteCode`, `inviteCodeExpiresAt`, and `allowedEmailDomains` for **every** member of a room, including students. This leaked the teacher's real email address (PII) and the active invite code — the latter being an access-control secret that should only be visible to educators for sharing purposes.

The fix adds a sanitization step after the database query: for each room in the `joinedRooms` array, if the requesting user's role in that room is `student` (or any role other than `teacher`, `owner`, or `admin`), the sensitive fields are destructured out of the response object. Teachers, owners, and admins continue to receive the full data.

### Changes

* Added a `map` over `joinedRooms` that destructures out `teacherEmail`, `inviteCode`, `inviteCodeExpiresAt`, and `allowedEmailDomains` for non-teacher roles.
* Teacher/owner/admin roles receive the full object unchanged.

### Testing

* `npx tsc --noEmit` ✅
* `npx eslint src/app/api/rooms/route.ts` ✅
* `npx jest "rooms" --watchAll=false --forceExit` ✅ — 8/8 room tests passing.
* `git diff --check` ✅

### Related Issue

Closes #1325

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed teacher email and invite code from student classroom list responses to prevent PII leakage and access-control exposure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Protect sensitive classroom details in student room responses

### What Changed
- Students and other non-staff members no longer receive the teacher’s email, invite code, invite-code expiration, or allowed email domains in `GET /api/rooms`
- Teachers, owners, and admins continue to see the classroom details needed to manage and share rooms

### Impact
`✅ Prevented teacher email exposure to students`
`✅ Protected classroom invite codes`
`✅ Preserved room management details for staff`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
