### PR TITLE
fix: validate empty prompt before calling Groq API

### DIFF
--- a/src/app/api/ask-ai/route.ts
+++ b/src/app/api/ask-ai/route.ts
@@ -62,6 +62,16 @@ export async function POST(req: Request): Promise<NextResponse> {
         ? body.message
         : "";
 
+  // Reject empty or whitespace-only prompts before they ever reach the Groq
+  // API. Without this, an empty user message causes Groq to throw, which
+  // was being caught and surfaced as a 502/500 instead of a proper 400.
+  if (!prompt.trim()) {
+    return NextResponse.json(
+      { error: "Prompt cannot be empty" },
+      { status: 400 }
+    );
+  }
+
   if (body.imageBase64 !== undefined) {
     const img = body.imageBase64 as string;
     const validMime = /^data:image\/(png|jpe?g|webp);base64,/.test(img);


### PR DESCRIPTION
## **User description**
Fixes #1337

Adds validation to reject empty or whitespace-only prompts before they
reach the Groq API. Previously an empty prompt would cause Groq to throw,
which was caught and surfaced as a 502/500 instead of a proper 400.


___

## **CodeAnt-AI Description**
Reject empty prompts with a clear client error before contacting the AI service

### What Changed
- Empty or whitespace-only prompts now return a 400 error with the message “Prompt cannot be empty”
- Invalid prompts no longer trigger an upstream AI service failure or appear as a 500/502 error

### Impact
`✅ Clearer empty-prompt errors`
`✅ Fewer misleading server errors`
`✅ No unnecessary AI service requests`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to prevent empty or whitespace-only prompts from being submitted.
  * Users now receive a clear error message when a prompt is missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->