### PR TITLE
fix: enforce request body size limit on resume upload

### DIFF
--- a/src/app/api/resume-analyzer/route.ts
+++ b/src/app/api/resume-analyzer/route.ts
@@ -8,6 +8,7 @@ import { currentUser } from "@clerk/nextjs/server";
 import { checkUserBlock } from "@/lib/auth/auth-utils";
 import { enforceAiAvailability} from "@/lib/ai/kill-switch";
 import { getAnonymousQuotaIdentifier } from "@/lib/auth/request-identity";
+import { limitRequestBodySize } from "@/lib/validations/validate";
 
 const require = createRequire(import.meta.url);
 const pdf = require("pdf-parse-fork");
@@ -15,6 +16,12 @@ const pdf = require("pdf-parse-fork");
 const MAX_RESUME_SIZE_BYTES = 5 * 1024 * 1024;
 const SUPPORTED_RESUME_MIME_TYPES = new Set(["application/pdf"]);
 const MAX_TEXT_LENGTH = 10_000;
+
+// Multipart form data adds boundary/header overhead on top of the resume
+// file itself, plus a few small text fields (jobDescription, fieldOfInterest,
+// targetRole). 1MB of headroom above the resume size cap is comfortable
+// without opening the door back up to large-payload abuse.
+const MAX_REQUEST_BODY_BYTES = MAX_RESUME_SIZE_BYTES + 1 * 1024 * 1024;
 
 const textFieldSchema = z.string().max(MAX_TEXT_LENGTH, `Field must not exceed ${MAX_TEXT_LENGTH} characters`);
 
@@ -47,6 +54,13 @@ function validateResumeFile(file: File) {
 
 export async function POST(req: NextRequest) {
     try {
+        // Reject oversized payloads before reading anything into memory.
+        // Without this, an attacker could send an arbitrarily large multipart
+        // body and force the server to buffer all of it via formData()/
+        // arrayBuffer() before any size validation ever runs.
+        const sizeError = await limitRequestBodySize(req, MAX_REQUEST_BODY_BYTES);
+        if (sizeError) return sizeError;
+
         const formData = await req.formData();
         const file = formData.get("resume");
         const jobDescription = (formData.get("jobDescription") as string || "").trim();


### PR DESCRIPTION
## **User description**
Fixes #1339

Adds limitRequestBodySize() at the top of the POST handler so oversized
multipart payloads are rejected before the server reads anything into
memory via formData()/arrayBuffer().

Note: the shared helper defaults to a 4MB limit, but this route already
allows resumes up to 5MB (MAX_RESUME_SIZE_BYTES). Used an explicit
5MB + 1MB buffer instead of the default, so legitimate uploads near the
existing limit aren't rejected by this new check.


___

## **CodeAnt-AI Description**
Limit resume upload requests before processing their contents

### What Changed
- Resume analysis requests larger than 6MB are rejected before the server reads the multipart upload into memory
- Valid PDF resumes up to the existing 5MB file limit continue to be accepted, including space for form-data overhead
- Oversized uploads no longer reach file parsing and validation

### Impact
`✅ Lower memory use during resume uploads`
`✅ Reduced risk from oversized upload requests`
`✅ Existing 5MB resume uploads remain supported`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a 6 MB upload limit for resume analyzer requests.
  * Oversized uploads are rejected before processing, improving reliability and resource usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->