### PR TITLE
fix(replies): guard Enter key against duplicate submissions

### DIFF
--- a/src/components/classroom/DoubtRepliesModal.tsx
+++ b/src/components/classroom/DoubtRepliesModal.tsx
@@ -983,7 +983,7 @@ export default function DoubtRepliesModal({ doubt, isOpen, onClose, onReplyChang
                                             onFocus={() => setTyping(true)}
                                             onBlur={() => setTyping(false)}
                                             onKeyDown={(e) => {
-                                                if (e.key === 'Enter') {
+                                                if (e.key === 'Enter' && !e.repeat && !isPosting) {
                                                     handlePost('comment');
                                                 }
                                             }}


### PR DESCRIPTION
## **User description**
## Description

Added `isPosting` and `e.repeat` guards to the Enter key handler in the doubt replies modal to prevent duplicate comment submissions.

During investigation of #1327, the `onKeyDown` handler in `src/components/classroom/DoubtRepliesModal.tsx` (line 985) was found to call `handlePost('comment')` directly on Enter with no debounce or state check. The visual submit button on the same input correctly used `disabled={isPosting || !chatText.trim()}`, but the keyboard path bypassed this entirely. Pressing and holding Enter fired repeated `handlePost` calls, creating multiple duplicate comments when rate-limit permitted.

The fix adds two guards to the Enter key condition: `!e.repeat` (prevents held-key repeat events) and `!isPosting` (prevents submission while a request is in flight), matching the button's disabled logic.

### Changes

* Changed `if (e.key === 'Enter')` to `if (e.key === 'Enter' && !e.repeat && !isPosting)` in the `onKeyDown` handler.

### Testing

* `npx tsc --noEmit` ✅
* `npx eslint src/components/classroom/DoubtRepliesModal.tsx` ✅
* `git diff --check` ✅

### Related Issue

Closes #1327

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate comment submissions by guarding the Enter key handler against repeated key events and in-flight posting state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Prevent duplicate doubt replies when submitting with Enter

### What Changed
- Pressing and holding Enter no longer submits multiple replies
- Enter submissions are ignored while a previous reply is still being sent

### Impact
`✅ No duplicate replies from held Enter keys`
`✅ Fewer repeated submissions during slow requests`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
