### PR TITLE
feat(classroom): implement AbortController signal in debounced similarity requests (#1334)

### DIFF
--- a/src/components/classroom/AskDoubt.tsx
+++ b/src/components/classroom/AskDoubt.tsx
@@ -155,9 +155,11 @@ export default function AskDoubt({ defaultSubject = "", isOpen, onClose, onSucce
             });
             if (res.ok) {
                 const data = await res.json();
+                if (similarityAbortControllerRef.current !== controller) return;
                 setSimilarDoubts(data.similarDoubts || []);
                 setSimilarityChecked(true);
             } else {
+                if (similarityAbortControllerRef.current !== controller) return;
                 setSimilarDoubts([]);
                 setSimilarityChecked(false);
                 setSimilarityCheckError(true);
@@ -166,6 +168,7 @@ export default function AskDoubt({ defaultSubject = "", isOpen, onClose, onSucce
             if (err.name === "AbortError") {
                 return;
             }
+            if (similarityAbortControllerRef.current !== controller) return;
             console.error("Similarity check failed:", err);
             setSimilarDoubts([]);
             setSimilarityChecked(false);
@@ -231,6 +234,7 @@ export default function AskDoubt({ defaultSubject = "", isOpen, onClose, onSucce
             if (similarityAbortControllerRef.current) {
                 similarityAbortControllerRef.current.abort();
                 similarityAbortControllerRef.current = null;
+                setIsCheckingSimilarity(false);
             }
             setSuggestedSubject("");
             setSimilarDoubts([]);
@@ -256,6 +260,7 @@ export default function AskDoubt({ defaultSubject = "", isOpen, onClose, onSucce
             if (similarityAbortControllerRef.current) {
                 similarityAbortControllerRef.current.abort();
                 similarityAbortControllerRef.current = null;
+                setIsCheckingSimilarity(false);
             }
         };
     }, [content, subjectWasEdited]);
@@ -264,6 +269,7 @@ export default function AskDoubt({ defaultSubject = "", isOpen, onClose, onSucce
         if (!isOpen && similarityAbortControllerRef.current) {
             similarityAbortControllerRef.current.abort();
             similarityAbortControllerRef.current = null;
+            setIsCheckingSimilarity(false);
         }
     }, [isOpen]);
 

--- a/src/components/classroom/AskDoubt.tsx
+++ b/src/components/classroom/AskDoubt.tsx
@@ -128,6 +128,7 @@ export default function AskDoubt({ defaultSubject = "", isOpen, onClose, onSucce
     const [similarityCheckError, setSimilarityCheckError] = useState(false);
     const [expandedSolvedId, setExpandedSolvedId] = useState<number | null>(null);
     const similarityDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const similarityAbortControllerRef = useRef<AbortController | null>(null);
 
     const checkSimilarity = async (text: string) => {
         if (doubtToEdit || text.trim().length < 20) {
@@ -136,6 +137,13 @@ export default function AskDoubt({ defaultSubject = "", isOpen, onClose, onSucce
             setSimilarityCheckError(false);
             return;
         }
+
+        if (similarityAbortControllerRef.current) {
+            similarityAbortControllerRef.current.abort();
+        }
+        const controller = new AbortController();
+        similarityAbortControllerRef.current = controller;
+
         setIsCheckingSimilarity(true);
         setSimilarityCheckError(false);
         try {
@@ -143,6 +151,7 @@ export default function AskDoubt({ defaultSubject = "", isOpen, onClose, onSucce
                 method: "POST",
                 headers: { "Content-Type": "application/json" },
                 body: JSON.stringify({ content: text, classroomId }),
+                signal: controller.signal,
             });
             if (res.ok) {
                 const data = await res.json();
@@ -153,13 +162,18 @@ export default function AskDoubt({ defaultSubject = "", isOpen, onClose, onSucce
                 setSimilarityChecked(false);
                 setSimilarityCheckError(true);
             }
-        } catch (err) {
+        } catch (err: any) {
+            if (err.name === "AbortError") {
+                return;
+            }
             console.error("Similarity check failed:", err);
             setSimilarDoubts([]);
             setSimilarityChecked(false);
             setSimilarityCheckError(true);
         } finally {
-            setIsCheckingSimilarity(false);
+            if (similarityAbortControllerRef.current === controller) {
+                setIsCheckingSimilarity(false);
+            }
         }
     };
 
@@ -214,6 +228,10 @@ export default function AskDoubt({ defaultSubject = "", isOpen, onClose, onSucce
 
     useEffect(() => {
         if (content.trim().length < 20) {
+            if (similarityAbortControllerRef.current) {
+                similarityAbortControllerRef.current.abort();
+                similarityAbortControllerRef.current = null;
+            }
             setSuggestedSubject("");
             setSimilarDoubts([]);
             setSimilarityChecked(false);
@@ -235,8 +253,19 @@ export default function AskDoubt({ defaultSubject = "", isOpen, onClose, onSucce
 
         return () => {
             if (similarityDebounceRef.current) clearTimeout(similarityDebounceRef.current);
+            if (similarityAbortControllerRef.current) {
+                similarityAbortControllerRef.current.abort();
+                similarityAbortControllerRef.current = null;
+            }
         };
     }, [content, subjectWasEdited]);
+
+    useEffect(() => {
+        if (!isOpen && similarityAbortControllerRef.current) {
+            similarityAbortControllerRef.current.abort();
+            similarityAbortControllerRef.current = null;
+        }
+    }, [isOpen]);
 
     useEffect(() => {
         const handleEsc = (e: KeyboardEvent) => {


### PR DESCRIPTION
## **User description**
### Problem
When a student types inside the doubt description textarea in \AskDoubt.tsx\, \checkSimilarity(content)\ is scheduled via \setTimeout\. If network latency fluctuates, earlier search responses can resolve after later search responses, populating stale similar doubts.

### Solution
- Attached an \AbortController\ ref (\similarityAbortControllerRef\) inside \AskDoubt.tsx\.
- Cancel ongoing HTTP requests (\controller.abort()\) whenever a new debounced input change or modal close event occurs.
- Passed \signal: controller.signal\ to \etch('/api/doubts/check-duplicate', { signal })\.
- Gracefully handled \AbortError\ in exception handling to avoid false error notifications.

Closes #1334


___

## **CodeAnt-AI Description**
Prevent stale similar-doubt results while typing

### What Changed
- Cancels an in-progress similarity check when the student enters new text, clears the description, or closes the doubt form
- Ensures responses from older searches cannot replace results for the student’s latest description
- Treats canceled searches as expected behavior instead of showing an error

### Impact
`✅ Up-to-date similar-doubt suggestions`
`✅ Fewer misleading similarity results`
`✅ No false errors when leaving or editing the form`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved duplicate-question checks by cancelling outdated requests.
  * Prevented stale results from affecting the loading state.
  * Ensured pending checks are cancelled when the question is too short or the dialog closes.
  * Reduced unnecessary errors during request cancellation.
  * Improved responsiveness and reliability when questions are edited rapidly or checks are interrupted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->