### PR TITLE
test(teacher-insights): cover recommendations/weakTopics pipeline 

### DIFF
--- a/src/__tests__/api/teacher-insights.test.ts
+++ b/src/__tests__/api/teacher-insights.test.ts
@@ -24,10 +24,17 @@ jest.mock('@/configs/db', () => ({
     },
 }));
 
+const generateRecommendationsMock = jest.fn();
+jest.mock('@/lib/ai/recommendations', () => ({
+    generateRecommendations: (weakTopics: any) => generateRecommendationsMock(weakTopics),
+}));
+
 describe('Teacher Insights API Endpoint', () => {
     beforeEach(() => {
         currentUserMock.mockReset();
         selectResultsQueue.length = 0;
+        generateRecommendationsMock.mockReset();
+        generateRecommendationsMock.mockResolvedValue([]);
     });
 
     it('returns 401 when the request is unauthenticated', async () => {
@@ -100,7 +107,9 @@ describe('Teacher Insights API Endpoint', () => {
             [
                 { subject: 'Programming', count: 4 },
                 { subject: 'Math', count: 2 },
-            ]
+            ],
+            [],
+            []
         );
 
         const req = new NextRequest('http://localhost/api/teacher/insights?classroomId=7');
@@ -111,5 +120,92 @@ describe('Teacher Insights API Endpoint', () => {
         expect(json.topTopics).toHaveLength(2);
         expect(json.statusDistribution).toHaveLength(2);
         expect(json.subjectVolume).toHaveLength(2);
+        expect(json.recommendations).toEqual([]);
+        expect(generateRecommendationsMock).toHaveBeenCalledWith([]);
+    });
+
+    it('builds weakTopics from unresolved/total counts and passes sample doubt IDs to recommendations', async () => {
+        currentUserMock.mockResolvedValue({
+            primaryEmailAddress: { emailAddress: 'teacher@example.com' },
+        });
+
+        selectResultsQueue.push(
+            [{ role: 'teacher' }],
+            [{ topic: 'Loops', subject: 'Programming', count: 4 }],
+            [{ status: 'unsolved', count: 4 }],
+            [{ subject: 'Programming', count: 4 }],
+            [{ topic: 'Loops', subject: 'Programming', unresolvedCount: 3 }],
+            [{ topic: 'Loops', subject: 'Programming', totalCount: 4 }],
+            [{ id: 101 }, { id: 102 }, { id: 103 }]
+        );
+        generateRecommendationsMock.mockResolvedValue([
+            { topic: 'Loops', subject: 'Programming', suggestion: 'Review iteration basics' },
+        ]);
+
+        const req = new NextRequest('http://localhost/api/teacher/insights?classroomId=7');
+        const res = await GET(req);
+        const json = await res.json();
+
+        expect(res.status).toBe(200);
+        expect(json.recommendations).toEqual([
+            { topic: 'Loops', subject: 'Programming', suggestion: 'Review iteration basics' },
+        ]);
+
+        expect(generateRecommendationsMock).toHaveBeenCalledWith([
+            {
+                topic: 'Loops',
+                subject: 'Programming',
+                totalCount: 4,
+                unresolvedCount: 3,
+                sampleDoubtIds: [101, 102, 103],
+            },
+        ]);
+    });
+
+    it('falls back to unresolvedCount when no matching totalPerTopic entry is found', async () => {
+        currentUserMock.mockResolvedValue({
+            primaryEmailAddress: { emailAddress: 'teacher@example.com' },
+        });
+
+        selectResultsQueue.push(
+            [{ role: 'teacher' }],
+            [],
+            [],
+            [],
+            [{ topic: 'Recursion', subject: 'Programming', unresolvedCount: 2 }],
+            [],
+            [{ id: 201 }]
+        );
+
+        const req = new NextRequest('http://localhost/api/teacher/insights?classroomId=7');
+        await GET(req);
+
+        expect(generateRecommendationsMock).toHaveBeenCalledWith([
+            {
+                topic: 'Recursion',
+                subject: 'Programming',
+                totalCount: 2,
+                unresolvedCount: 2,
+                sampleDoubtIds: [201],
+            },
+        ]);
+    });
+
+    it('returns 500 when an unexpected (non-ApiError) error is thrown', async () => {
+        currentUserMock.mockResolvedValue({
+            primaryEmailAddress: { emailAddress: 'teacher@example.com' },
+        });
+
+        const dbMock = jest.requireMock('@/configs/db').db;
+        dbMock.select.mockImplementationOnce(() => {
+            throw new Error('connection reset');
+        });
+
+        const req = new NextRequest('http://localhost/api/teacher/insights?classroomId=7');
+        const res = await GET(req);
+        const json = await res.json();
+
+        expect(res.status).toBe(500);
+        expect(json.error).toBe('Internal Server Error');
     });
 });


### PR DESCRIPTION
## **User description**
**Problem**
The recommendations/weakTopics pipeline in GET /api/teacher/insights
(lines 98–140) had zero test coverage — 79.86% line coverage on route.ts,
with the mock's `?? []` fallback silently masking missing mocks instead
of failing loud.

**Fix**
Added 3 new test cases covering the full unresolvedPerTopic → totalPerTopic
→ sample-ID → weakTopics → generateRecommendations chain, the totalCount
fallback edge case, and the non-ApiError 500 path.
Closes #1330


___

## **CodeAnt-AI Description**
Expand teacher insights tests for recommendations and error handling

### What Changed
- Verifies that unresolved topic counts, total counts, and sample doubt IDs are combined before recommendations are generated
- Covers the fallback that uses unresolved counts when total counts are unavailable
- Confirms empty recommendation results and unexpected database errors return the expected API responses

### Impact
`✅ Reliable teacher recommendation coverage`
`✅ Verified topic-count fallback behavior`
`✅ Clearer internal-error responses`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for recommendation generation inputs and empty recommendation results.
  * Added tests for fallback totals and unexpected database errors returning a 500 response.
  * Improved test setup to reset and resolve mocked recommendation behavior consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->