### PR TITLE
feat(doubt): Doubt Description Version History & Edit Timeline #1056

### DIFF
--- a/src/app/api/doubts/[id]/edits/route.ts
+++ b/src/app/api/doubts/[id]/edits/route.ts
@@ -1,0 +1,68 @@
+import { NextResponse } from "next/server";
+import { db } from "@/configs/db";
+import { doubtEditsTable, doubtsTable, membershipsTable } from "@/configs/schema";
+import { eq, desc, and, isNull } from "drizzle-orm";
+import { currentUser } from "@clerk/nextjs/server";
+import { canTeach } from "@/lib/auth/membership-guard";
+
+export async function GET(req: Request, { params }: { params: Promise<{ id: string }> }) {
+    try {
+        const { id } = await params;
+        const doubtId = parseInt(id);
+
+        if (isNaN(doubtId)) {
+            return NextResponse.json({ error: "Invalid doubt ID" }, { status: 400 });
+        }
+
+        const user = await currentUser();
+        const email = user?.primaryEmailAddress?.emailAddress;
+
+        // Fetch doubt to check access
+        const [doubt] = await db
+            .select()
+            .from(doubtsTable)
+            .where(and(eq(doubtsTable.id, doubtId), isNull(doubtsTable.deletedAt)))
+            .limit(1);
+
+        if (!doubt) {
+            return NextResponse.json({ error: "Doubt not found" }, { status: 404 });
+        }
+
+        // Security: Verify doubt visibility/classroom membership
+        if (doubt.classroomId) {
+            if (!email) {
+                return NextResponse.json({ error: "Unauthorized access to classroom doubt" }, { status: 401 });
+            }
+            const [membership] = await db
+                .select()
+                .from(membershipsTable)
+                .where(
+                    and(
+                        eq(membershipsTable.userEmail, email),
+                        eq(membershipsTable.classroomId, doubt.classroomId)
+                    )
+                );
+            if (!membership) {
+                return NextResponse.json({ error: "Access denied to this classroom's doubt" }, { status: 403 });
+            }
+        }
+
+        const edits = await db
+            .select({
+                id: doubtEditsTable.id,
+                doubtId: doubtEditsTable.doubtId,
+                previousSubject: doubtEditsTable.previousSubject,
+                previousContent: doubtEditsTable.previousContent,
+                editedByEmail: doubtEditsTable.editedByEmail, // Kept internal, UI can show "by Author"
+                editedAt: doubtEditsTable.editedAt,
+            })
+            .from(doubtEditsTable)
+            .where(eq(doubtEditsTable.doubtId, doubtId))
+            .orderBy(desc(doubtEditsTable.editedAt));
+
+        return NextResponse.json(edits);
+    } catch (error) {
+        console.error("Error fetching doubt edits:", error);
+        return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+    }
+}

--- a/src/app/api/doubts/action/[id]/route.ts
+++ b/src/app/api/doubts/action/[id]/route.ts
@@ -1,5 +1,5 @@
 import { db } from "@/configs/db";
-import { doubtTagsTable, doubtsTable, likesTable, classroomsTable, repliesTable, tagsTable, membershipsTable } from "@/configs/schema";
+import { doubtTagsTable, doubtsTable, likesTable, classroomsTable, repliesTable, tagsTable, membershipsTable, doubtEditsTable } from "@/configs/schema";
 import { and, eq, isNull, sql } from "drizzle-orm";
 import { NextResponse } from "next/server";
 import { currentUser } from "@clerk/nextjs/server";
@@ -237,11 +237,20 @@ export async function PATCH(req: Request, { params }: { params: Promise<{ id: st
                 : isNull(tagsTable.classroomId);
 
             const { updated, savedTags } = await db.transaction(async (tx) => {
+                // Record the previous state before updating
+                await tx.insert(doubtEditsTable).values({
+                    doubtId,
+                    previousSubject: doubt.subject,
+                    previousContent: doubt.content,
+                    editedByEmail: email!,
+                });
+
                 const [updatedRow] = await tx.update(doubtsTable)
                     .set({
                         content: content || null,
                         subject,
-                        imageUrl: imageUrl || null
+                        imageUrl: imageUrl || null,
+                        isEdited: true
                     })
                     .where(eq(doubtsTable.id, doubtId))
                     .returning();

--- a/src/components/classroom/DoubtCard.tsx
+++ b/src/components/classroom/DoubtCard.tsx
@@ -25,6 +25,7 @@ const ARIA_LABELS = {
   VIEW_REPLIES: (count: number) => `View ${count} ${count === 1 ? "reply" : "replies"}`,
 } as const;
 import { useSearchParams } from "next/navigation";
+import { DoubtEditHistory } from "./DoubtEditHistory";
 import { useUser } from "@clerk/nextjs";
 import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuItem } from "@/components/ui/dropdown-menu";
 
@@ -259,9 +260,12 @@ export default function DoubtCard({ doubt, onUpdate, onViewAISolution, role, ope
                                 {doubt.author || 'Anonymous'}
                                 {isOwner && <span className="ml-2 text-[10px] bg-blue-600/20 text-blue-400 px-2 py-0.5 rounded-full uppercase tracking-widest font-black">You</span>}
                             </h3>
-                            <p className="text-[10px] text-slate-500 dark:text-slate-500 font-bold uppercase tracking-widest mt-0.5">
-                                {new Date(doubt.createdAt).toLocaleDateString()}
-                            </p>
+                            <div className="flex items-center gap-2 mt-0.5">
+                                <p className="text-[10px] text-slate-500 dark:text-slate-500 font-bold uppercase tracking-widest">
+                                    {new Date(doubt.createdAt).toLocaleDateString()}
+                                </p>
+                                {doubt.isEdited && <DoubtEditHistory doubtId={doubt.id} />}
+                            </div>
                         </div>
                     </div>
                     <div className="flex flex-wrap items-center gap-2 w-full sm:w-auto">

--- a/src/components/classroom/DoubtEditHistory.tsx
+++ b/src/components/classroom/DoubtEditHistory.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import { useState } from "react";
+import { format } from "date-fns";
+import { History, Clock, ChevronDown, ChevronUp, Loader2 } from "lucide-react";
+import {
+    Dialog,
+    DialogContent,
+    DialogHeader,
+    DialogTitle,
+    DialogTrigger,
+} from "@/components/ui/dialog";
+import type { DoubtEdit } from "@/types";
+
+interface DoubtEditHistoryProps {
+    doubtId: number;
+    trigger?: React.ReactNode;
+}
+
+export function DoubtEditHistory({ doubtId, trigger }: DoubtEditHistoryProps) {
+    const [edits, setEdits] = useState<DoubtEdit[]>([]);
+    const [isLoading, setIsLoading] = useState(false);
+    const [isOpen, setIsOpen] = useState(false);
+    const [expandedEditId, setExpandedEditId] = useState<number | null>(null);
+
+    const fetchEdits = async () => {
+        setIsLoading(true);
+        try {
+            const res = await fetch(`/api/doubts/${doubtId}/edits`);
+            if (res.ok) {
+                const data = await res.json();
+                setEdits(data);
+                if (data.length > 0) {
+                    setExpandedEditId(data[0].id); // expand the latest edit by default
+                }
+            }
+        } catch (error) {
+            console.error("Failed to fetch edits", error);
+        } finally {
+            setIsLoading(false);
+        }
+    };
+
+    const handleOpenChange = (open: boolean) => {
+        setIsOpen(open);
+        if (open && edits.length === 0) {
+            fetchEdits();
+        }
+    };
+
+    return (
+        <Dialog open={isOpen} onOpenChange={handleOpenChange}>
+            <DialogTrigger asChild>
+                {trigger || (
+                    <button className="inline-flex items-center gap-1.5 text-xs text-slate-400 hover:text-slate-600 dark:hover:text-slate-200 transition-colors bg-slate-100 dark:bg-zinc-800/50 px-2 py-0.5 rounded-full border border-slate-200 dark:border-zinc-700/50">
+                        <History className="w-3 h-3" />
+                        (Edited)
+                    </button>
+                )}
+            </DialogTrigger>
+            <DialogContent className="max-w-2xl max-h-[80vh] overflow-hidden flex flex-col p-0 gap-0">
+                <DialogHeader className="p-6 pb-4 border-b border-slate-100 dark:border-zinc-800">
+                    <DialogTitle className="flex items-center gap-2 text-xl">
+                        <History className="w-5 h-5 text-blue-500" />
+                        Edit History
+                    </DialogTitle>
+                </DialogHeader>
+                
+                <div className="flex-1 overflow-y-auto p-6 bg-slate-50/50 dark:bg-zinc-900/20">
+                    {isLoading ? (
+                        <div className="flex justify-center p-8">
+                            <Loader2 className="w-6 h-6 animate-spin text-blue-500" />
+                        </div>
+                    ) : edits.length === 0 ? (
+                        <div className="text-center p-8 text-slate-500">
+                            No edit history found.
+                        </div>
+                    ) : (
+                        <div className="relative space-y-6 before:absolute before:inset-0 before:ml-5 before:-translate-x-px md:before:mx-auto md:before:translate-x-0 before:h-full before:w-0.5 before:bg-gradient-to-b before:from-transparent before:via-slate-200 dark:before:via-zinc-700 before:to-transparent">
+                            {edits.map((edit, index) => {
+                                const isExpanded = expandedEditId === edit.id;
+                                return (
+                                    <div key={edit.id} className="relative flex items-center justify-between md:justify-normal md:odd:flex-row-reverse group is-active">
+                                        {/* Icon */}
+                                        <div className="flex items-center justify-center w-10 h-10 rounded-full border-4 border-white dark:border-black bg-blue-100 dark:bg-blue-900/50 text-blue-500 shadow shrink-0 md:order-1 md:group-odd:-translate-x-1/2 md:group-even:translate-x-1/2 z-10">
+                                            <Clock className="w-4 h-4" />
+                                        </div>
+                                        
+                                        {/* Content Card */}
+                                        <div className="w-[calc(100%-4rem)] md:w-[calc(50%-2.5rem)] p-4 rounded-xl border border-slate-200 dark:border-zinc-800 bg-white dark:bg-zinc-900 shadow-sm transition-all">
+                                            <button 
+                                                onClick={() => setExpandedEditId(isExpanded ? null : edit.id)}
+                                                className="flex items-center justify-between w-full text-left"
+                                            >
+                                                <div>
+                                                    <span className="text-xs font-semibold text-blue-500 tracking-wide uppercase">
+                                                        Version {edits.length - index}
+                                                    </span>
+                                                    <div className="text-sm text-slate-500 mt-1">
+                                                        {format(new Date(edit.editedAt), "MMM d, yyyy 'at' h:mm a")}
+                                                    </div>
+                                                </div>
+                                                {isExpanded ? (
+                                                    <ChevronUp className="w-4 h-4 text-slate-400" />
+                                                ) : (
+                                                    <ChevronDown className="w-4 h-4 text-slate-400" />
+                                                )}
+                                            </button>
+
+                                            {isExpanded && (
+                                                <div className="mt-4 pt-4 border-t border-slate-100 dark:border-zinc-800 animate-in slide-in-from-top-2 duration-200">
+                                                    {edit.previousSubject && (
+                                                        <div className="mb-3">
+                                                            <div className="text-xs font-bold text-slate-400 mb-1 uppercase tracking-wider">Previous Subject</div>
+                                                            <div className="text-sm font-medium text-slate-900 dark:text-slate-200">{edit.previousSubject}</div>
+                                                        </div>
+                                                    )}
+                                                    {edit.previousContent && (
+                                                        <div>
+                                                            <div className="text-xs font-bold text-slate-400 mb-1 uppercase tracking-wider">Previous Content</div>
+                                                            <div className="text-sm text-slate-600 dark:text-slate-400 whitespace-pre-wrap line-clamp-6 hover:line-clamp-none transition-all">
+                                                                {edit.previousContent}
+                                                            </div>
+                                                        </div>
+                                                    )}
+                                                </div>
+                                            )}
+                                        </div>
+                                    </div>
+                                );
+                            })}
+                        </div>
+                    )}
+                </div>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/src/configs/schema.ts
+++ b/src/configs/schema.ts
@@ -122,6 +122,7 @@ export const doubtsTable = pgTable("doubts", {
     type: varchar({ length: 20 }).default("community"),
     isPinned: boolean().default(false),
     isHidden: boolean("isHidden").default(false).notNull(),
+    isEdited: boolean().default(false).notNull(),
     deletedAt: timestamp(),
     createdAt: timestamp().defaultNow().notNull(),
 
@@ -159,6 +160,27 @@ export const doubtsTable = pgTable("doubts", {
             columns: [table.classroomId],
             foreignColumns: [classroomsTable.id],
         }).onDelete("set null"),
+    };
+});
+
+export const doubtEditsTable = pgTable("doubt_edits", {
+    id: integer().primaryKey().generatedAlwaysAsIdentity(),
+    doubtId: integer().notNull(),
+    previousSubject: varchar({ length: 100 }),
+    previousContent: text(),
+    editedByEmail: varchar({ length: 255 }).notNull(),
+    editedAt: timestamp().defaultNow().notNull(),
+}, (table) => {
+    return {
+        doubtIdIndex: index("doubt_edits_doubtId_idx").on(table.doubtId),
+        doubtIdFk: foreignKey({
+            columns: [table.doubtId],
+            foreignColumns: [doubtsTable.id],
+        }).onDelete("cascade"),
+        editedByEmailFk: foreignKey({
+            columns: [table.editedByEmail],
+            foreignColumns: [usersTable.email],
+        }).onDelete("cascade"),
     };
 });
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -164,6 +164,7 @@ export interface Doubt {
     solvedReplyId?: number | null;
     type: "ai" | "community" | "teacher";
     isPinned: boolean | null;
+    isEdited?: boolean | null;
     isPendingSync?: boolean;
     createdAt: Date | string;
     // The raw author identifier must never appear on a client-facing Doubt. Typing
@@ -184,6 +185,15 @@ export interface Doubt {
  * type-check against this shape.
  */
 export type PublicDoubt = PublicAuthored<Doubt>;
+
+export interface DoubtEdit {
+    id: number;
+    doubtId: number;
+    previousSubject: string | null;
+    previousContent: string | null;
+    editedByEmail: string;
+    editedAt: Date | string;
+}
 
 /** Type for a doubt record with simplified fields (server-side DB record;
  *  carries the raw author identifier, unlike the client-facing Doubt/PublicDoubt). */


### PR DESCRIPTION
## **User description**
Fixes #1056 

Adds the ability to track and view edit histories for doubt descriptions.
- Created `doubtEditsTable` to store chronological versions of doubt subject and content.
- Updated `PATCH /api/doubts/action/[id]` to insert the previous state into the edits table before applying modifications.
- Added a new `GET /api/doubts/[id]/edits` endpoint to fetch version history.
- Built a visually appealing `DoubtEditHistory` dialog modal that displays the edits timeline.
- Added an `(Edited)` badge next to the timestamp in `DoubtCard`.


___

## **CodeAnt-AI Description**
Let users view the edit history of doubts

### What Changed
- Edited doubts are marked with an “Edited” indicator beside their original date
- Users can open an edit timeline to review previous subjects and content versions
- Editing a doubt now saves its previous subject and content with the edit time
- Edit history is available only to users authorized to view the doubt

### Impact
`✅ Clearer doubt revision history`
`✅ Easier comparison of previous doubt content`
`✅ Protected classroom edit records`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
