### PR TITLE
fix: authorize room access before socket join

### DIFF
--- a/chat-system/package.json
+++ b/chat-system/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@clerk/backend": "^3.11.4",
     "@clerk/nextjs": "^7.5.17",
+    "@neondatabase/serverless": "^1.0.2",
     "@radix-ui/react-slot": "^1.2.4",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/chat-system/server.js
+++ b/chat-system/server.js
@@ -1,6 +1,7 @@
 // Simple Socket.IO server for chat-system
 const { createServer } = require('http');
 const { Server } = require('socket.io');
+const { neon } = require('@neondatabase/serverless');
 
 const httpServer = createServer();
 const io = new Server(httpServer, {
@@ -12,6 +13,39 @@ require('dotenv').config({ path: '../.env' });
 const { verifyToken, createClerkClient } = require('@clerk/backend');
 
 const clerkClient = createClerkClient({ secretKey: process.env.CLERK_SECRET_KEY });
+const sql = neon(process.env.DATABASE_URL);
+
+// Rooms that any signed-in user may join, regardless of classroom membership.
+const PUBLIC_ROOMS = new Set(['general', 'peer-to-peer']);
+
+// Checks whether userEmail is allowed to join `room`.
+// - Public rooms (general, peer-to-peer) are open to anyone authenticated.
+// - Any other room is treated as a classroom ID and checked against the
+//   memberships table (or classroom ownership, for the teacher), mirroring
+//   the same rule the main app already enforces in
+//   src/lib/auth/membership-guard.ts requireMembership().
+async function checkRoomAccess(userEmail, room) {
+  if (PUBLIC_ROOMS.has(room)) {
+    return true;
+  }
+
+  const classroomId = Number(room);
+  if (!Number.isInteger(classroomId) || classroomId <= 0) {
+    // Unrecognized room format - fail closed instead of guessing.
+    return false;
+  }
+
+  const rows = await sql`
+    SELECT 1 FROM "memberships"
+    WHERE "userEmail" = ${userEmail} AND "classroomId" = ${classroomId}
+    UNION
+    SELECT 1 FROM "classrooms"
+    WHERE "id" = ${classroomId} AND "teacherEmail" = ${userEmail}
+    LIMIT 1
+  `;
+
+  return rows.length > 0;
+}
 
 // Authentication middleware
 io.use(async (socket, next) => {
@@ -26,7 +60,8 @@ io.use(async (socket, next) => {
     });
 
     const user = await clerkClient.users.getUser(payload.sub);
-    socket.userName = user.firstName || user.username || user.emailAddresses[0].emailAddress;
+    socket.userEmail = user.primaryEmailAddress?.emailAddress;
+    socket.userName = user.firstName || user.username || socket.userEmail;
     next();
   } catch (err) {
     next(new Error('Authentication error: Invalid token'));
@@ -34,8 +69,17 @@ io.use(async (socket, next) => {
 });
 
 io.on('connection', (socket) => {
-  socket.on('join', (room) => {
-    socket.join(room);
+  socket.on('join', async (room) => {
+    try {
+      const isAuthorized = await checkRoomAccess(socket.userEmail, room);
+      if (!isAuthorized) {
+        return socket.emit('error', 'Unauthorized to join room');
+      }
+      socket.join(room);
+    } catch (err) {
+      console.error('Room access check failed:', err);
+      socket.emit('error', 'Could not verify room access');
+    }
   });
   socket.on('leave', (room) => {
     socket.leave(room);


### PR DESCRIPTION
## **User description**
Fixes #1338 

Adds an authorization check (checkRoomAccess) before a socket is allowed
to join a room. Public demo rooms (general, peer-to-peer) stay open;
any other room is now validated as a classroom ID against the existing
memberships/classrooms tables, reusing the same rule the /api/rooms/[id]
route already enforces via requireMembership().

Also updates the auth middleware to capture the user's email, since
membership is keyed by email in this codebase.


___

## **CodeAnt-AI Description**
Authorize users before allowing them to join chat rooms

### What Changed
- Signed-in users can still join the public `general` and `peer-to-peer` rooms
- Classroom chat rooms now allow only enrolled members or the classroom teacher
- Invalid or unauthorized room requests are rejected instead of joining the room
- Users receive a clear error when access cannot be verified

### Impact
`✅ Prevented unauthorized classroom chat access`
`✅ Public chat rooms remain available to all signed-in users`
`✅ Clearer room access errors`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added access controls for chat rooms.
  - Public rooms are available to authenticated users.
  - Classroom rooms now require appropriate membership or teacher ownership.
  - Invalid room identifiers are rejected.

- **Bug Fixes**
  - Unauthorized users can no longer join restricted rooms.
  - Join requests now provide clearer feedback when room verification fails.
  - Authentication now retains the account’s primary email address.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->