### PR TITLE
feat(sla): TTR SLA Tracker & Teacher Alerts #1052

### DIFF
--- a/src/app/api/doubts/action/[id]/route.ts
+++ b/src/app/api/doubts/action/[id]/route.ts
@@ -188,7 +188,8 @@ export async function PATCH(req: Request, { params }: { params: Promise<{ id: st
             const updated = await db.update(doubtsTable)
                 .set({ 
                     isSolved: newStatus,
-                    solvedReplyId: newSolvedReplyId 
+                    solvedReplyId: newSolvedReplyId,
+                    resolvedAt: newStatus === DOUBT_STATUS.SOLVED ? new Date() : null
                 })
                 .where(eq(doubtsTable.id, doubtId))
                 .returning();

--- a/src/app/api/inngest/route.ts
+++ b/src/app/api/inngest/route.ts
@@ -11,7 +11,8 @@ import {
     generateVideo,
     cleanupStaleVideoJobs,
     checkUrgentClassroomActivity,
-    notifyFlaggedContentHidden
+    notifyFlaggedContentHidden,
+    evaluateSlas
 } from "../../../inngest/functions";
 
 // Serve your registered background processes safely
@@ -27,6 +28,7 @@ export const { GET, POST, PUT } = serve({
         generateVideo,
         cleanupStaleVideoJobs,
         checkUrgentClassroomActivity,
-        notifyFlaggedContentHidden
+        notifyFlaggedContentHidden,
+        evaluateSlas
     ],
 });

--- a/src/components/classroom/DoubtCard.tsx
+++ b/src/components/classroom/DoubtCard.tsx
@@ -294,6 +294,28 @@ export default function DoubtCard({ doubt, onUpdate, onViewAISolution, role, ope
                                         <span className="text-[9px] font-black text-blue-400 uppercase tracking-widest">Pinned</span>
                                     </div>
                                 )}
+                                {doubt.isSolved !== "solved" && doubt.slaStatus === "breached" && (
+                                    <Tooltip>
+                                        <TooltipTrigger asChild>
+                                            <div className="px-3 py-1 bg-rose-500/10 border border-rose-500/20 rounded-full flex items-center gap-1.5 cursor-help">
+                                                <AlertTriangle className="w-3 h-3 text-rose-500" />
+                                                <span className="text-[9px] font-black text-rose-500 uppercase tracking-widest">SLA Breached</span>
+                                            </div>
+                                        </TooltipTrigger>
+                                        <TooltipContent>Unsolved for over 24 hours</TooltipContent>
+                                    </Tooltip>
+                                )}
+                                {doubt.isSolved !== "solved" && doubt.slaStatus === "warning" && (
+                                    <Tooltip>
+                                        <TooltipTrigger asChild>
+                                            <div className="px-3 py-1 bg-orange-500/10 border border-orange-500/20 rounded-full flex items-center gap-1.5 cursor-help">
+                                                <AlertTriangle className="w-3 h-3 text-orange-500" />
+                                                <span className="text-[9px] font-black text-orange-500 uppercase tracking-widest">SLA Warning</span>
+                                            </div>
+                                        </TooltipTrigger>
+                                        <TooltipContent>Unsolved for over 12 hours</TooltipContent>
+                                    </Tooltip>
+                                )}
                                 {doubt.isSolved === "solved" ? (
                                     <div className="px-3 py-1 bg-emerald-500/10 border border-emerald-500/20 rounded-full flex items-center gap-1.5">
                                         <CheckCircle className="w-3 h-3 text-emerald-500" />

--- a/src/configs/schema.ts
+++ b/src/configs/schema.ts
@@ -122,6 +122,8 @@ export const doubtsTable = pgTable("doubts", {
     type: varchar({ length: 20 }).default("community"),
     isPinned: boolean().default(false),
     isHidden: boolean("isHidden").default(false).notNull(),
+    slaStatus: varchar({ length: 20 }).default("ok").notNull(),
+    resolvedAt: timestamp(),
     deletedAt: timestamp(),
     createdAt: timestamp().defaultNow().notNull(),
 

--- a/src/inngest/functions.ts
+++ b/src/inngest/functions.ts
@@ -3,10 +3,10 @@ import type { NonRetriableError } from "inngest";
 import fs from "fs";
 import path from "path";
 import { db } from "../configs/db";
-import { doubtsTable, usersTable, pendingNotificationsTable, repliesTable, videoJobsTable } from "../configs/schema";
-import { eq, inArray, and, lt } from "drizzle-orm";
+import { doubtsTable, usersTable, pendingNotificationsTable, repliesTable, videoJobsTable, classroomsTable } from "../configs/schema";
+import { eq, inArray, and, lt, isNull } from "drizzle-orm";
 import { emailNotificationLimiter, redisClient } from "@/lib/ratelimit/ratelimit";
-import { sendReplyNotificationEmail, sendDigestEmail } from "@/lib/email/email";
+import { sendReplyNotificationEmail, sendDigestEmail, sendSlaBreachEmail } from "@/lib/email/email";
 import { getAnonymousHandle } from "@/lib/anonymity/anonymity";
 import { runVideoPipeline } from "../lib/video/pipeline";
 import { TEMP_ROOT } from "../lib/video/temp";
@@ -428,4 +428,68 @@ export const cleanupStaleVideoJobs = inngest.createFunction(
       return { failedStaleJobs: failed.length };
     });
   },
+);
+
+export const evaluateSlas = inngest.createFunction(
+  { id: "evaluate-slas", triggers: [{ cron: "0 * * * *" }] },
+  async ({ step }: { step: InngestStep }) => {
+    return await step.run("evaluate-slas-step", async () => {
+      const now = new Date();
+      const twelveHoursAgo = new Date(now.getTime() - 12 * 60 * 60 * 1000);
+      const twentyFourHoursAgo = new Date(now.getTime() - 24 * 60 * 60 * 1000);
+
+      const unsolvedDoubts = await db
+        .select()
+        .from(doubtsTable)
+        .where(
+          and(
+            inArray(doubtsTable.isSolved, ["unsolved", "in-progress"]),
+            isNull(doubtsTable.deletedAt)
+          )
+        );
+
+      let warningsUpdated = 0;
+      let breachesUpdated = 0;
+
+      for (const doubt of unsolvedDoubts) {
+        const doubtAge = doubt.createdAt.getTime();
+        
+        if (doubtAge < twentyFourHoursAgo.getTime() && doubt.slaStatus !== "breached") {
+          // Breach
+          await db
+            .update(doubtsTable)
+            .set({ slaStatus: "breached" })
+            .where(eq(doubtsTable.id, doubt.id));
+            
+          breachesUpdated++;
+
+          if (doubt.classroomId) {
+            const [classroom] = await db
+              .select()
+              .from(classroomsTable)
+              .where(eq(classroomsTable.id, doubt.classroomId));
+
+            if (classroom && classroom.teacherEmail) {
+              await sendSlaBreachEmail({
+                toEmail: classroom.teacherEmail,
+                doubtId: doubt.id,
+                doubtSubject: doubt.subject,
+                hours: 24
+              }).catch(err => console.error("Failed to send SLA breach email:", err));
+            }
+          }
+        } else if (doubtAge >= twentyFourHoursAgo.getTime() && doubtAge < twelveHoursAgo.getTime() && doubt.slaStatus === "ok") {
+          // Warning
+          await db
+            .update(doubtsTable)
+            .set({ slaStatus: "warning" })
+            .where(eq(doubtsTable.id, doubt.id));
+          
+          warningsUpdated++;
+        }
+      }
+
+      return { warningsUpdated, breachesUpdated };
+    });
+  }
 );

--- a/src/lib/email/email.ts
+++ b/src/lib/email/email.ts
@@ -194,6 +194,35 @@ export async function sendBlockEmail(
 }
 
 /**
+ * Sends a notification email when a doubt breaches the SLA.
+ */
+export async function sendSlaBreachEmail(params: {
+    toEmail: string;
+    doubtId: number;
+    doubtSubject: string;
+    hours: number;
+}): Promise<EmailSendResult> {
+    const { toEmail, doubtId, doubtSubject, hours } = params;
+    const appUrl = process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000";
+    const doubtLink = `${appUrl}/doubts/${doubtId}`;
+    
+    const subject = "SLA Breached - DoubtDesk Action Required";
+    const html = `
+      <p>A doubt in your classroom has been unsolved for over <strong>${hours} hours</strong> and has breached the SLA.</p>
+      <p><strong>Subject:</strong> ${escapeHtml(doubtSubject)}</p>
+      <p><a href="${doubtLink}">Click here to view and resolve the doubt</a></p>
+    `;
+
+    console.log(`[EMAIL] Preparing SLA breach email for doubt ${doubtId}`);
+    return sendResendEmail({
+        toEmail,
+        subject,
+        html,
+        logLabel: "SLA breach email",
+    });
+}
+
+/**
  * Sends a premium, responsive HTML email notification to the doubt author when a reply is posted.
  */
 export async function sendReplyNotificationEmail(params: {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -165,6 +165,8 @@ export interface Doubt {
     type: "ai" | "community" | "teacher";
     isPinned: boolean | null;
     isPendingSync?: boolean;
+    slaStatus: string;
+    resolvedAt?: Date | string | null;
     createdAt: Date | string;
     // The raw author identifier must never appear on a client-facing Doubt. Typing
     // it as `never` means a raw DB row (which carries `userEmail: string`) does not


### PR DESCRIPTION
## **User description**
Fixes #1052 

Adds Time-to-Resolution (TTR) SLA tracking for doubts.
- Added `slaStatus` (ok/warning/breached) and `resolvedAt` to `doubtsTable`
- Added hourly Inngest background job to evaluate doubt SLAs (12h warning, 24h breach)
- Triggers `sendSlaBreachEmail` to the classroom teacher if a doubt breaches the 24h SLA
- Added dynamic SLA badges (Warning / Breached) on the frontend `DoubtCard`


___

## **CodeAnt-AI Description**
Track doubt resolution SLAs and alert teachers when responses are overdue

### What Changed
- Doubts receive a warning after 12 hours without resolution and are marked as breached after 24 hours
- Classroom teachers receive an email when a doubt breaches the 24-hour SLA, with a direct link to resolve it
- Doubt cards show clear warning and breach badges for unresolved doubts
- Resolving a doubt records its resolution time and clears the active SLA state

### Impact
`✅ Earlier visibility into overdue doubts`
`✅ Direct teacher alerts for 24-hour breaches`
`✅ Clearer SLA status on doubt cards`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added SLA monitoring for unresolved doubts, including warning and breach statuses.
  * Added visible “SLA Warning” and “SLA Breached” indicators to doubt cards.
  * Added automated email notifications when doubts breach SLA.
  * Added hourly SLA evaluation.
* **Bug Fixes**
  * Resolution timestamps are now recorded when doubts are solved and cleared when reopened.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->