### PR TITLE
fix(organizations): strip ownerEmail from non-owner member responses

### DIFF
--- a/src/app/api/organizations/route.ts
+++ b/src/app/api/organizations/route.ts
@@ -42,7 +42,16 @@ export async function GET() {
       )
       .where(eq(organizationMembershipsTable.userEmail, email));
 
-    return NextResponse.json(userOrgs);
+    // Strip ownerEmail for non-owner/non-admin members to prevent PII leakage
+    const sanitizedOrgs = userOrgs.map((org) => {
+      if (org.role === 'owner' || org.role === 'admin') {
+        return org;
+      }
+      const { ownerEmail, ...safe } = org;
+      return safe;
+    });
+
+    return NextResponse.json(sanitizedOrgs);
   } catch (error) {
     const { status, body } = buildErrorResponse(error);
     return NextResponse.json(body, { status });


### PR DESCRIPTION
## **User description**
## Description

Stripped `ownerEmail` from organization list responses for non-owner/non-admin members to prevent PII leakage.

During investigation of #1328, the `GET /api/organizations` endpoint (`src/app/api/organizations/route.ts`) was found to select and return `ownerEmail` for every organization the user belongs to, regardless of their role. A student or regular member could call this endpoint and see the organization owner's personal email address — sensitive data that should only be visible to the owner and admins.

The fix adds a sanitization step after the database query: for each organization in the `userOrgs` array, if the requesting user's role is not `owner` or `admin`, the `ownerEmail` field is destructured out of the response object. This mirrors the pattern already used in #1325 for classroom `teacherEmail`.

### Changes

* Added a `map` over `userOrgs` that destructures out `ownerEmail` for non-owner/non-admin roles.
* Owner and admin roles receive the full object unchanged.

### Testing

* `npx tsc --noEmit` ✅
* `npx eslint src/app/api/organizations/route.ts` ✅
* `git diff --check` ✅

### Related Issue

Closes #1328

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed organization owner email from API responses for non-owner and non-admin members to prevent PII leakage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Restrict organization owner email visibility by member role

### What Changed
- Organization owners and admins continue to receive the owner's email address
- Regular members and students no longer receive the owner's email in organization list responses

### Impact
`✅ Prevented owner email exposure to regular members`
`✅ Reduced organization member privacy risks`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
