### PR TITLE
fix: handle concurrent tag creation

### DIFF
--- a/src/app/api/doubts/route.ts
+++ b/src/app/api/doubts/route.ts
@@ -491,9 +491,38 @@ export async function POST(req: Request) {
         }
       }
 
-      if (tagsToInsert.length > 0) {
-        const insertedRows = await db.insert(tagsTable).values(tagsToInsert).returning();
-        savedTags.push(...insertedRows);
+       if (tagsToInsert.length > 0) {
+            await db
+                .insert(tagsTable)
+                .values(tagsToInsert)
+                .onConflictDoNothing();
+
+        const resolvedTags = (await db
+          .select()
+          .from(tagsTable)
+          .where(
+            and(
+              inArray(
+                tagsTable.normalizedName,
+                tagsToInsert.map((tag) => tag.normalizedName),
+              ),
+              parsedClassroomId
+                ? eq(tagsTable.classroomId, parsedClassroomId)
+                : isNull(tagsTable.classroomId),
+            ),
+          )) as Array<typeof tagsTable.$inferSelect>;
+
+        const resolvedTagsMap = new Map(
+          resolvedTags.map((tag) => [tag.normalizedName, tag]),
+        );
+
+        for (const tag of tagsToInsert) {
+          const resolvedTag = resolvedTagsMap.get(tag.normalizedName);
+
+          if (resolvedTag) {
+            savedTags.push(resolvedTag);
+          }
+        }
       }
 
       if (savedTags.length > 0) {


### PR DESCRIPTION
## **User description**
Problem

When creating a doubt with a new tag, the API first checks whether the tag already exists and then attempts to create it if it does not.

With concurrent requests, two users can both observe that the same tag does not exist and attempt to insert it simultaneously. Due to the unique constraint on tags, one request could fail even though the doubt itself is valid.

Fix
Use onConflictDoNothing() when inserting new tags to safely handle unique-constraint races.
Re-fetch the canonical tag records after the insert attempt.
Ensure concurrent doubt creations resolve to the same existing tag record.
Preserve the existing tag normalization and doubt-tag relationship logic.
Expected Behavior
Concurrent doubt creation with the same new tag does not fail.
Only one tag record is created.
Both doubts reference the same tag.
Existing doubt creation behavior remains unchanged.
Closes #1396


___

## **CodeAnt-AI Description**
Prevent concurrent doubt creation from failing on shared new tags

### What Changed
- Concurrent requests creating doubts with the same new tag now safely reuse one tag instead of failing on a duplicate
- Both doubts are linked to the same canonical tag record
- Existing tag matching and tag-to-doubt relationships continue to work as before

### Impact
`✅ Fewer failed doubt submissions`
`✅ Consistent shared tags during concurrent creation`
`✅ No duplicate tags from simultaneous requests`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tag creation reliability when multiple requests create the same classroom or global tags concurrently.
  * Ensured successfully created or existing tags are consistently saved and available after creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->