### PR TITLE
fix: return proper HTTP error instead of misleading JSON payload on a…

### DIFF
--- a/src/app/api/analytics/export/route.test.ts
+++ b/src/app/api/analytics/export/route.test.ts
@@ -1,0 +1,150 @@
+import { GET } from "./route";
+import { NextRequest } from "next/server";
+
+const currentUserMock = jest.fn();
+const checkUserBlockMock = jest.fn();
+const requireTeacherMock = jest.fn();
+
+jest.mock("@clerk/nextjs/server", () => ({
+  currentUser: () => currentUserMock(),
+}));
+
+jest.mock("@/lib/auth/auth-utils", () => ({
+  checkUserBlock: (...args: unknown[]) => checkUserBlockMock(...args),
+}));
+
+jest.mock("@/lib/auth/membership-guard", () => ({
+  requireTeacher: (...args: unknown[]) => requireTeacherMock(...args),
+  TEACHER_ROLES: ["teacher", "owner", "admin"],
+}));
+
+const selectResultQueue: any[] = [];
+
+jest.mock("@/configs/db", () => {
+  const makeChain = () => {
+    const chain: any = {
+      from: jest.fn().mockImplementation(() => chain),
+      where: jest.fn().mockImplementation(() => chain),
+      orderBy: jest.fn().mockImplementation(() => chain),
+      limit: jest.fn().mockImplementation(() => chain),
+      groupBy: jest.fn().mockImplementation(() => chain),
+      innerJoin: jest.fn().mockImplementation(() => chain),
+      then: jest.fn().mockImplementation((resolve) => {
+        const data = selectResultQueue.shift() ?? [];
+        return Promise.resolve(resolve(data));
+      }),
+    };
+    return chain;
+  };
+  return {
+    db: {
+      select: jest.fn().mockImplementation(() => makeChain()),
+    },
+  };
+});
+
+function makeReq(classroomId?: number) {
+  const url = classroomId
+    ? `http://localhost/api/analytics/export?classroomId=${classroomId}`
+    : "http://localhost/api/analytics/export";
+  return new NextRequest(url);
+}
+
+describe("Analytics Export API Endpoint", () => {
+  beforeEach(() => {
+    currentUserMock.mockReset();
+    checkUserBlockMock.mockReset();
+    requireTeacherMock.mockReset();
+    selectResultQueue.length = 0;
+    jest.clearAllMocks();
+
+    currentUserMock.mockResolvedValue({
+      primaryEmailAddress: { emailAddress: "teacher@example.com" },
+    });
+    checkUserBlockMock.mockResolvedValue({ isBlocked: false, errorResponse: null });
+    requireTeacherMock.mockResolvedValue(undefined);
+  });
+
+  it("returns 200 with CSV on success", async () => {
+    // trendingDoubts
+    selectResultQueue.push([]);
+    // mostAskedTopics
+    selectResultQueue.push([]);
+    // solvedStats
+    selectResultQueue.push([]);
+    // peakTime
+    selectResultQueue.push([]);
+    // engagement
+    selectResultQueue.push([{ totalStudents: 5, totalDoubts: 20 }]);
+    // totalReplies
+    selectResultQueue.push([{ count: 30 }]);
+    // topContributors
+    selectResultQueue.push([]);
+    // recentAIReplies
+    selectResultQueue.push([]);
+
+    const res = await GET(makeReq(1));
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toBe("text/csv");
+    expect(res.headers.get("Content-Disposition")).toContain("analytics-report.csv");
+    const text = await res.text();
+    expect(text).toContain("Metric,Value");
+    expect(text).toContain("Total Students,5");
+  });
+
+  it("returns 500 JSON error when database query fails", async () => {
+    // Force the parallel Promise.all to reject
+    selectResultQueue.push(Promise.reject(new Error("DB connection failed")));
+
+    const res = await GET(makeReq(1));
+    const body = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(body).toHaveProperty("error");
+    expect(typeof body.error).toBe("string");
+    expect(body.error.length).toBeGreaterThan(0);
+  });
+
+  it("does not return misleading analytics fallback payload on error", async () => {
+    selectResultQueue.push(Promise.reject(new Error("DB failure")));
+
+    const res = await GET(makeReq(1));
+    const body = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(body).not.toHaveProperty("trendingDoubts");
+    expect(body).not.toHaveProperty("mostAskedTopics");
+    expect(body).not.toHaveProperty("solvedStats");
+    expect(body).not.toHaveProperty("peakTime");
+    expect(body).not.toHaveProperty("engagement");
+    expect(body).not.toHaveProperty("weakTopics");
+    expect(body).not.toHaveProperty("topContributors");
+    expect(body).not.toHaveProperty("classroomSettings");
+    expect(body).not.toHaveProperty("recentAIReplies");
+  });
+
+  it("returns 401 JSON when user is not authenticated", async () => {
+    currentUserMock.mockResolvedValue(null);
+
+    const res = await GET(makeReq());
+    const body = await res.json();
+
+    expect(res.status).toBe(401);
+    expect(body.error).toBe("Unauthorized");
+  });
+
+  it("returns 403 JSON when user has no teacher classrooms", async () => {
+    // No classroomId → multi-classroom path
+    // teacherMemberships
+    selectResultQueue.push([]);
+    // ownedClassrooms
+    selectResultQueue.push([]);
+
+    const res = await GET(makeReq());
+    const body = await res.json();
+
+    expect(res.status).toBe(403);
+    expect(body.error).toBe("Forbidden");
+  });
+});

--- a/src/app/api/analytics/export/route.ts
+++ b/src/app/api/analytics/export/route.ts
@@ -20,6 +20,7 @@ import {
 } from "drizzle-orm";
 import { currentUser } from "@clerk/nextjs/server";
 import { checkUserBlock } from "@/lib/auth/auth-utils";
+import { buildErrorResponse } from "@/lib/errors/error-handler";
 
 export async function GET(req: Request) {
   const user = await currentUser();
@@ -342,19 +343,7 @@ if (classroomId) {
     });
   } catch (error: unknown) {
     console.error("Error fetching analytics:", error);
-    return NextResponse.json({
-      trendingDoubts: [],
-      mostAskedTopics: [],
-      solvedStats: [],
-      peakTime: [],
-      engagement: { totalStudents: 0, totalDoubts: 0, totalReplies: 0 },
-      weakTopics: [],
-      topContributors: [],
-      classroomSettings: {
-        pedagogyLevel: "Undergraduate (Freshman)",
-        targetGradeLevel: 13,
-      },
-      recentAIReplies: [],
-    });
+    const { status, body } = buildErrorResponse(error);
+    return NextResponse.json(body, { status });
   }
 }


### PR DESCRIPTION
## **User description**
## Description

Fixed the analytics export error handling so database/export failures no longer return a misleading `200 OK` JSON analytics payload.

The error path now uses the repository's standard `buildErrorResponse` handler, returning a proper `500` error response instead of JSON shaped like a successful analytics export.

## Related Issue

Closes #1348

## Type of Change

* [x] Bug fix (non-breaking change that fixes an issue)
* [ ] New feature (non-breaking change that adds functionality)
* [ ] Documentation update (README, guides, comments)
* [ ] Style / UI change (no logic change)
* [ ] Code refactor (no behavior change)
* [ ] Test addition or update
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Screenshots (if UI change)

Not applicable — this is a backend-only change.

## How Has This Been Tested?

* [x] TypeScript check (`npx tsc --noEmit`)
* [x] ESLint
* [x] Relevant Jest tests — 5/5 passed
* [x] `git diff --check`
* [ ] Tested locally with `npm run dev`
* [ ] Verified on mobile viewport (375px) — not applicable
* [ ] Verified on desktop viewport (1440px) — not applicable

### Regression Coverage

Added tests covering:

* Successful CSV export returns `200` with `text/csv`
* Database failure returns `500` with a JSON error
* Error responses do not contain the misleading analytics fallback payload
* Unauthenticated requests return `401`
* Users without teacher classrooms return `403`

## Checklist

* [x] I have tested my changes locally
* [x] My code follows the existing code style
* [x] I have not introduced unrelated changes
* [x] I have added comments where necessary
* [x] My branch is up to date with `main`
* [x] I have linked the related issue above
* [x] Screenshots are not applicable — no UI change


___

## **CodeAnt-AI Description**
Return clear errors when analytics exports fail

### What Changed
- Analytics export failures now return an HTTP error with a JSON message instead of a `200 OK` response containing empty analytics data
- Successful exports still return the analytics CSV file
- Added coverage for successful exports, database failures, unauthenticated requests, and users without teacher access

### Impact
`✅ Accurate export failure status`
`✅ No misleading empty analytics reports`
`✅ Clearer access and database error responses`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
