### PR TITLE
fix: reject reply votes on deleted doubts

### DIFF
--- a/src/app/api/replies/vote/route.test.ts
+++ b/src/app/api/replies/vote/route.test.ts
@@ -305,6 +305,55 @@ describe('Reply Vote API Endpoint', () => {
         expect(inngest.send).not.toHaveBeenCalledWith({
             name: 'karma/answer.upvoted',
             data: { replyAuthorEmail: 'author@example.com', replyId: 1, doubtId: 7 },
-        });
+        }); 
     });
+    it('rejects voting on a reply whose parent doubt has been soft-deleted', async () => {
+    mockCurrentUser.mockResolvedValue({
+        id: 'voter_clerk_id',
+        username: 'voter',
+        fullName: 'Voter User',
+        primaryEmailAddress: {
+            emailAddress: 'voter@example.com',
+        },
+    });
+
+    mockSelectResultQueue.push(
+        [], // checkUserBlock
+        [
+            {
+                id: 1,
+                doubtId: 7,
+                userEmail: 'author@example.com',
+                upvotes: 5,
+            },
+        ], // reply lookup
+        [] // parent doubt is not returned because it is soft-deleted
+    );
+
+    const req = new Request(
+        'http://localhost/api/replies/vote',
+        {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({
+                replyId: 1,
+            }),
+        }
+    );
+
+    const res = await POST(req);
+    const json = await res.json();
+
+    expect(res.status).toBe(404);
+    expect(json.error).toBe('Doubt not found');
+
+    const { db } = jest.requireMock('@/configs/db');
+    const { inngest } = jest.requireMock('@/inngest/client');
+
+    expect(db.transaction).not.toHaveBeenCalled();
+    expect(db.insert).not.toHaveBeenCalled();
+    expect(inngest.send).not.toHaveBeenCalled();
+});
 });

--- a/src/app/api/replies/vote/route.ts
+++ b/src/app/api/replies/vote/route.ts
@@ -1,6 +1,6 @@
 import { db } from "@/configs/db";
 import { doubtsTable, repliesTable, replyLikesTable } from "@/configs/schema";
-import { and, eq, sql } from "drizzle-orm";
+import { and, eq, isNull, sql } from "drizzle-orm";
 import { NextResponse } from "next/server";
 import { currentUser } from "@clerk/nextjs/server";
 import { inngest } from "@/inngest/client";
@@ -20,15 +20,25 @@ export async function POST(req: Request) {
         const { replyId } = data;
 
         const user = await currentUser();
-        if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+        if (!user) {
+            return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+        }
 
         const email = user.primaryEmailAddress?.emailAddress;
-        if (!email) return NextResponse.json({ error: "Email required" }, { status: 400 });
+        if (!email) {
+            return NextResponse.json({ error: "Email required" }, { status: 400 });
+        }
 
-        const rateLimitResponse = await enforceApiRateLimit(generalLimiter, email, "general");
+        const rateLimitResponse = await enforceApiRateLimit(
+            generalLimiter,
+            email,
+            "general"
+        );
+
         if (rateLimitResponse) return rateLimitResponse;
 
         const { isBlocked, errorResponse: blockResponse } = await checkUserBlock(email);
+
         if (blockResponse) return blockResponse;
         if (isBlocked) return blockResponse;
 
@@ -40,40 +50,60 @@ export async function POST(req: Request) {
             .limit(1);
 
         if (!reply) {
-            return NextResponse.json({ error: "Reply not found" }, { status: 404 });
+            return NextResponse.json(
+                { error: "Reply not found" },
+                { status: 404 }
+            );
         }
 
         // Capture the author email up front. The karma event must credit
         // whoever owned the reply at the moment the vote was cast, never the
-        // post-update returning() row — that row is trusted output of a write
-        // we just performed, so any later corruption to repliesTable.userEmail
-        // would otherwise leak karma to the wrong account.
+        // post-update returning() row.
         const originalReplyAuthorEmail = reply.userEmail;
 
-        // ── 2. FIX: ANTI-SELF-UPVOTE GUARD ──────────────────────────────────
-        // Blocks authors from liking their own replies and exploiting the karma event trigger
-        if (email && originalReplyAuthorEmail === email) {
+        // ── 2. ANTI-SELF-UPVOTE GUARD ───────────────────────────────────────
+        // Blocks authors from liking their own replies and exploiting the
+        // karma event trigger.
+        if (email === originalReplyAuthorEmail) {
             return NextResponse.json(
                 { error: "Forbidden: You cannot upvote your own reply." },
                 { status: 403 }
             );
         }
 
+        // ── 3. VALIDATE PARENT DOUBT IS ACTIVE ───────────────────────────────
+        // Replies belonging to soft-deleted doubts must not be votable.
+        //
+        // A soft-deleted doubt has deletedAt set. By requiring deletedAt
+        // to be NULL here, the query returns no row for deleted doubts and
+        // the vote request is rejected before any vote or karma changes occur.
         const [doubt] = await db
             .select({ classroomId: doubtsTable.classroomId })
             .from(doubtsTable)
-            .where(eq(doubtsTable.id, reply.doubtId))
+            .where(
+                and(
+                    eq(doubtsTable.id, reply.doubtId),
+                    isNull(doubtsTable.deletedAt)
+                )
+            )
             .limit(1);
 
-        if (doubt?.classroomId) {
+        if (!doubt) {
+            return NextResponse.json(
+                { error: "Doubt not found" },
+                { status: 404 }
+            );
+        }
+
+        if (doubt.classroomId) {
             await requireMembership(email, doubt.classroomId);
         }
 
-        // ── 3. ATOMIC TRANSACTION FLOW ──────────────────────────────────────
+        // ── 4. ATOMIC TRANSACTION FLOW ──────────────────────────────────────
         const result = await db.transaction(async (tx) => {
-
             // Check existing vote inside transaction
-            const existingLike = await tx.select()
+            const existingLike = await tx
+                .select()
                 .from(replyLikesTable)
                 .where(
                     and(
@@ -85,7 +115,8 @@ export async function POST(req: Request) {
 
             if (existingLike.length > 0) {
                 // Remove vote
-                await tx.delete(replyLikesTable)
+                await tx
+                    .delete(replyLikesTable)
                     .where(
                         and(
                             eq(replyLikesTable.userEmail, email),
@@ -94,7 +125,8 @@ export async function POST(req: Request) {
                     );
 
                 // Prevent negative vote counts
-                const updated = await tx.update(repliesTable)
+                const updated = await tx
+                    .update(repliesTable)
                     .set({
                         upvotes: sql`GREATEST(${repliesTable.upvotes} - 1, 0)`
                     })
@@ -105,17 +137,18 @@ export async function POST(req: Request) {
                     ...updated[0],
                     hasUpvoted: false
                 };
-
             } else {
                 // Add vote
-                await tx.insert(replyLikesTable)
+                await tx
+                    .insert(replyLikesTable)
                     .values({
                         userEmail: email,
                         replyId
                     });
 
                 // Atomic increment
-                const updated = await tx.update(repliesTable)
+                const updated = await tx
+                    .update(repliesTable)
                     .set({
                         upvotes: sql`${repliesTable.upvotes} + 1`
                     })
@@ -129,7 +162,7 @@ export async function POST(req: Request) {
             }
         });
 
-        // ── 4. BACKGROUND SYSTEM EMISSION ───────────────────────────────────
+        // ── 5. BACKGROUND SYSTEM EMISSION ───────────────────────────────────
         if (result && result.userEmail && originalReplyAuthorEmail) {
             if (result.userEmail !== originalReplyAuthorEmail) {
                 console.error(
@@ -150,7 +183,8 @@ export async function POST(req: Request) {
                     },
                 });
             } else {
-                // Vote removed - revoke the +10 karma that was awarded when the vote was added
+                // Vote removed - revoke the +10 karma that was awarded
+                // when the vote was added.
                 await inngest.send({
                     name: "karma/answer.unupvoted",
                     data: {
@@ -163,8 +197,9 @@ export async function POST(req: Request) {
         }
 
         // Strip the author's real email before returning — identity must
-        // stay server-side only (see src/lib/anonymity/anonymity.ts).
+        // stay server-side only.
         const { userEmail: _, ...safeResult } = result ?? {};
+
         return NextResponse.json(safeResult);
     } catch (error) {
         const { status, body } = buildErrorResponse(error);


### PR DESCRIPTION
## **User description**
Problem

Reply voting was still allowed for replies belonging to soft-deleted doubts. This could cause votes, upvote counts, and karma changes to be applied to content that is no longer active.

Fix
Added a check to ensure the parent doubt exists and has not been soft-deleted (deletedAt IS NULL) before processing a reply vote.
Return 404 Doubt not found when the parent doubt has been deleted.
Added a regression test to verify that voting on replies of deleted doubts is rejected.
Existing voting behavior for active doubts remains unchanged
Closes #1395


___

## **CodeAnt-AI Description**
Reject votes on replies from deleted doubts

### What Changed
- Voting on a reply is rejected with a 404 error when its parent doubt has been soft-deleted
- Deleted doubt replies no longer receive vote counts, votes, or karma changes
- Added a regression test confirming no vote transaction or karma event is created for deleted doubts

### Impact
`✅ Prevented votes on deleted content`
`✅ Preserved accurate vote counts`
`✅ Prevented incorrect karma changes`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented voting on replies associated with deleted doubts.
  * Improved validation for authentication, email, and rate limits before processing votes.
  * Ensured rejected votes do not create likes, transactions, or karma events.

* **Tests**
  * Added coverage confirming deleted doubts return a “Doubt not found” response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->