### PR TITLE
fix(rooms): mount ConfusionAlertPanel in room page

### DIFF
--- a/src/app/(routes)/rooms/[id]/page.tsx
+++ b/src/app/(routes)/rooms/[id]/page.tsx
@@ -43,6 +43,7 @@ import {
   User2Icon,
 } from "lucide-react";
 import AskDoubt from "@/components/classroom/AskDoubt";
+import ConfusionAlertPanel from "@/components/classroom/ConfusionAlertPanel";
 import DoubtCard from "@/components/classroom/DoubtCard";
 import AskAIView from "@/components/classroom/AskAIView";
 import ExportButton from "@/components/common/ExportButton";
@@ -456,6 +457,8 @@ export default function ClassroomPage() {
       </div>
 
       <div className="max-w-7xl mx-auto p-4 md:py-6 md:px-12 relative z-10">
+        <ConfusionAlertPanel roomId={String(id)} />
+
         {activeTab === "ask-ai" && (
           <div className="animate-in fade-in slide-in-from-bottom-4 duration-500 space-y-10">
             <div className="space-y-6">

--- a/src/app/(routes)/rooms/[id]/page.tsx
+++ b/src/app/(routes)/rooms/[id]/page.tsx
@@ -430,7 +430,7 @@ export default function ClassroomPage() {
                 {
                   id: "teacher-doubts",
                   label:
-                    classroom?.role === "teacher"
+                    isTeacherRole(classroom?.role)
                       ? "Students Doubt"
                       : "Ask Teacher",
                   icon: GraduationCap,
@@ -457,7 +457,9 @@ export default function ClassroomPage() {
       </div>
 
       <div className="max-w-7xl mx-auto p-4 md:py-6 md:px-12 relative z-10">
-        <ConfusionAlertPanel roomId={String(id)} />
+        {hasTeacherAccess && (
+          <ConfusionAlertPanel roomId={String(id)} />
+        )}
 
         {activeTab === "ask-ai" && (
           <div className="animate-in fade-in slide-in-from-bottom-4 duration-500 space-y-10">
@@ -751,7 +753,7 @@ export default function ClassroomPage() {
           <div className="animate-in fade-in slide-in-from-bottom-4 duration-500 space-y-8">
             <div className="flex flex-col sm:flex-row items-center justify-between gap-4 bg-slate-50/50 dark:bg-zinc-950/20 border border-slate-200 dark:border-zinc-900 p-4 rounded-xl shadow-sm">
               <h2 className="text-lg font-bold tracking-tight px-2">
-                {classroom?.role === "teacher" ? (
+                {isTeacherRole(classroom?.role) ? (
                   <>Students Doubts</>
                 ) : (
                   <>Direct Teacher Doubts</>
@@ -795,7 +797,7 @@ export default function ClassroomPage() {
                     Clear
                   </button>
                 )}
-                {classroom?.role !== "teacher" && (
+                {!isTeacherRole(classroom?.role) && (
                   <button
                     onClick={() => setIsAskModalOpen(true)}
                     className="px-5 py-2.5 bg-purple-600 hover:bg-purple-700 text-white rounded-xl font-bold uppercase tracking-wider text-xs transition-all duration-300 shadow-md shadow-purple-600/10 flex items-center gap-2 shrink-0"
@@ -877,11 +879,11 @@ export default function ClassroomPage() {
                         <div className="col-span-full py-24 text-center space-y-4 bg-slate-100 dark:bg-white/5 border border-dashed border-slate-200 dark:border-white/10 rounded-[2.5rem]">
                           <GraduationCap className="w-12 h-12 text-slate-700 mx-auto" />
                           <p className="text-slate-500 dark:text-slate-500 font-bold uppercase tracking-widest text-xs">
-                            {classroom?.role === "teacher"
+                            {isTeacherRole(classroom?.role)
                               ? "No unsolved doubts from students."
                               : "No unsolved teacher doubts."}
                           </p>
-                          {classroom?.role !== "teacher" && (
+                          {!isTeacherRole(classroom?.role) && (
                             <button
                               onClick={() => setIsAskModalOpen(true)}
                               className="text-purple-600 dark:text-purple-400 font-bold uppercase tracking-wider text-xs hover:underline underline-offset-4"
@@ -1255,7 +1257,7 @@ function ClassroomInsightsView({
   const [data, setData] = useState<AnalyticsData | null>(null);
   const [loading, setLoading] = useState(true);
 
-  const isTeacher = role === "teacher";
+  const isTeacher = isTeacherRole(role);
 
   const fetchData = async () => {
     try {


### PR DESCRIPTION
## **User description**
## Description

Mounted the existing `ConfusionAlertPanel` component in the classroom room page so teachers can see and acknowledge live confusion alerts.

During investigation of #1326, the component `src/components/classroom/ConfusionAlertPanel.tsx` was found to be fully implemented — it polls `/api/confusion?roomId=...` every 60 seconds, displays an amber alert card with topic, summary, and confidence score, and provides a dismiss button that calls `PATCH /api/confusion?id=...` to acknowledge the alert. However, a repo-wide search confirmed the component was never imported or rendered in any page, leaving confusion alerts invisible to teachers despite the API correctly returning active alerts.

The fix imports `ConfusionAlertPanel` and renders it at the top of the main content area in the room page (`src/app/(routes)/rooms/[id]/page.tsx`). The panel is visible to all room members; the existing API already enforces access control — `GET` requires membership via `requireMembership`, and `PATCH` (dismiss) requires teacher role via `requireTeacher`.

### Changes

* Imported `ConfusionAlertPanel` from `@/components/classroom/ConfusionAlertPanel`.
* Rendered `<ConfusionAlertPanel roomId={String(id)} />` at the top of the room page content, above the tab panels.

### Testing

* `npx tsc --noEmit` ✅
* `npx eslint "src/app/(routes)/rooms/[id]/page.tsx"` ✅
* `npx jest "rooms" --watchAll=false --forceExit` ✅ — 8/8 room tests passing.
* `git diff --check` ✅

### Related Issue

Closes #1326

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a confusion alert panel to classroom pages for teachers and other teacher-access roles.
  * Expanded teacher access recognition to include owners and administrators across classroom tools.

* **Bug Fixes**
  * Improved consistency for teacher controls, tab labels, empty states, and personalized analytics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Show confusion alerts only to teachers and preserve role-based room behavior

### What Changed
- Teachers now see the live confusion alert panel at the top of classroom rooms
- Students and other room members no longer see teacher-only confusion alerts
- Role-based labels, doubt actions, and analytics now correctly recognize teacher roles

### Impact
`✅ Teachers can review and acknowledge live confusion alerts`
`✅ Students see only student-appropriate doubt actions`
`✅ Correct teacher and student room experiences`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
