### PR TITLE
fix: isolate temporary video assets

### DIFF
--- a/src/__tests__/video/temp-isolation.test.ts
+++ b/src/__tests__/video/temp-isolation.test.ts
@@ -1,0 +1,119 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { TEMP_ROOT, ensureTempRoot, createAudioTempDir, getVideoTempPath } from "../../lib/video/temp";
+
+describe("temp isolation (issue #1345)", () => {
+  const createdPaths: string[] = [];
+
+  afterEach(() => {
+    // Clean up any temp dirs created during tests (in reverse order for nesting)
+    for (const p of createdPaths.reverse()) {
+      try {
+        if (fs.existsSync(p)) {
+          fs.rmSync(p, { recursive: true, force: true });
+        }
+      } catch {
+        // best-effort cleanup in tests
+      }
+    }
+    createdPaths.length = 0;
+  });
+
+  it("TEMP_ROOT is a subdirectory of os.tmpdir(), not os.tmpdir() itself", () => {
+    expect(TEMP_ROOT).toContain(os.tmpdir());
+    expect(TEMP_ROOT).not.toBe(os.tmpdir());
+  });
+
+  it("ensureTempRoot creates the directory", () => {
+    ensureTempRoot();
+    expect(fs.existsSync(TEMP_ROOT)).toBe(true);
+    expect(fs.statSync(TEMP_ROOT).isDirectory()).toBe(true);
+    createdPaths.push(TEMP_ROOT);
+  });
+
+  it("createAudioTempDir returns a unique directory under TEMP_ROOT", () => {
+    const dir1 = createAudioTempDir();
+    const dir2 = createAudioTempDir();
+    createdPaths.push(dir1, dir2);
+
+    expect(dir1).toContain(TEMP_ROOT);
+    expect(dir2).toContain(TEMP_ROOT);
+    expect(dir1).not.toBe(dir2);
+    expect(dir1.startsWith("doubtdesk-audio-")).toBe(false);
+    expect(path.basename(dir1).startsWith("doubtdesk-audio-")).toBe(true);
+    expect(fs.existsSync(dir1)).toBe(true);
+    expect(fs.existsSync(dir2)).toBe(true);
+  });
+
+  it("getVideoTempPath returns a unique path under TEMP_ROOT", () => {
+    const p1 = getVideoTempPath();
+    // Ensure next call gets a distinct Date.now() value
+    const start = Date.now();
+    while (Date.now() === start) { /* spin */ }
+    const p2 = getVideoTempPath();
+    createdPaths.push(path.dirname(p1), path.dirname(p2));
+
+    expect(p1).toContain(TEMP_ROOT);
+    expect(p2).toContain(TEMP_ROOT);
+    expect(p1).not.toBe(p2);
+    expect(path.basename(p1).startsWith("video-")).toBe(true);
+    expect(path.basename(p1).endsWith(".mp4")).toBe(true);
+  });
+
+  it("two concurrent jobs get isolated directories (Scenario A)", () => {
+    const jobADir = createAudioTempDir();
+    const jobBDir = createAudioTempDir();
+    createdPaths.push(jobADir, jobBDir);
+
+    // Write a file in each directory
+    fs.writeFileSync(path.join(jobADir, "audio.mp3"), "job-a");
+    fs.writeFileSync(path.join(jobBDir, "audio.mp3"), "job-b");
+
+    // Deleting job A's directory must NOT affect job B
+    fs.rmSync(jobADir, { recursive: true, force: true });
+    expect(fs.existsSync(jobADir)).toBe(false);
+    expect(fs.existsSync(jobBDir)).toBe(true);
+    expect(fs.readFileSync(path.join(jobBDir, "audio.mp3"), "utf-8")).toBe("job-b");
+  });
+
+  it("cleanup scoped to TEMP_ROOT cannot delete files outside it (Scenario E)", () => {
+    // Create a file directly in os.tmpdir() — simulating an unrelated application
+    const unrelatedFile = path.join(os.tmpdir(), "unrelated-app-data.txt");
+    fs.writeFileSync(unrelatedFile, "do not delete");
+
+    // Create DoubtDesk temp assets
+    const ddDir = createAudioTempDir();
+    createdPaths.push(ddDir);
+    fs.writeFileSync(path.join(ddDir, "audio.mp3"), "doubtdesk data");
+
+    // Simulate cleanup: only scan TEMP_ROOT, never os.tmpdir()
+    const entries = fs.readdirSync(TEMP_ROOT);
+    let cleanedCount = 0;
+    for (const entry of entries) {
+      const entryPath = path.join(TEMP_ROOT, entry);
+      if (entry.startsWith("doubtdesk-audio-") && fs.statSync(entryPath).isDirectory()) {
+        fs.rmSync(entryPath, { recursive: true, force: true });
+        cleanedCount++;
+      }
+    }
+
+    expect(cleanedCount).toBeGreaterThanOrEqual(1);
+    // The unrelated file MUST survive
+    expect(fs.existsSync(unrelatedFile)).toBe(true);
+    expect(fs.readFileSync(unrelatedFile, "utf-8")).toBe("do not delete");
+
+    // Clean up unrelated file
+    fs.unlinkSync(unrelatedFile);
+  });
+
+  it("pipeline video output lands under TEMP_ROOT, not directly in os.tmpdir()", () => {
+    const videoPath = getVideoTempPath();
+    createdPaths.push(path.dirname(videoPath));
+
+    // Verify the video file is under the app root, not directly in /tmp/
+    expect(videoPath).toContain(TEMP_ROOT);
+    // Verify it's NOT directly in os.tmpdir()
+    expect(path.dirname(videoPath)).not.toBe(os.tmpdir());
+  });
+});

--- a/src/inngest/functions.ts
+++ b/src/inngest/functions.ts
@@ -2,13 +2,13 @@ import { inngest } from "./client";
 import type { NonRetriableError } from "inngest";
 import fs from "fs";
 import path from "path";
-import os from "os";
 import { db } from "../configs/db";
 import { doubtsTable, usersTable, pendingNotificationsTable, repliesTable, videoJobsTable } from "../configs/schema";
 import { eq, inArray, and, lt } from "drizzle-orm";
 import { emailNotificationLimiter, redisClient } from "@/lib/ratelimit/ratelimit";
 import { sendReplyNotificationEmail, sendDigestEmail } from "@/lib/email/email";
 import { runVideoPipeline } from "../lib/video/pipeline";
+import { TEMP_ROOT } from "../lib/video/temp";
 
 interface InngestEvent {
     data: Record<string, unknown>;
@@ -43,7 +43,7 @@ export const cleanupTempAssets = inngest.createFunction(
       const now = Date.now();
       let count = 0;
 
-      const tmpRoot = os.tmpdir();
+      const tmpRoot = TEMP_ROOT;
       if (fs.existsSync(tmpRoot)) {
         const entries = fs.readdirSync(tmpRoot);
         for (const entry of entries) {

--- a/src/lib/video/pipeline.ts
+++ b/src/lib/video/pipeline.ts
@@ -1,11 +1,11 @@
 import { renderMedia, selectComposition } from "@remotion/renderer";
 import path from "path";
 import fs from "fs";
-import os from "os";
 import { groq } from "@/lib/ai/groq-client";
 import axios from "axios";
 import Tesseract from "tesseract.js";
 import { uploadVideo } from "./storage";
+import { createAudioTempDir, getVideoTempPath } from "./temp";
 
 export interface SceneData {
   text?: string;
@@ -199,7 +199,7 @@ Return ONLY a JSON object with a "scenes" array.`;
 
   // 4. Generate audio (free Google TTS).
   await onProgress({ progress: 65, step: "Generating audio…" });
-  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "doubtdesk-audio-"));
+  const tempDir = createAudioTempDir();
 
   const scenes: EnrichedScene[] = await Promise.all(
     rawScenes.map(async (scene: SceneData, i: number): Promise<EnrichedScene> => {
@@ -228,7 +228,7 @@ Return ONLY a JSON object with a "scenes" array.`;
   // 5. Render the video with Remotion.
   await onProgress({ progress: 90, step: "Rendering video…" });
   const entryPoint = path.resolve(process.cwd(), "src/lib/video/remotion/index.tsx");
-  const outputLocation = path.join(os.tmpdir(), `video-${Date.now()}.mp4`);
+  const outputLocation = getVideoTempPath();
 
   try {
     const { bundle } = await import("@remotion/bundler");

--- a/src/lib/video/temp.ts
+++ b/src/lib/video/temp.ts
@@ -1,0 +1,40 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+
+/**
+ * Application-owned temp root. All DoubtDesk temporary assets (audio, video)
+ * live under this directory so that:
+ *
+ * 1. The hourly cleanupTempAssets cron scans ONLY this root — never the
+ *    shared os.tmpdir(), eliminating cross-process / cross-job data loss.
+ * 2. Each pipeline invocation gets a unique subdirectory, so concurrent
+ *    jobs cannot interfere with one another.
+ */
+export const TEMP_ROOT = path.join(os.tmpdir(), "doubtdesk");
+
+/**
+ * Ensure the application temp root exists (idempotent).
+ */
+export function ensureTempRoot(): string {
+  fs.mkdirSync(TEMP_ROOT, { recursive: true });
+  return TEMP_ROOT;
+}
+
+/**
+ * Create a fresh, unique temporary directory under the application temp root.
+ * Each call returns a path like  /tmp/doubtdesk/doubtdesk-audio-<random>
+ */
+export function createAudioTempDir(): string {
+  ensureTempRoot();
+  return fs.mkdtempSync(path.join(TEMP_ROOT, "doubtdesk-audio-"));
+}
+
+/**
+ * Return the path for a rendered video file inside the application temp root.
+ * The filename incorporates Date.now() for uniqueness.
+ */
+export function getVideoTempPath(): string {
+  ensureTempRoot();
+  return path.join(TEMP_ROOT, `video-${Date.now()}.mp4`);
+}


### PR DESCRIPTION
## **User description**
## Description

Isolates DoubtDesk temporary assets from the shared OS temp directory to prevent `cleanupTempAssets` from deleting files belonging to concurrent jobs or other applications.

* Added a dedicated `os.tmpdir()/doubtdesk/` temp root.
* Added per-job temporary directories using `fs.mkdtempSync()`.
* Updated the video pipeline to use the isolated temp paths.
* Updated the cleanup cron to scan only the DoubtDesk-owned temp root.
* Added regression tests covering temp-file isolation and concurrent-job safety.

## Related Issue

Closes #1345

## Type of Change

* [x] Bug fix (non-breaking change that fixes an issue)
* [ ] New feature (non-breaking change that adds functionality)
* [ ] Documentation update (README, guides, comments)
* [ ] Style / UI change (no logic change)
* [ ] Code refactor (no behavior change)
* [x] Test addition or update
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Screenshots (if UI change)

Not applicable — this is a backend/temp-file lifecycle fix.

## How Has This Been Tested?

* [x] Targeted regression tests — 7/7 passed
* [x] TypeScript (`npx tsc --noEmit`) — passed
* [x] ESLint — passed
* [x] `git diff --check` — clean
* [x] Pre-commit hooks — passed
* [ ] Tested locally with `npm run dev` — not applicable
* [ ] Verified on mobile viewport (375px) — not applicable
* [ ] Verified on desktop viewport (1440px) — not applicable

The full test suite retains the same pre-existing failures as the baseline; no new failures were introduced.

## Checklist

* [x] I have tested my changes locally
* [x] My code follows the existing code style (TypeScript, Tailwind, no `any` types)
* [x] I have not introduced unrelated changes (each PR should address one issue)
* [x] I have added comments where necessary
* [x] My branch is up to date with `main`
* [x] I have linked the related issue above
* [ ] Screenshots are included (not applicable — no UI change)


___

## **CodeAnt-AI Description**
Isolate temporary video assets to prevent cleanup from deleting unrelated files

### What Changed
- Video audio and rendered files are now stored under a dedicated DoubtDesk temporary directory instead of the shared system temp directory
- Each video job receives its own temporary audio directory, preventing concurrent jobs from affecting one another
- Scheduled cleanup now removes only stale DoubtDesk assets and leaves files owned by other jobs or applications untouched
- Added regression coverage for isolated paths, concurrent jobs, and cleanup safety

### Impact
`✅ Prevented deletion of unrelated temporary files`
`✅ Safer concurrent video processing`
`✅ Reliable cleanup of DoubtDesk assets`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved isolation of temporary video and audio files to prevent conflicts between concurrent jobs.
  * Scoped cleanup to application-created temporary files, preserving unrelated system temporary files.
  * Standardized video output and audio processing within dedicated temporary locations.

* **Tests**
  * Added coverage for unique paths, concurrent job isolation, cleanup behavior, and output placement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->